### PR TITLE
fix: accept IDs beyond safe integer range

### DIFF
--- a/src/bilibili/video-api.ts
+++ b/src/bilibili/video-api.ts
@@ -176,7 +176,7 @@ function parseSubtitleResponse(raw: unknown): SubtitleResponse {
     if (
       !isRecord(row) ||
       typeof row.id !== "number" ||
-      !Number.isSafeInteger(row.id) ||
+      !Number.isInteger(row.id) ||
       row.id < 0 ||
       typeof row.lan !== "string" ||
       row.lan.length < 1 ||

--- a/tests/bilibili-video-api.test.ts
+++ b/tests/bilibili-video-api.test.ts
@@ -47,7 +47,7 @@ afterEach(() => {
 });
 
 describe("getVideoSubtitle", () => {
-  it("returns WBI subtitles without calling the non-WBI fallback", async () => {
+  it("accepts WBI subtitle IDs beyond the safe integer range without calling the non-WBI fallback", async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url.includes("/x/frontend/finger/spi")) {
         return jsonResponse({
@@ -77,9 +77,9 @@ describe("getVideoSubtitle", () => {
             subtitle: {
               subtitles: [
                 {
-                  id: 1,
-                  lan: "zh-Hans",
-                  lan_doc: "中文",
+                  id: 9_007_199_254_740_992,
+                  lan: "ai-zh",
+                  lan_doc: "AI中文",
                   subtitle_url: "//example.test/wbi.json",
                 },
               ],


### PR DESCRIPTION
## Summary

- accept subtitle IDs beyond `Number.MAX_SAFE_INTEGER`
- add regression coverage for large AI subtitle IDs
- preserve the existing subtitle response shape

## Verification

- 39 test files passed
- 803 tests passed
- TypeScript build passed

Fixes XZXZZX-Ai/bilibili-mcp#42