### PR TITLE
fix: harden MCP runtime contracts

### DIFF
--- a/docs/agent-memory/codemap.md
+++ b/docs/agent-memory/codemap.md
@@ -6,6 +6,8 @@ This file is a navigation index for `@xzxzzx/bilibili-mcp`. It is not a design s
 
 - `src/index.ts`: stdio startup entry point. Loads environment configuration
   and connects the reusable MCP server through the bounded stdio transport.
+- `src/load-env.ts`: first-evaluated entrypoint side effect that loads the
+  optional package-root `.env` before server dependencies freeze runtime config.
 - `src/server.ts`: reusable MCP `Server` instance. Registers `tools/list` and
   `tools/call`, delegates schemas and handlers, installs per-request
   cancellation context, and applies bounded secret-free response handling.
@@ -14,7 +16,9 @@ This file is a navigation index for `@xzxzzx/bilibili-mcp`. It is not a design s
   startup, and exposes `setup` (credentials plus optional ASR with three-model
   selector), `doctor` (credential and ASR status plus `asr.model` key),
   `config`, `check`, `check-update`, and `version`.
-- `src/config.ts`: runtime configuration (rate limits, timeouts, cache sizing) and preferred subtitle language normalization.
+- `src/config.ts`: runtime configuration with strict positive-safe-integer
+  validation for rate limits, timeouts, and cache sizing, plus canonical
+  supported-language selection that preserves `ai-zh` and rejects unknown values.
 
 ## Shared Security Boundaries
 
@@ -91,7 +95,8 @@ When adding or changing a public MCP tool, inspect both `tool-schemas.ts` and `t
 - `src/bilibili/favorites.ts`: authenticated current-account Favorites discovery. Stateless opaque base64url cursor encode/decode (versioned Folder ID + page only), strict canonical pre-network decoding and safe-integer emission, nav→created/list-all→at most one resource/list page per call, defensive Folder/Video normalization, and reported-count/skipped-count behavior.
 - `src/bilibili/comments-api.ts`: raw comments API access.
 - `src/bilibili/comments.ts`: comments retrieval, filtering, and response shaping.
-- `src/bilibili/types.ts`: shared Bilibili-facing types.
+- `src/bilibili/types.ts`: shared Bilibili-facing types and the runtime
+  `SUPPORTED_LANGUAGES` tuple reused by config, validation, and public schemas.
 
 ## Utilities
 
@@ -112,7 +117,13 @@ When adding or changing a public MCP tool, inspect both `tool-schemas.ts` and `t
 ## Tests
 
 - `tests/mcp-server-smoke.test.ts`: built `index.js`/`cli.js` stdio coverage, Agent-facing doctor/setup/version CLI probes, MCP handler smoke coverage, and a public JSON-clean `initialize` → `tools/list` → representative `tools/call` wire test.
-- `tests/cli.test.ts`: deterministic CLI tests for help output, `buildDoctorStatus` JSON contract (including ASR object), credential-source priority, and no-leak checks.
+- `tests/cli.test.ts`: deterministic CLI tests for help output,
+  `buildDoctorStatus` JSON contract (including ASR object), credential-source
+  priority, isolated blank-replacement protection, and no-leak checks.
+- `tests/config.test.ts`: canonical-language behavior and table-driven strict
+  validation for every user-facing numeric environment variable.
+- `tests/index-env-order.test.ts`: mocked dotenv regression proving the entrypoint
+  loads `.env` before runtime config is imported and validated.
 - `tests/asr-installer.test.ts`: deterministic installer/state tests. State read/validation/write, Python discovery (override/path/version), venv/pip/download/verify subprocess gating, and full orchestration success/failure. No tests invoke real Python, pip, network, or model download.
 - `tests/asr-installer-process.test.ts`: mocked default subprocess deadlines,
   output ceilings, argv, stdio, and platform process-group settings.

--- a/docs/agent-memory/handoffs/2026-08-08-contract-correctness-hardening-task-ticket.md
+++ b/docs/agent-memory/handoffs/2026-08-08-contract-correctness-hardening-task-ticket.md
@@ -1,0 +1,77 @@
+# Task Ticket: Contract Correctness Hardening
+
+## Ticket
+
+- ID: `CONTRACT-2026-08-08`
+- Title: Harden comments, language, credential, numeric-config, and JSON `-403` contracts
+- Status: `done`
+- Owner: `Codex`
+- Source: User-authorized implementation task on 2026-08-08, with Git delivery authorized on 2026-08-09
+
+## Objective
+
+Make five bounded correctness fixes on live `master` without changing the ten-tool product boundary: define comment `limit` as a bounded main-comment count, preserve explicit `ai-zh`, reject blank credential replacement, strictly validate numeric environment configuration, and classify plain JSON `-403` by endpoint semantics.
+
+## Scope
+
+In scope:
+
+- Comments schema, bilingual tool-reference wording, and focused pagination/reply tests.
+- Shared supported-language validation and handler-level `ai-zh` preservation tests.
+- CLI credential configuration with synthetic temporary-user tests.
+- Strict positive safe-integer parsing for every current user-facing numeric environment variable, without inventing unsupported upper bounds.
+- Plain JSON business-code `-403` mapping for non-video endpoints, with synthetic endpoint tests.
+- Focused red/green evidence, full build/test/pack/audit/stdio verification, and a public-flow QA record.
+
+Out of scope:
+
+- New MCP tools, dependency upgrades, lockfile changes, live credential use, ASR changes, protocol modernization, release workflow changes, tags, npm/MCP Registry publication, GitHub Releases, and deployment.
+- Direct edits or history rewrites in the pre-existing dirty main worktree.
+
+Delivery extension:
+
+- On 2026-08-09 the user explicitly authorized creating the isolated branch, committing, pushing, opening a PR, and merging it after green checks.
+- Version bumping and publication remain separate decisions; this ticket keeps package version `1.11.3`.
+
+## Files To Inspect Or Edit
+
+Expected edit areas:
+
+- `src/server/tool-schemas.ts`, `docs/tool-reference.md`, `docs/tool-reference.en.md`, and comments/schema tests.
+- `src/config.ts`, language validation/selection call sites when required, and handler/config tests.
+- `src/cli.ts`, `src/bilibili/http.ts`, and focused CLI/HTTP tests.
+- `docs/qa/2026-08-08-contract-correctness-hardening.md`.
+
+Do not touch:
+
+- `package-lock.json`, dependency declarations, generated `dist/`, workflows, release metadata, the original worktree, or the da51 review worktree.
+
+## Required Capabilities
+
+- Skills: `tdd`, `vitest`, `secret-scanning`, `code-review`, `bilibili-mcp-memory`.
+- Subagents: up to three bounded Codex workers with mutually exclusive file ownership; final `risk-reviewer` coverage before acceptance.
+- CLI: `git`, `rg`, `npm`, `node`, `tsc`, and existing Vitest/MCP smoke tests.
+
+## Acceptance Criteria
+
+- [x] `get_video_comments.limit` is an integer from 1 through 50 and is documented as the main-comment count; child replies may expand the flat result.
+- [x] `preferred_lang: "ai-zh"` reaches both video-info and transcript selection unchanged; unsupported languages fail explicitly.
+- [x] Any trimmed-empty credential field leaves an existing synthetic credential file unchanged and does not report success.
+- [x] All current user-facing numeric environment variables reject empty, partial, non-numeric, zero, negative, and unsafe-integer values with actionable secret-free errors.
+- [x] HTTP 200 JSON `code: -403` from nav/Favorites-like non-video endpoints is not reported as `PAID_VIDEO`; HTTP status 403 behavior is preserved.
+- [x] Focused tests demonstrate red before implementation and green after implementation.
+- [x] `npm test`, `npm run build`, the existing real stdio smoke, `npm pack --dry-run --json`, and `npm audit --omit=dev` are run and reported.
+- [x] `package-lock.json` and the tracked diff fingerprints of the original and da51 worktrees remain unchanged.
+- [x] Public MCP tool names and successful response shapes remain stable except for the explicitly tightened comments schema.
+- [x] No credential, Cookie, token, `.env` content, or private value is printed or committed.
+- [x] `docs/agent-memory/codemap.md` is checked and updated for the new environment bootstrap and config-test navigation.
+
+## Risks And Rollback
+
+- Risk: rejecting values that were previously silently coerced can expose startup errors. Mitigation: validate only documented numeric variables and provide variable-specific guidance.
+- Risk: changing the generic `-403` branch can lose paid-video specificity. Mitigation: keep paid mapping only at endpoints whose semantics establish it and preserve HTTP-status handling.
+- Rollback: before merge, abandon only the isolated branch; after merge, use a normal revert PR. The pre-existing dirty main worktree remains untouched.
+
+## Stop And Report Conditions
+
+Stop and report if the fix requires a new dependency, lockfile mutation, a new public tool/response shape beyond this ticket, a real credential, a live write beyond the explicitly authorized Git branch/PR delivery, or a broader architecture change.

--- a/docs/agent-memory/project-facts.md
+++ b/docs/agent-memory/project-facts.md
@@ -398,3 +398,51 @@
   the Official Registry API exact match with `status=active` and `isLatest=true`.
 - Impact: future Official Registry updates must preserve the case-sensitive
   namespace and publish the matching npm version before Registry metadata.
+
+## 2026-08-08
+
+- Fact: An isolated, uncommitted implementation worktree based on live master
+  `1b97183` hardens five public contracts: comments `limit` counts main
+  comments, `ai-zh` is canonical and preserved, blank credential replacement
+  is rejected without mutation, numeric runtime settings are strictly
+  validated, and plain JSON `-403` is classified by endpoint semantics.
+- Evidence: schemas, handlers, bilingual references, synthetic CLI/HTTP tests,
+  the public stdio language-validation assertion, 41 files / 853 full tests,
+  and `docs/qa/2026-08-08-contract-correctness-hardening.md`.
+- Impact: Child replies may legitimately make flat `comments[]` exceed
+  `limit`; unsupported languages and malformed numeric settings now fail
+  explicitly; Favorites/nav access denial no longer masquerades as paid video.
+
+- Fact: The stdio entrypoint now evaluates `src/load-env.ts` before importing
+  the server, so optional project-local `.env` numeric values are loaded before
+  runtime config is frozen and validated; the reusable default server export
+  remains unchanged.
+- Evidence: the old-order red and fixed-order green in
+  `tests/index-env-order.test.ts`, clean TypeScript build, real stdio smoke,
+  package inspection, and independent risk-reviewer PASS.
+- Impact: The documented source `npm start` / `dist/index.js` `.env` path is
+  now real for runtime settings. This work is not on master or npm until a
+  separately authorized commit and release occur.
+
+## 2026-08-09
+
+- Fact: Bilibili comments pagination must keep the upstream page size fixed;
+  incrementing `pn` while shrinking `ps` changes the offset and can overlap
+  rows. A non-empty short page is also not sufficient evidence of completion.
+- Evidence: public-seam `limit: 21` and 19-row-page regressions, both observed
+  red before the bounded fixed-`ps` implementation and green afterward; final
+  raw-exhaustion and malformed-container regressions; and final full suite 41
+  files / 857 tests.
+- Impact: Requests above 20 main comments use `ps=20`, stop on an empty page
+  or after `ceil(limit / 20)` pages, and slice locally. Child replies may still
+  expand the flat result beyond the requested main-comment limit. A page whose
+  raw rows are non-empty continues even when every row is rejected during
+  normalization; a missing or non-array `replies` container fails closed.
+
+- Fact: The 2026-08-09 delivery authorization covers an isolated branch,
+  commit, push, PR, and merge for the verified source changes only.
+- Evidence: user instruction in the active task and the delivery extension in
+  `docs/agent-memory/handoffs/2026-08-08-contract-correctness-hardening-task-ticket.md`.
+- Impact: package version remains `1.11.3`; tag, npm publication, Official MCP
+  Registry publication, GitHub Release, and deployment require a separate
+  release decision.

--- a/docs/agent-memory/verification-log.md
+++ b/docs/agent-memory/verification-log.md
@@ -1361,3 +1361,81 @@
   returned one exact match with `status=active` and `isLatest=true`.
 - Boundary: npm v1.11.2 remains immutable but its lowercase Registry namespace
   was rejected with HTTP 403. v1.11.3 is the corrected public latest version.
+
+## 2026-08-08 Contract Correctness Hardening (Uncommitted)
+
+- Baseline: detached isolated worktree at
+  `1b97183c70145eaf273bbddef4e0474e53bc177e`; Node `v25.6.1`, npm `11.16.0`.
+- TDD: focused failures reproduced the old comments number schema, missing
+  language enums, silent unsupported-language fallback, blank credential
+  mutation path, permissive numeric parsing, non-video `-403` paid mapping,
+  video-only access guidance, and late dotenv evaluation. Each targeted test
+  passed after the corresponding minimum fix.
+- Command: focused integrated Vitest run for comments, config, validation,
+  handlers, cache, CLI, HTTP, WBI, and error guidance.
+- Result: 10 files / 358 tests passed.
+- Command: `npm run build`.
+- Result: passed; TypeScript compiled the final source including
+  `src/load-env.ts`.
+- Command: `npm test`.
+- Result: 41 files / 853 tests passed.
+- Command: real child-process stdio protocol smoke for `initialize` → exact
+  `tools/list` → representative `tools/call` plus unsupported language.
+- Result: passed, 1 selected test / 11 skipped.
+- Command: `npm pack --dry-run --json --ignore-scripts`.
+- Result: 185 files, 1,088,165 packed bytes, 1,716,461 unpacked bytes; required
+  index, CLI, declarations, dotenv bootstrap, package metadata, and license
+  present; forbidden paths zero.
+- Command: `npm audit --omit=dev --json`.
+- Result: zero info/low/moderate/high/critical production vulnerabilities;
+  97 production dependencies reported.
+- Command: `git diff --check`, package-lock blob check, scoped secret-pattern
+  classification, and independent `risk-reviewer` review.
+- Result: diff check passed; `package-lock.json` remained
+  `70cee9306932ebb2d32bc1cce4016770cd2963d4`; no private-key, provider-token,
+  AWS-key, JWT, or real credential finding; reviewer returned PASS with no
+  P0/P1/P2 blocker.
+- Boundary: no live Bilibili/Cookie, ASR E2E, external desktop client, commit,
+  push, tag, Issue/PR write, release, publication, or deployment occurred.
+
+## 2026-08-09 Contract Correctness Hardening Review Correction
+
+- Review correction: a two-axis pre-delivery review found that the original
+  multi-page comments loop changed `ps` on its final request. Under Bilibili's
+  page-number/page-size semantics that overlapped earlier rows and could omit
+  requested main comments. The old mock's hard-coded 20-row offset had hidden
+  the defect.
+- TDD: a public-seam regression using real `pn`/`ps` offset semantics failed
+  with 20 unique rows for `limit: 21`, then passed after requests kept
+  `ps=20` and sliced locally. A second regression reproduced non-empty
+  19-row pages and passed after pagination stopped only on an empty page or
+  the bounded `ceil(limit / 20)` request count.
+- Normalization correction: final standards review found that normalized-empty
+  rows were still being used as the page-exhaustion signal. A `remaining=1`
+  case with a rejected first row and valid later row failed before the raw and
+  normalized states were separated, then passed. An all-rejected non-empty
+  page regression confirms traversal continues to later pages.
+- Malformed-container correction: a missing or non-array `replies` value first
+  reproduced a silent empty success, then failed closed as
+  `UpstreamResponseError`. Only an explicit empty array now represents
+  confirmed page exhaustion.
+- Refactor: supported-language membership and its error path now live in
+  `src/utils/validation.ts`; `src/config.ts` delegates to that shared path.
+  The task ticket status also uses the canonical `done` value.
+- Gates: TypeScript build passed; 41 files / 857 tests passed; the selected
+  real stdio JSON-RPC test passed; production audit reported zero
+  vulnerabilities across 97 dependencies; the 185-file dry-run package had
+  all required entrypoints and zero forbidden paths; `git diff --check`
+  passed; and `package-lock.json` retained blob
+  `70cee9306932ebb2d32bc1cce4016770cd2963d4`.
+- Secret classification: private-key, GitHub-token, npm-token, AWS-key, JWT,
+  and secret-filename checks were zero. Cookie-shaped matches were confined
+  to bilingual placeholders, verification prose, and synthetic CLI tests;
+  no credential value was printed or accepted as evidence.
+- Final review: independent standards and specification reviewers returned
+  PASS with no remaining P0-P3. Their final focused comments/error run passed
+  51/51 tests, and both confirmed the explicit-empty versus malformed-response
+  distinction at the public error boundary.
+- Delivery boundary: branch/commit/push/PR/merge was explicitly authorized;
+  version bumping, tags, npm publication, MCP Registry publication, and a
+  GitHub Release remain outside this work.

--- a/docs/client-setup.en.md
+++ b/docs/client-setup.en.md
@@ -1145,6 +1145,8 @@ The MCP server reads these variables at process startup. Restart the client or r
 | `USER_AGENT` | Project default | Override the request User-Agent |
 | `BILIBILI_MCP_DEBUG` | Disabled | Set to `1` to emit credential-redacted debug logs to `stderr` |
 
+All three numeric variables must be complete decimal positive safe integers. Empty, partial, zero, negative, or unsafe-integer values make the server reject startup with a configuration error. `BILIBILI_RATE_LIMIT_MS` and `BILIBILI_REQUEST_TIMEOUT_MS` must also not exceed the Node.js timer limit of `2147483647`.
+
 See [Tool reference: Request controls and cache](./tool-reference.en.md#request-controls-and-cache) for retry, cache, and error semantics.
 
 ## Develop from source

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -1139,6 +1139,8 @@ BILIBILI_DEDEUSERID=<your_dedeuserid>
 | `USER_AGENT` | 项目默认值 | 覆盖请求使用的 User-Agent |
 | `BILIBILI_MCP_DEBUG` | 未启用 | 设为 `1` 时向 `stderr` 输出经过凭证脱敏的 debug 日志 |
 
+三个数值变量必须是完整的十进制正安全整数；空值、部分数字、`0`、负数及非安全整数会让 server 以配置错误拒绝启动。`BILIBILI_RATE_LIMIT_MS` 和 `BILIBILI_REQUEST_TIMEOUT_MS` 还不得超过 Node.js 计时器上限 `2147483647`。
+
 请求重试、缓存和错误语义的完整说明见[工具参考：请求控制与缓存](./tool-reference.md#请求控制与缓存)。
 
 ## 从源码开发

--- a/docs/qa/2026-08-08-contract-correctness-hardening.md
+++ b/docs/qa/2026-08-08-contract-correctness-hardening.md
@@ -1,0 +1,123 @@
+# QA: Contract Correctness Hardening
+
+## QA Session
+
+- Title: Comments, language, credential, numeric-config, and JSON `-403` contract hardening
+- Date: 2026-08-08
+- Version or commit: `1.11.3` baseline at `1b97183c70145eaf273bbddef4e0474e53bc177e`
+- Owner: Codex
+- Related ticket: `docs/agent-memory/handoffs/2026-08-08-contract-correctness-hardening-task-ticket.md`
+- QA type: `MCP tool change | credential flow | regression`
+
+## Scope
+
+In scope:
+
+- Comments `limit` schema and main-comment semantics.
+- Canonical supported languages, `ai-zh` preservation, and unknown-language rejection.
+- Blank credential replacement protection using an isolated temporary home and synthetic fixtures.
+- Strict numeric environment parsing, including `.env`-before-config entrypoint ordering.
+- Endpoint-aware plain JSON `-403` classification and resource-generic recovery guidance.
+- Full build, test, stdio, package, audit, diff, lockfile, and scoped secret verification.
+
+Out of scope:
+
+- Live Bilibili or real-Cookie validation, ready-model ASR, third-party desktop clients, dependency upgrades, commits, publication, deployment, and remote writes.
+
+## Preconditions
+
+- [x] Detached implementation baseline and commit recorded.
+- [x] Package version `1.11.3` recorded.
+- [x] Tests use only synthetic credentials; no real credential source is read or recorded.
+- [x] The shareable synthetic BVID fixture is used only with mocked business/network paths.
+- [x] Node `v25.6.1`, npm `11.16.0`, Vitest, and the built stdio entrypoint were identified.
+
+## Automated Baseline
+
+- Build: `npm run build` passed.
+- Tests: final `npm test` passed, 41 files / 857 tests.
+- Focused contract tests: 10 files / 358 tests passed before the final bootstrap regression was added; the final full suite includes all focused coverage.
+- Post-review focus: comments/config/validation/server tests passed, 5 files / 212 tests; the comments file alone passed 29 tests after the pagination regressions ran red then green.
+- Stdio: real child-process `initialize` → exact `tools/list` → representative `tools/call` passed, including an unsupported-language wire assertion.
+- Pack: `npm pack --dry-run --json --ignore-scripts` passed with 185 files, 1,088,447 packed bytes, and 1,717,397 unpacked bytes; all required entrypoints were present and forbidden paths were zero.
+- Audit: `npm audit --omit=dev --json` passed with zero production vulnerabilities across 97 production dependencies.
+- Skipped: live Bilibili, real credentials, ASR E2E, external `npx`, and desktop-client QA were intentionally not run.
+
+## Package And Install Path
+
+- [x] Package version remains `1.11.3`; the isolated source branch is not a release candidate.
+- [x] Dry-run package includes `dist/index.js`, `dist/index.d.ts`, `dist/cli.js`, `dist/load-env.js`, `package.json`, and `LICENSE`.
+- [x] Dry-run package excludes source, tests, agent memory, QA records, local config, `.env`, keys, and credential files.
+- [x] Existing `bin`, `main`, `module`, and `types` targets resolve to built `dist` output.
+- Registry and external exact-version smoke were not rerun because no publication or registry state is in scope.
+
+## MCP Stdio And Tool Discovery
+
+- [x] The built server keeps stdout JSON-clean before protocol traffic.
+- [x] `tools/list` returns the unchanged ten-tool set.
+- [x] Comments and language descriptions match their public schemas.
+- [x] `get_video_comments.limit` is `integer`, minimum 1, maximum 50.
+- [x] Both `preferred_lang` schemas use the canonical supported-language enum.
+
+Expected tools:
+
+- `get_credential_setup_instructions`
+- `check_bilibili_credentials`
+- `check_mcp_update`
+- `get_video_info`
+- `get_video_transcript`
+- `get_video_metadata`
+- `get_video_comments`
+- `search_bilibili_videos`
+- `list_bilibili_favorite_videos`
+- `get_video_chapters`
+
+## Credential States
+
+- [x] A trimmed-empty synthetic field leaves the existing file bytes and in-memory credentials unchanged, reports failure, and stops setup before the ASR prompt.
+- [x] A complete synthetic credential set is trimmed and persisted only under an isolated temporary home.
+- [x] HTTP tests mock credential headers as empty and assert the nav request contains no Cookie.
+- Live no-credential, expired, and valid-login checks were not run because they require an external user session.
+
+## Tool Workflows
+
+- [x] `limit: 1` with replies returns one main comment plus bounded child replies.
+- [x] Multi-page requests keep upstream `ps=20`, slice the caller-visible main-comment limit locally, and continue across a non-empty short page without exceeding `ceil(limit / 20)` requests.
+- [x] Raw-page exhaustion is tracked separately from normalized output, so rejected rows cannot hide later valid rows or pages.
+- [x] Only an explicit empty `replies` array means exhaustion; a missing or non-array container fails closed as `UpstreamResponseError`.
+- [x] Video-info and transcript handlers pass `ai-zh` unchanged and reject unsupported languages before business work.
+- [x] Nav and Favorites JSON `-403` map to `ACCESS_DENIED`; only an explicitly paid video endpoint/message maps to `PAID_VIDEO`.
+- [x] HTTP status 403 remains a separate `NetworkError` path.
+- [x] Successful response shapes and tool names remain unchanged.
+
+## Client Compatibility
+
+| Client | Version | Install method | Result | Notes |
+|---|---|---|---|---|
+| Claude Desktop | not tested | not tested | not tested | No external client launch in scope |
+| Cursor | not tested | not tested | not tested | No external client launch in scope |
+| Codex | local test harness | built stdio | pass | Public JSON-RPC child-process smoke |
+
+## Documentation Checks
+
+- [x] Bilingual tool references define comments `limit`, supported languages, and resource-generic `ACCESS_DENIED` guidance consistently.
+- [x] Bilingual client setup and tool references document strict numeric values and timer bounds.
+- [x] Credential docs remain secret-safe; no README or changelog update is needed before a future release decision.
+
+## Security And Privacy Checks
+
+- [x] Scoped value-free scan found zero private-key, GitHub-token, npm-token, AWS-key, or JWT patterns.
+- [x] Credential-shaped matches are limited to bilingual placeholder documentation, verification prose, and explicitly synthetic CLI fixtures.
+- [x] No real credential, `.env` content, or private value was read into test output.
+- [x] Runtime input validation occurs before Bilibili business calls for unsupported languages.
+- [x] Existing network, response, and stdio budgets remain covered by the full regression suite.
+
+## Result
+
+- Overall result: `pass with caveats`
+- Blocking issues: none
+- Non-blocking caveats: no real Cookie, ready-model ASR, or external desktop-client QA; no version bump, tag, package publication, or release is part of this source delivery.
+- Follow-up tickets: none required for this batch.
+- Codemap update status: updated for `src/load-env.ts`, strict config, and new tests.
+- Research note: not required; no external facts affected implementation.
+- Independent review: the initial `risk-reviewer` passed. The 2026-08-09 two-axis review then found and drove the pagination, raw-exhaustion, malformed-container, shared-language, and ticket-status corrections; final standards and specification re-reviews both returned PASS with no remaining P0–P3.

--- a/docs/tool-reference.en.md
+++ b/docs/tool-reference.en.md
@@ -25,7 +25,7 @@ This page preserves detailed behavior, parameters, examples, error contracts, an
 - Prioritizes retrieving CC or AI subtitles.
 - Automatically falls back to video title, description, and tags if no subtitles are available.
 - Supports multi-language subtitle selection (defaults to Simplified Chinese).
-- Supports manual preference for subtitle languages (e.g., `en`, `zh-Hant`).
+- Supports explicit subtitle languages `zh-Hans`, `zh-CN`, `zh-Hant`, `en`, `ja`, `ko`, and `ai-zh`; `ai-zh` reaches selection unchanged, while unsupported values return `VALIDATION_ERROR`.
 
 ### 2. Comment Summarization (`get_video_comments`)
 - Retrieves popular comments to help gauge video sentiment.
@@ -35,7 +35,7 @@ This page preserves detailed behavior, parameters, examples, error contracts, an
   - `brief`: 10 popular comments summary.
   - `detailed`: 20 popular comments + high-quality replies.
 - Optional parameters:
-  - `limit`: Explicit comment count `1-50`, overrides `detail_level` default.
+  - `limit`: Main-comment count, integer `1-50`; overrides the `detail_level` default. When replies are included, the flattened `comments[]` may contain more than `limit` items.
   - `sort`: Sort order `"hot"` (default) or `"time"`.
   - `include_replies`: Whether to include top replies (default `true`).
 
@@ -45,7 +45,7 @@ This page preserves detailed behavior, parameters, examples, error contracts, an
 - Supports multi-Part selection, timestamp output, time-range filtering, and optional keyword search.
 - Successful calls return both the backward-compatible formatted JSON text and the same data as MCP `structuredContent`.
 - Optional parameters:
-  - `preferred_lang`: Preferred subtitle language code.
+  - `preferred_lang`: Preferred subtitle language code: `zh-Hans`, `zh-CN`, `zh-Hant`, `en`, `ja`, `ko`, or `ai-zh`. `ai-zh` reaches selection unchanged; unsupported values return `VALIDATION_ERROR`.
   - `fallback_to_description`: Fall back to video description if subtitles unavailable (default `false`).
   - `fallback_to_asr`: Run ready local ASR only after subtitles are definitively unavailable (default `false`).
   - `page`: Multi-Part video page number (1-based positive integer).
@@ -171,7 +171,7 @@ Supported error codes:
 | `NETWORK_ERROR` | Network request failed (HTTP 5xx, connection errors, etc.) | Retry later; check network/proxy/firewall if it keeps happening |
 | `NETWORK_TIMEOUT` | Request to Bilibili timed out | Retry later; check network/proxy/firewall if it keeps happening |
 | `API_RATE_LIMITED` | Bilibili API rate limit hit (HTTP 429) | Wait and retry; reduce request frequency or raise `BILIBILI_RATE_LIMIT_MS` |
-| `ACCESS_DENIED` | Bilibili denied access (permissions, private, region-locked, removed) | Verify the video access permissions; run the credential check if needed |
+| `ACCESS_DENIED` | Bilibili denied access to a resource (permissions, private, region/account restrictions, removed) | Verify the resource and account access permissions; run the credential check if needed |
 | `PAID_VIDEO` | Video may require payment, membership, or extra permissions | Confirm in Bilibili; this MCP will not bypass paid or restricted access |
 | `COMMENTS_DISABLED` | Comments are disabled or restricted | Use transcript or metadata tools; confirm on the Bilibili page |
 | `BILIBILI_API_ERROR` | Other Bilibili API errors | Retry if it looks temporary; include the code when reporting repeated issues |
@@ -292,7 +292,7 @@ Request:
 
 Returns: `bvid`, `title`, `language`, `transcript` (newline-joined), `data_source` (`subtitle`, `asr`, or `description`), `page`.
 
-> Returns `SUBTITLE_UNAVAILABLE` when no subtitles exist. Set `fallback_to_description: true` to fall back.
+> `preferred_lang` accepts only `zh-Hans`, `zh-CN`, `zh-Hant`, `en`, `ja`, `ko`, or `ai-zh`. Explicit `ai-zh` is not rewritten to another language; unsupported values return `VALIDATION_ERROR`. The tool returns `SUBTITLE_UNAVAILABLE` when no subtitles exist. Set `fallback_to_description: true` to fall back.
 
 **Explicit ASR fallback example**:
 
@@ -393,7 +393,7 @@ Request:
 
 Returns: `data_source` (`subtitle` or `description`), `video_info` (title, description, tags, subtitle text, publish date).
 
-> Videos without subtitles automatically degrade to description and tags (`data_source: "description"`).
+> `preferred_lang` accepts only `zh-Hans`, `zh-CN`, `zh-Hant`, `en`, `ja`, `ko`, or `ai-zh`. Explicit `ai-zh` is not rewritten to another language; unsupported values return `VALIDATION_ERROR`. Videos without subtitles automatically degrade to description and tags (`data_source: "description"`).
 
 ### `get_video_comments`
 
@@ -416,7 +416,7 @@ Request:
 
 Returns: `comments[]` (author, content, likes, timestamp, has_timestamp), `summary` (total count, timestamp count).
 
-> Expired or missing cookies may result in empty comments. Use `sort: "time"` for newest comments, `include_replies: false` to skip replies.
+> `limit` applies only to main comments. With `include_replies: true` and `detail_level: "detailed"`, the flattened `comments[]` also contains child replies and may therefore exceed `limit`. Expired or missing cookies may result in empty comments. Use `sort: "time"` for newest comments, `include_replies: false` to skip replies.
 
 ---
 
@@ -430,6 +430,8 @@ Built-in request controls reduce the chance of triggering Bilibili risk checks o
 - **Timeout**: defaults to 10 seconds, configurable with `BILIBILI_REQUEST_TIMEOUT_MS`.
 - **Cache capacity**: defaults to 100 entries, configurable with `BILIBILI_CACHE_SIZE`.
 - **User-Agent**: overridable via `USER_AGENT`.
+
+All three numeric variables must be complete decimal positive safe integers. Empty, partial, zero, negative, or unsafe-integer values raise a configuration error and prevent startup. The two millisecond variables must also not exceed the Node.js timer limit of `2147483647`; cache capacity has no additional arbitrary cap.
 
 All of the above environment variables are read at MCP server process startup. After changing them, restart the MCP client or reconnect the MCP server for the new values to take effect.
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -25,7 +25,7 @@
 - 优先获取视频的 CC 或 AI 字幕
 - 无字幕时自动降级为视频标题、简介和标签
 - 支持多语言字幕选择（默认优先简体中文）
-- 可手动指定偏好字幕语言（如 `en`, `zh-Hant` 等）
+- 可手动指定偏好字幕语言：`zh-Hans`、`zh-CN`、`zh-Hant`、`en`、`ja`、`ko`、`ai-zh`；`ai-zh` 会原样传入选择逻辑，未知值返回 `VALIDATION_ERROR`
 
 ### 2. 评论总结 (`get_video_comments`)
 - 获取视频热门评论，辅助判断视频真实口碑
@@ -35,7 +35,7 @@
   - `brief`: 10 条热门评论速览
   - `detailed`: 20 条热门评论 + 高赞连带回复
 - 可选参数：
-  - `limit`: 显式评论数量 `1-50`，覆盖 `detail_level` 的默认数量
+  - `limit`: 主评论数量，整数 `1-50`，覆盖 `detail_level` 的默认主评论数量；若包含子回复，扁平的 `comments[]` 总条数可超过 `limit`
   - `sort`: 排序方式 `"hot"`（按热度，默认）或 `"time"`（按时间）
   - `include_replies`: 是否包含高赞回复（默认 `true`）
 
@@ -46,7 +46,7 @@
 - 支持可选关键词搜索：返回带上下文的时间戳匹配列表（大小写不敏感字面匹配）
 - 成功调用会同时返回向后兼容的格式化 JSON 文本和内容相同的 MCP `structuredContent`
 - 可选参数：
-  - `preferred_lang`: 偏好字幕语言代码
+  - `preferred_lang`: 偏好字幕语言代码，支持 `zh-Hans`、`zh-CN`、`zh-Hant`、`en`、`ja`、`ko`、`ai-zh`；`ai-zh` 会原样传入选择逻辑，未知值返回 `VALIDATION_ERROR`
   - `fallback_to_description`: 字幕不可用时是否降级为视频描述（默认 `false`）
   - `fallback_to_asr`: 确认无可用字幕时是否运行已就绪的本地 ASR（默认 `false`）
   - `page`: 多P视频分集编号（从1开始的正整数）
@@ -173,7 +173,7 @@
 | `NETWORK_ERROR` | 网络请求失败（HTTP 5xx、连接错误等） | 稍后重试；如反复出现请检查网络/代理/防火墙 |
 | `NETWORK_TIMEOUT` | 请求 Bilibili 超时 | 稍后重试；如反复出现请检查网络/代理/防火墙 |
 | `API_RATE_LIMITED` | 触发 Bilibili API 频率限制（HTTP 429） | 等待一段时间后重试；降低调用频率或调大 `BILIBILI_RATE_LIMIT_MS` |
-| `ACCESS_DENIED` | Bilibili 拒绝访问（权限不足、私密、地区限制、已下架等） | 检查视频访问权限，必要时运行凭据检查 |
+| `ACCESS_DENIED` | Bilibili 拒绝访问资源（权限不足、私密、地区或账号限制、已下架等） | 检查资源与账号访问权限，必要时运行凭据检查 |
 | `PAID_VIDEO` | 视频可能需要付费、会员或额外权限 | 在 Bilibili 端确认；本 MCP 不会绕过付费或受限访问 |
 | `COMMENTS_DISABLED` | 视频评论已关闭或访问受限 | 改用字幕或元数据工具；也可在 Bilibili 页面确认 |
 | `BILIBILI_API_ERROR` | 其他 Bilibili API 错误 | 临时问题可稍后重试；持续出现请带错误码反馈 |
@@ -296,7 +296,7 @@
 
 返回内容：`bvid`、`title`、`language`、`transcript`（按行合并）、`data_source`（`subtitle`、`asr` 或 `description`）、`page`（分集编号）。
 
-> 默认无字幕时返回 `SUBTITLE_UNAVAILABLE`。如需降级，设置 `fallback_to_description: true`。
+> `preferred_lang` 仅接受 `zh-Hans`、`zh-CN`、`zh-Hant`、`en`、`ja`、`ko`、`ai-zh`；显式传入 `ai-zh` 不会被改写为其他语言，未知值返回 `VALIDATION_ERROR`。默认无字幕时返回 `SUBTITLE_UNAVAILABLE`。如需降级，设置 `fallback_to_description: true`。
 
 **显式 ASR 回退示例**：
 
@@ -397,7 +397,7 @@
 
 返回内容：`data_source`（`subtitle` 或 `description`）、`video_info`（标题、描述、标签、字幕文本、发布时间）。
 
-> 无字幕视频会自动降级返回描述和标签（即 `data_source: "description"`）。
+> `preferred_lang` 仅接受 `zh-Hans`、`zh-CN`、`zh-Hant`、`en`、`ja`、`ko`、`ai-zh`；显式传入 `ai-zh` 不会被改写为其他语言，未知值返回 `VALIDATION_ERROR`。无字幕视频会自动降级返回描述和标签（即 `data_source: "description"`）。
 
 ### `get_video_comments`
 
@@ -420,7 +420,7 @@
 
 返回内容：`comments[]`（含 `author`、`content`、`likes`、`timestamp`、`has_timestamp`）、`summary`（总数和时间戳评论数）。
 
-> Cookie 过期或未登录可能导致评论为空。`sort: "time"` 可获取最新评论，`include_replies: false` 不返回子回复。
+> `limit` 只限制主评论数量；当 `include_replies: true` 且 `detail_level: "detailed"` 时，扁平的 `comments[]` 还包含子回复，因此总条数可超过 `limit`。Cookie 过期或未登录可能导致评论为空。`sort: "time"` 可获取最新评论，`include_replies: false` 不返回子回复。
 
 ---
 
@@ -434,6 +434,8 @@
 - **超时控制**：默认 10 秒，可通过 `BILIBILI_REQUEST_TIMEOUT_MS` 调整。
 - **缓存容量**：默认 100 条，可通过 `BILIBILI_CACHE_SIZE` 调整。
 - **User-Agent**：可通过 `USER_AGENT` 覆盖默认请求头。
+
+三个数值变量必须是完整的十进制正安全整数；空值、部分数字、`0`、负数及非安全整数会触发配置错误并阻止启动。两个毫秒变量还必须不超过 Node.js 计时器上限 `2147483647`；缓存容量没有额外的人为上限。
 
 以上环境变量均在 MCP server 进程启动时读取，修改后需重启 MCP 客户端或重连 MCP server 才能生效。
 

--- a/src/bilibili/comments.ts
+++ b/src/bilibili/comments.ts
@@ -11,6 +11,7 @@ import { cacheManager } from "../utils/cache.js";
 import {
   CommentsDisabledError,
   ResourceLimitError,
+  UpstreamResponseError,
 } from "../utils/errors.js";
 import { logger, redactSecrets } from "../utils/logger.js";
 import { SECURITY_LIMITS, utf8ByteLength } from "../security/limits.js";
@@ -91,16 +92,23 @@ function normalizeRemoteComment(
 
 function acceptCommentPage(
   data: unknown,
-  remainingItems: number,
+  maxAcceptedItems: number,
+  maxRawItems: number,
   includeReplies: boolean,
-): Comment[] {
-  if (!isRecord(data) || !Array.isArray(data.replies)) return [];
+): { comments: Comment[]; rawIsEmpty: boolean } {
+  if (!isRecord(data) || !Array.isArray(data.replies)) {
+    throw new UpstreamResponseError(
+      "Bilibili returned an invalid comments response",
+    );
+  }
+  const rawReplies = data.replies.slice(0, maxRawItems);
   const accepted: Comment[] = [];
-  for (const rawComment of data.replies.slice(0, remainingItems)) {
+  for (const rawComment of rawReplies) {
+    if (accepted.length >= maxAcceptedItems) break;
     const comment = normalizeRemoteComment(rawComment, includeReplies);
     if (comment) accepted.push(comment);
   }
-  return accepted;
+  return { comments: accepted, rawIsEmpty: rawReplies.length === 0 };
 }
 
 
@@ -232,14 +240,19 @@ export async function getVideoCommentsData(
       rawComments = acceptCommentPage(
         commentsData,
         commentCount,
+        commentCount,
         includeReplies,
-      );
+      ).comments;
     } else {
       rawComments = [];
       let page = 1;
       let remaining = commentCount;
-      while (remaining > 0) {
-        const pageSize = Math.min(remaining, 20);
+      // Bilibili uses page-number/page-size pagination. Changing ps on the
+      // final request changes that page's offset, so keep ps stable and
+      // enforce the caller-visible limit locally.
+      const pageSize = 20;
+      const maxPages = Math.ceil(commentCount / pageSize);
+      while (remaining > 0 && page <= maxPages) {
         const pageData = await getVideoComments(
           bvidOrUrl,
           page,
@@ -247,15 +260,15 @@ export async function getVideoCommentsData(
           sort,
           includeReplies,
         );
-        const pageReplies = acceptCommentPage(
+        const acceptedPage = acceptCommentPage(
           pageData,
+          remaining,
           pageSize,
           includeReplies,
         );
-        if (pageReplies.length === 0) break;
-        rawComments.push(...pageReplies);
-        if (pageReplies.length < pageSize) break;
-        remaining -= pageReplies.length;
+        if (acceptedPage.rawIsEmpty) break;
+        rawComments.push(...acceptedPage.comments);
+        remaining -= acceptedPage.comments.length;
         page++;
       }
       rawComments = rawComments.slice(0, commentCount);

--- a/src/bilibili/http.ts
+++ b/src/bilibili/http.ts
@@ -27,6 +27,10 @@ const BASE_URL = config.baseUrl;
 // 请求限流 - 避免高频请求被 Bilibili 限制
 const RATE_LIMIT_MS = config.rateLimitMs;
 const REQUEST_TIMEOUT_MS = config.requestTimeoutMs;
+const PAID_VIDEO_ENDPOINTS = new Set([
+  "/x/web-interface/view",
+  "/x/player/v2",
+]);
 let lastRequestTime: number | null = null;
 let pendingAdmissions = 0;
 let activeAndQueuedOperations = 0;
@@ -34,6 +38,14 @@ let activeAndQueuedOperations = 0;
 export interface HttpOperationContext {
   signal?: AbortSignal;
   deadlineAt: number;
+}
+
+function isExplicitPaidVideoDenial(path: string, message: unknown): boolean {
+  return (
+    PAID_VIDEO_ENDPOINTS.has(path) &&
+    typeof message === "string" &&
+    /(?:付费|购买后|需购买)/u.test(message)
+  );
 }
 
 async function reserveAdmission(
@@ -456,8 +468,16 @@ export async function fetchWithoutWBI(
             );
           }
           if (data.code === -403) {
-            throw new PaidVideoError(
-              "该视频为付费内容，无法获取完整信息",
+            if (isExplicitPaidVideoDenial(path, data.message)) {
+              throw new PaidVideoError(
+                "该视频为付费内容，无法获取完整信息",
+              );
+            }
+            throw new BilibiliAPIError(
+              "Bilibili denied access to this resource.",
+              "ACCESS_DENIED",
+              undefined,
+              data,
             );
           }
           throw new BilibiliAPIError(

--- a/src/bilibili/types.ts
+++ b/src/bilibili/types.ts
@@ -128,8 +128,18 @@ export interface CommentsSummary {
   };
 }
 
-// 支持的语言类型
-export type SupportedLanguage = 'zh-Hans' | 'zh-CN' | 'zh-Hant' | 'en' | 'ja' | 'ko' | 'ai-zh';
+// 支持的语言列表与类型（运行时验证与公开 schema 共用）
+export const SUPPORTED_LANGUAGES = [
+  "zh-Hans",
+  "zh-CN",
+  "zh-Hant",
+  "en",
+  "ja",
+  "ko",
+  "ai-zh",
+] as const;
+
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
 // 评论详细程度类型
 export type CommentDetailLevel = 'brief' | 'detailed';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,13 +77,21 @@ async function startServer() {
 }
 
 // Configure credentials
-async function configureCredentials() {
+export async function configureCredentials(
+  askHiddenFn: (question: string) => Promise<string> = askHidden,
+): Promise<boolean> {
   console.log("请输入您的 Bilibili 凭证信息（可从浏览器开发者工具中获取）：");
   console.log("输入内容不会在终端回显。");
 
-  const sessdata = await askHidden("SESSDATA: ");
-  const bili_jct = await askHidden("bili_jct: ");
-  const dedeuserid = await askHidden("DedeUserID: ");
+  const sessdata = (await askHiddenFn("SESSDATA: ")).trim();
+  const bili_jct = (await askHiddenFn("bili_jct: ")).trim();
+  const dedeuserid = (await askHiddenFn("DedeUserID: ")).trim();
+
+  if (!sessdata || !bili_jct || !dedeuserid) {
+    console.error("配置未保存：SESSDATA、bili_jct 和 DedeUserID 均不能为空；已有凭证保持不变。");
+    process.exitCode = 1;
+    return false;
+  }
 
   try {
     const credentials = {
@@ -104,6 +112,7 @@ async function configureCredentials() {
     console.log("");
     console.log("下次启动 MCP 服务器时将自动加载此凭证，无需重新配置。");
     console.log("⚠️  如需更新凭证，请重新运行 bilibili-mcp config");
+    return true;
   } catch (error) {
     console.error("配置失败：", redactSecrets(error));
     process.exit(1);
@@ -261,7 +270,7 @@ export function doctorCommand(
 }
 
 export async function setupCredentials(
-  configure: () => Promise<void> = configureCredentials,
+  configure: () => Promise<boolean | void> = configureCredentials,
   runAsr: (modelKey: AsrModelKey) => Promise<{ success: boolean; error?: string }> = async () => ({ success: false, error: "installer not injected" }),
   askHiddenFn: (question: string) => Promise<string> = askHidden,
 ) {
@@ -288,7 +297,11 @@ export async function setupCredentials(
     );
     // Fall through to ASR question even with existing credentials
   } else {
-    await configure();
+    const configured = await configure();
+    if (configured === false) {
+      process.exitCode = 1;
+      return;
+    }
   }
 
   // Optional ASR installation prompt
@@ -362,7 +375,9 @@ export function createCli() {
   cli
     .command("config")
     .description("配置 Bilibili 凭证信息")
-    .action(configureCredentials);
+    .action(async () => {
+      await configureCredentials();
+    });
 
   cli
     .command("check")

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,15 @@
  * 配置文件 - 集中管理所有配置项
  */
 
+import {
+  SUPPORTED_LANGUAGES,
+  type SupportedLanguage,
+} from "./bilibili/types.js";
+import {
+  isSupportedLanguage,
+  validateLanguage,
+} from "./utils/validation.js";
+
 export interface Config {
   // 请求限流配置
   rateLimitMs: number;
@@ -16,7 +25,7 @@ export interface Config {
   maxCacheSize: number;
 
   // 支持的语言列表
-  supportedLanguages: string[];
+  supportedLanguages: readonly SupportedLanguage[];
 
   // API 基础 URL
   baseUrl: string;
@@ -34,26 +43,75 @@ export const DEFAULT_CONFIG: Config = {
   wbiCacheExpirationMs: 60 * 60 * 1000, // 1小时缓存过期
   requestTimeoutMs: 10000, // 10秒超时
   maxCacheSize: 100, // 最大缓存条目
-  supportedLanguages: ['zh-Hans', 'zh-CN', 'zh-Hant', 'en', 'ja', 'ko'],
+  supportedLanguages: SUPPORTED_LANGUAGES,
   baseUrl: 'https://api.bilibili.com',
   userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
   referer: 'https://www.bilibili.com'
 };
 
+class ConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigurationError";
+  }
+}
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function readPositiveSafeIntegerEnv(
+  name: string,
+  maximum?: number,
+): number | undefined {
+  const rawValue = process.env[name];
+  if (rawValue === undefined) return undefined;
+
+  if (!/^\d+$/.test(rawValue)) {
+    throw new ConfigurationError(
+      `${name} must be a positive safe integer written in base-10 digits`,
+    );
+  }
+
+  const parsed = Number(rawValue);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new ConfigurationError(
+      `${name} must be a positive safe integer written in base-10 digits`,
+    );
+  }
+
+  if (maximum !== undefined && parsed > maximum) {
+    throw new ConfigurationError(
+      `${name} must not exceed ${maximum} milliseconds`,
+    );
+  }
+
+  return parsed;
+}
+
 // 从环境变量加载配置（可选）
 function loadConfigFromEnv(): Partial<Config> {
   const envConfig: Partial<Config> = {};
 
-  if (process.env.BILIBILI_RATE_LIMIT_MS) {
-    envConfig.rateLimitMs = parseInt(process.env.BILIBILI_RATE_LIMIT_MS, 10);
+  const rateLimitMs = readPositiveSafeIntegerEnv(
+    "BILIBILI_RATE_LIMIT_MS",
+    MAX_TIMER_DELAY_MS,
+  );
+  if (rateLimitMs !== undefined) {
+    envConfig.rateLimitMs = rateLimitMs;
   }
 
-  if (process.env.BILIBILI_REQUEST_TIMEOUT_MS) {
-    envConfig.requestTimeoutMs = parseInt(process.env.BILIBILI_REQUEST_TIMEOUT_MS, 10);
+  const requestTimeoutMs = readPositiveSafeIntegerEnv(
+    "BILIBILI_REQUEST_TIMEOUT_MS",
+    MAX_TIMER_DELAY_MS,
+  );
+  if (requestTimeoutMs !== undefined) {
+    envConfig.requestTimeoutMs = requestTimeoutMs;
   }
 
-  if (process.env.BILIBILI_CACHE_SIZE) {
-    envConfig.maxCacheSize = parseInt(process.env.BILIBILI_CACHE_SIZE, 10);
+  // Cache capacity has no existing product-defined upper bound, so its
+  // positive safe-integer boundary is intentionally not narrowed here.
+  const maxCacheSize = readPositiveSafeIntegerEnv("BILIBILI_CACHE_SIZE");
+  if (maxCacheSize !== undefined) {
+    envConfig.maxCacheSize = maxCacheSize;
   }
 
   if (process.env.USER_AGENT) {
@@ -70,14 +128,11 @@ export const config: Config = {
 };
 
 // 语言验证函数
-export function isValidLanguage(lang: string): boolean {
-  return config.supportedLanguages.includes(lang);
+export function isValidLanguage(lang: string): lang is SupportedLanguage {
+  return isSupportedLanguage(lang);
 }
 
-// 获取首选语言（如果没有提供或无效，返回默认）
-export function getPreferredLanguage(preferredLang?: string): string {
-  if (preferredLang && isValidLanguage(preferredLang)) {
-    return preferredLang;
-  }
-  return config.supportedLanguages[0]; // 默认第一个语言
+// 获取首选语言（未提供时返回默认；不支持的值必须显式报错）
+export function getPreferredLanguage(preferredLang?: string): SupportedLanguage {
+  return validateLanguage(preferredLang) ?? SUPPORTED_LANGUAGES[0];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,9 @@
 // MCP 服务器入口
-import { config } from "dotenv";
+import "./load-env.js";
 import { fileURLToPath } from "url";
-import { dirname, resolve } from "path";
 import { server } from "./server.js";
 import { redactSecrets } from "./utils/logger.js";
 import { BoundedStdioServerTransport } from "./server/bounded-stdio-transport.js";
-
-// 获取当前文件的目录
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-// 尝试加载.env文件
-const envPath = resolve(__dirname, "../.env");
-try {
-  config({ path: envPath, quiet: true });
-} catch (e) {
-  // .env is optional
-}
 
 // Reusable default server export for programmatic use
 export default server;

--- a/src/load-env.ts
+++ b/src/load-env.ts
@@ -1,0 +1,15 @@
+import { config } from "dotenv";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+// This side-effect module must be the first dependency evaluated by index.ts.
+// Runtime configuration imports can then validate values loaded from the
+// project-local .env instead of freezing defaults before dotenv runs.
+const moduleDirectory = dirname(fileURLToPath(import.meta.url));
+const envPath = resolve(moduleDirectory, "../.env");
+
+try {
+  config({ path: envPath, quiet: true });
+} catch {
+  // .env is optional.
+}

--- a/src/server/tool-schemas.ts
+++ b/src/server/tool-schemas.ts
@@ -1,5 +1,7 @@
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
+import { SUPPORTED_LANGUAGES } from "../bilibili/types.js";
+
 export const toolSchemas: Tool[] = [
   {
     name: "get_credential_setup_instructions",
@@ -44,8 +46,9 @@ export const toolSchemas: Tool[] = [
         },
         preferred_lang: {
           type: "string",
+          enum: [...SUPPORTED_LANGUAGES],
           description:
-            "可选参数，指定偏好字幕语言代码，如 'zh-Hans', 'zh-Hant', 'en' 等。默认按 zh-Hans -> zh-Hant -> en 顺序选择。",
+            "可选字幕语言。支持 zh-Hans、zh-CN、zh-Hant、en、ja、ko、ai-zh；ai-zh 会原样传入字幕选择，未知值会被拒绝。默认 zh-Hans。 Optional subtitle language; ai-zh is preserved and unsupported values are rejected.",
         },
         page: {
           type: "integer",
@@ -75,9 +78,11 @@ export const toolSchemas: Tool[] = [
           enum: ["brief", "detailed"],
         },
         limit: {
-          type: "number",
+          type: "integer",
+          minimum: 1,
+          maximum: 50,
           description:
-            "可选评论数量限制，整数 1-50。覆盖 detail_level 的默认数量。",
+            "可选，主评论数量，整数 1-50；覆盖 detail_level 的默认主评论数量。include_replies 为 true 时，扁平 comments[] 会包含子回复，因此总条数可超过 limit。 Optional main-comment count (integer 1-50); overrides the detail_level default. With include_replies=true, flattened comments[] may exceed limit because replies are included.",
         },
         sort: {
           type: "string",
@@ -107,8 +112,9 @@ export const toolSchemas: Tool[] = [
         },
         preferred_lang: {
           type: "string",
+          enum: [...SUPPORTED_LANGUAGES],
           description:
-            "可选，指定偏好字幕语言代码，如 'zh-Hans', 'en' 等。",
+            "可选字幕语言。支持 zh-Hans、zh-CN、zh-Hant、en、ja、ko、ai-zh；ai-zh 会原样传入字幕选择，未知值会被拒绝。默认 zh-Hans。 Optional subtitle language; ai-zh is preserved and unsupported values are rejected.",
         },
         fallback_to_description: {
           type: "boolean",

--- a/src/utils/error-guidance.ts
+++ b/src/utils/error-guidance.ts
@@ -323,12 +323,12 @@ export function buildStructuredErrorPayload(
       retryable: false,
       user_action_required: true,
       next_steps_en: [
-        "Check whether the video is private, region-restricted, removed, or requires a logged-in account.",
-        "Run the credential check if you expected your account to have access.",
+        "Check whether the requested Bilibili resource (such as a video or Favorite Folder) is private, restricted, removed, or requires a logged-in account.",
+        "Run the credential check if you expected this account to have access.",
       ],
       next_steps_zh: [
-        "请检查视频是否为私密、地区限制、已下架，或需要登录账号访问。",
-        "如果你认为账号应有权限，请先运行凭据检查。",
+        "请检查所请求的 Bilibili 资源（如视频或收藏夹）是否为私密、受限、已下架，或需要登录账号访问。",
+        "如果你认为当前账号应有权限，请先运行凭据检查。",
       ],
       details: { api_code: error.code, status_code: error.statusCode },
     });

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -3,6 +3,10 @@
  * 提供统一的输入验证功能
  */
 
+import {
+  SUPPORTED_LANGUAGES,
+  type SupportedLanguage,
+} from "../bilibili/types.js";
 import { ValidationError } from "./errors.js";
 
 export interface ValidationOptions {
@@ -58,19 +62,33 @@ export function validateBVInput(input: unknown): void {
 /**
  * 验证语言参数
  */
-export function validateLanguage(lang?: string): void {
-  if (lang) {
-    validateLength(lang, {
-      maxLength: 10,
-      minLength: 2,
-      required: false
-    });
-    
-    // 语言代码格式验证
-    if (!/^[a-z]{2}(-[A-Za-z]{2,})?$/.test(lang)) {
-      throw new ValidationError('Invalid language code format');
-    }
+export function isSupportedLanguage(lang: string): lang is SupportedLanguage {
+  return SUPPORTED_LANGUAGES.some((supported) => supported === lang);
+}
+
+export function validateLanguage(
+  lang?: string,
+): SupportedLanguage | undefined {
+  if (lang === undefined) return undefined;
+
+  validateLength(lang, {
+    maxLength: 10,
+    minLength: 2,
+    required: true
+  });
+
+  // 语言代码格式验证
+  if (!/^[a-z]{2}(-[A-Za-z]{2,})?$/.test(lang)) {
+    throw new ValidationError('Invalid language code format');
   }
+
+  if (!isSupportedLanguage(lang)) {
+    throw new ValidationError(
+      `Unsupported language. Supported values: ${SUPPORTED_LANGUAGES.join(", ")}`,
+    );
+  }
+
+  return lang;
 }
 
 /**

--- a/tests/bilibili-comments-tool.test.ts
+++ b/tests/bilibili-comments-tool.test.ts
@@ -244,7 +244,76 @@ describe("getVideoCommentsData - cache key behavior", () => {
 });
 
 describe("getVideoCommentsData - pagination for limits above 20", () => {
-  it("limit: 50 fetches pages 1, 2, 3 with page sizes 20, 20, 10", async () => {
+  it("returns distinct main comments when the upstream honors pn/ps page semantics", async () => {
+    mockGetVideoComments.mockImplementation(
+      async (_url: string, page: number, pageSize: number, _sort: number, _includeReplies: boolean) => {
+        const start = (page - 1) * pageSize + 1;
+        return { replies: Array.from({ length: pageSize }, (_, i) => ({
+          rpid: start + i,
+          member: { uname: `User${start + i}`, avatar: "" },
+          content: { message: `Comment ${start + i}` },
+          like: start + i,
+          replies: [],
+        })) };
+      },
+    );
+
+    const result = await getVideoCommentsData("BV1T6PQzQErF", {
+      limit: 21,
+      includeReplies: false,
+    });
+    const contents = result.comments.map((comment) => comment.content);
+
+    expect(contents).toHaveLength(21);
+    expect(new Set(contents)).toHaveLength(21);
+    expect(contents).toContain("Comment 21");
+  });
+
+  it("finds a valid row after a rejected row when only one item remains", async () => {
+    mockGetVideoComments.mockImplementation(
+      async (_url: string, page: number, pageSize: number, _sort: number, _includeReplies: boolean) => {
+        if (page === 1) {
+          return { replies: Array.from({ length: pageSize }, (_, i) => ({
+            rpid: i + 1,
+            member: { uname: `User${i + 1}`, avatar: "" },
+            content: { message: `Comment ${i + 1}` },
+            like: i + 1,
+            replies: [],
+          })) };
+        }
+
+        return {
+          replies: [
+            {
+              rpid: 21,
+              content: { message: "Rejected row without a member" },
+              like: 0,
+              replies: [],
+            },
+            {
+              rpid: 22,
+              member: { uname: "User21", avatar: "" },
+              content: { message: "Comment 21" },
+              like: 21,
+              replies: [],
+            },
+          ],
+        };
+      },
+    );
+
+    const result = await getVideoCommentsData("BV1T6PQzQErF", {
+      limit: 21,
+      includeReplies: false,
+    });
+
+    expect(result.comments).toHaveLength(21);
+    expect(result.comments.map((comment) => comment.content)).toContain(
+      "Comment 21",
+    );
+  });
+
+  it("limit: 50 keeps the upstream page size fixed and slices locally", async () => {
     mockGetVideoComments.mockImplementation(
       async (_url: string, page: number, pageSize: number, _sort: number, _includeReplies: boolean) => {
         const start = (page - 1) * 20 + 1;
@@ -267,7 +336,7 @@ describe("getVideoCommentsData - pagination for limits above 20", () => {
     expect(calls[1][1]).toBe(2);
     expect(calls[1][2]).toBe(20);
     expect(calls[2][1]).toBe(3);
-    expect(calls[2][2]).toBe(10);
+    expect(calls[2][2]).toBe(20);
   });
 
   it("limit: 50 returns exactly 50 top-level comments", async () => {
@@ -312,32 +381,63 @@ describe("getVideoCommentsData - pagination for limits above 20", () => {
     expect(result.comments).toHaveLength(20);
   });
 
-  it("stops early when a page returns fewer than requested", async () => {
+  it("continues after a non-empty short page without exceeding the page bound", async () => {
     mockGetVideoComments.mockImplementation(
       async (_url: string, page: number, _pageSize: number, _sort: number, _includeReplies: boolean) => {
-        if (page === 1) {
-          return { replies: Array.from({ length: 20 }, (_, i) => ({
-            rpid: i + 1,
-            member: { uname: `User${i + 1}`, avatar: "" },
-            content: { message: `Comment ${i + 1}` },
-            like: i + 1,
-            replies: [],
-          })) };
-        }
-        return { replies: Array.from({ length: 5 }, (_, i) => ({
-          rpid: 21 + i,
-          member: { uname: `User${21 + i}`, avatar: "" },
-          content: { message: `Comment ${21 + i}` },
-          like: 21 + i,
+        const start = (page - 1) * 19 + 1;
+        return { replies: Array.from({ length: 19 }, (_, i) => ({
+          rpid: start + i,
+          member: { uname: `User${start + i}`, avatar: "" },
+          content: { message: `Comment ${start + i}` },
+          like: start + i,
           replies: [],
         })) };
       },
     );
 
     const result = await getVideoCommentsData("BV1T6PQzQErF", { limit: 50, includeReplies: false });
+    const contents = result.comments.map((comment) => comment.content);
 
-    expect(mockGetVideoComments).toHaveBeenCalledTimes(2);
-    expect(result.comments).toHaveLength(25);
+    expect(mockGetVideoComments).toHaveBeenCalledTimes(3);
+    expect(contents).toHaveLength(50);
+    expect(new Set(contents)).toHaveLength(50);
+    expect(contents).toContain("Comment 50");
+  });
+
+  it("continues after a non-empty page whose rows are all rejected", async () => {
+    mockGetVideoComments.mockImplementation(
+      async (_url: string, page: number, pageSize: number, _sort: number, _includeReplies: boolean) => {
+        const start = (page - 1) * pageSize + 1;
+        if (page === 1) {
+          return {
+            replies: Array.from({ length: pageSize }, (_, i) => ({
+              rpid: start + i,
+              content: { message: "Rejected row without a member" },
+              like: 0,
+              replies: [],
+            })),
+          };
+        }
+
+        return { replies: Array.from({ length: pageSize }, (_, i) => ({
+          rpid: start + i,
+          member: { uname: `User${start + i}`, avatar: "" },
+          content: { message: `Comment ${start + i}` },
+          like: start + i,
+          replies: [],
+        })) };
+      },
+    );
+
+    const result = await getVideoCommentsData("BV1T6PQzQErF", {
+      limit: 50,
+      includeReplies: false,
+    });
+    const contents = result.comments.map((comment) => comment.content);
+
+    expect(mockGetVideoComments).toHaveBeenCalledTimes(3);
+    expect(contents).toHaveLength(40);
+    expect(contents).toContain("Comment 60");
   });
 
   it("limit at or below 20 still makes a single request", async () => {
@@ -384,6 +484,17 @@ describe("getVideoCommentsData - pagination for limits above 20", () => {
 });
 
 describe("getVideoCommentsData - hostile upstream bounds", () => {
+  it("fails closed when the upstream replies container is malformed", async () => {
+    mockGetVideoComments.mockResolvedValue({ replies: "not-an-array" });
+
+    await expect(
+      getVideoCommentsData("BV1T6PQzQErF", {
+        limit: 1,
+        includeReplies: false,
+      }),
+    ).rejects.toMatchObject({ name: "UpstreamResponseError" });
+  });
+
   it("slices an over-returned page to the caller-visible main-comment limit", async () => {
     mockGetVideoComments.mockResolvedValue({
       replies: Array.from({ length: 7 }, (_, index) => ({
@@ -404,7 +515,7 @@ describe("getVideoCommentsData - hostile upstream bounds", () => {
     expect(result.summary.total_comments).toBe(1);
   });
 
-  it("retains at most three replies per accepted main comment", async () => {
+  it("treats limit: 1 as one main comment while preserving its replies", async () => {
     mockGetVideoComments.mockResolvedValue({
       replies: [
         {
@@ -428,7 +539,16 @@ describe("getVideoCommentsData - hostile upstream bounds", () => {
       includeReplies: true,
     });
 
+    expect(mockGetVideoComments).toHaveBeenCalledWith(
+      "BV1T6PQzQErF",
+      1,
+      1,
+      1,
+      true,
+    );
     expect(result.comments).toHaveLength(4);
+    expect(result.comments.map((item) => item.content)).toContain("Main comment");
+    expect(result.summary.total_comments).toBe(4);
     expect(result.comments.map((item) => item.content)).not.toContain(
       "Reply 3",
     );

--- a/tests/bilibili-http.test.ts
+++ b/tests/bilibili-http.test.ts
@@ -1,11 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const credentialsMock = vi.hoisted(() => ({
+  getAuthHeaders: vi.fn(() => ({})),
+}));
+
+vi.mock("../src/utils/credentials.js", () => ({
+  credentialManager: {
+    getAuthHeaders: credentialsMock.getAuthHeaders,
+  },
+}));
+
 const savedRateLimit = process.env.BILIBILI_RATE_LIMIT_MS;
 const savedRequestTimeout = process.env.BILIBILI_REQUEST_TIMEOUT_MS;
 
 beforeEach(async () => {
   vi.useFakeTimers();
   vi.resetModules();
+  credentialsMock.getAuthHeaders.mockClear();
   process.env.BILIBILI_RATE_LIMIT_MS = "500";
 });
 
@@ -210,6 +221,36 @@ describe("checkLoginStatus", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("maps a nav JSON -403 to ACCESS_DENIED instead of PAID_VIDEO", async () => {
+    const { checkLoginStatus } = await import("../src/bilibili/http.js");
+    const originalFetch = globalThis.fetch;
+    try {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ code: -403, message: "访问权限不足" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+      const outcome = checkLoginStatus().catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(outcome).resolves.toMatchObject({
+        name: "BilibiliAPIError",
+        code: "ACCESS_DENIED",
+      });
+      await expect(outcome).resolves.not.toMatchObject({
+        name: "PaidVideoError",
+      });
+      expect(credentialsMock.getAuthHeaders).toHaveBeenCalledOnce();
+      const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      expect(new Headers(requestInit.headers).has("Cookie")).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe("Bilibili redirect policy", () => {
@@ -234,6 +275,104 @@ describe("Bilibili redirect policy", () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ redirect: "manual" });
+  });
+});
+
+describe("plain JSON -403 classification", () => {
+  it.each([
+    "/x/v3/fav/folder/created/list-all",
+    "/x/v3/fav/resource/list",
+  ])(
+    "maps %s JSON -403 to ACCESS_DENIED even when its message mentions payment",
+    async (path) => {
+      const { fetchWithoutWBI } = await import("../src/bilibili/http.js");
+      const originalFetch = globalThis.fetch;
+      try {
+        globalThis.fetch = vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              code: -403,
+              message: "付费内容不可访问",
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        ) as typeof globalThis.fetch;
+
+        const outcome = fetchWithoutWBI(path).catch((error: unknown) => error);
+        await vi.advanceTimersByTimeAsync(500);
+
+        await expect(outcome).resolves.toMatchObject({
+          name: "BilibiliAPIError",
+          code: "ACCESS_DENIED",
+        });
+        await expect(outcome).resolves.not.toMatchObject({
+          name: "PaidVideoError",
+        });
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    },
+  );
+
+  it("does not infer payment from a video endpoint without an explicit paid message", async () => {
+    const { fetchWithoutWBI } = await import("../src/bilibili/http.js");
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ code: -403, message: "访问权限不足" }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ) as typeof globalThis.fetch;
+
+      const outcome = fetchWithoutWBI("/x/player/v2", {
+        bvid: "BV1synthetic",
+        cid: 1,
+      }).catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(outcome).resolves.toMatchObject({
+        name: "BilibiliAPIError",
+        code: "ACCESS_DENIED",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("keeps PAID_VIDEO only for an explicitly paid video response", async () => {
+    const { fetchWithoutWBI } = await import("../src/bilibili/http.js");
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: -403,
+            message: "该视频为付费视频，请购买后观看",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ) as typeof globalThis.fetch;
+
+      const outcome = fetchWithoutWBI("/x/player/v2", {
+        bvid: "BV1synthetic",
+        cid: 1,
+      }).catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(outcome).resolves.toMatchObject({ name: "PaidVideoError" });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/tests/bilibili-wbi-http-security.test.ts
+++ b/tests/bilibili-wbi-http-security.test.ts
@@ -27,7 +27,7 @@ function wbiNavResponse(): Response {
 
 beforeEach(() => {
   vi.resetModules();
-  process.env.BILIBILI_RATE_LIMIT_MS = "0";
+  process.env.BILIBILI_RATE_LIMIT_MS = "1";
   process.env.BILIBILI_REQUEST_TIMEOUT_MS = "1000";
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import os from "os";
+import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -78,6 +79,108 @@ describe("CLI help and commands", () => {
     const cli = createCli();
     const versionCmd = cli.commands.find((c) => c.name() === "version");
     expect(versionCmd).toBeDefined();
+  });
+});
+
+describe("config credential replacement", () => {
+  const originalUserProfile = process.env.USERPROFILE;
+  const originalHome = process.env.HOME;
+  let tempHome: string;
+  let savedExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
+    tempHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), "bilibili-mcp-cli-config-test-"),
+    );
+    process.env.USERPROFILE = tempHome;
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    if (originalUserProfile === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = originalUserProfile;
+    }
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    process.exitCode = savedExitCode;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it.each([
+    ["SESSDATA", ["   ", "synthetic-replacement-csrf", "20002"]],
+    ["bili_jct", ["synthetic-replacement-session", "\t", "20002"]],
+    [
+      "DedeUserID",
+      ["synthetic-replacement-session", "synthetic-replacement-csrf", "\n"],
+    ],
+  ])("keeps existing credentials when %s is blank", async (_field, answers) => {
+    vi.resetModules();
+    const credentialsModule = await import("../src/utils/credentials.js");
+    const cliModule = await import("../src/cli.js");
+    const existingCredentials = {
+      sessdata: "synthetic-existing-session",
+      bili_jct: "synthetic-existing-csrf",
+      dedeuserid: "10001",
+      expiresAt: Date.now() + 86_400_000,
+    };
+    fs.mkdirSync(credentialsModule.GLOBAL_CONFIG_DIR, { recursive: true });
+    const originalFile = `${JSON.stringify(existingCredentials, null, 2)}\n`;
+    fs.writeFileSync(credentialsModule.GLOBAL_CONFIG_FILE, originalFile, "utf8");
+    credentialsModule.credentialManager.setCredentials(existingCredentials);
+    const askHiddenFn = vi.fn<(question: string) => Promise<string>>();
+    for (const answer of answers) {
+      askHiddenFn.mockResolvedValueOnce(answer);
+    }
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await cliModule.configureCredentials(askHiddenFn);
+
+    expect(result).toBe(false);
+    expect(process.exitCode).toBe(1);
+    expect(fs.readFileSync(credentialsModule.GLOBAL_CONFIG_FILE, "utf8")).toBe(
+      originalFile,
+    );
+    expect(credentialsModule.credentialManager.getCredentials()).toEqual(
+      existingCredentials,
+    );
+    expect(logSpy.mock.calls.flat().join("\n")).not.toContain("凭证配置成功");
+  });
+
+  it("trims and persists a complete synthetic credential set in the isolated home", async () => {
+    vi.resetModules();
+    const credentialsModule = await import("../src/utils/credentials.js");
+    const cliModule = await import("../src/cli.js");
+    const askHiddenFn = vi
+      .fn<(question: string) => Promise<string>>()
+      .mockResolvedValueOnce("  synthetic-new-session  ")
+      .mockResolvedValueOnce("  synthetic-new-csrf  ")
+      .mockResolvedValueOnce("  30003  ");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await cliModule.configureCredentials(askHiddenFn);
+
+    expect(result).toBe(true);
+    expect(process.exitCode).toBeUndefined();
+    const saved = JSON.parse(
+      fs.readFileSync(credentialsModule.GLOBAL_CONFIG_FILE, "utf8"),
+    );
+    expect(saved).toMatchObject({
+      sessdata: "synthetic-new-session",
+      bili_jct: "synthetic-new-csrf",
+      dedeuserid: "30003",
+    });
+    expect(logSpy.mock.calls.flat().join("\n")).toContain("凭证配置成功");
   });
 });
 
@@ -414,10 +517,12 @@ describe("setup credential loadability", () => {
     process.stdin,
     "isTTY",
   );
+  const originalExitCode = process.exitCode;
 
   afterEach(() => {
     vi.restoreAllMocks();
     credentialManager.clearCredentials();
+    process.exitCode = originalExitCode;
     if (originalTtyDescriptor) {
       Object.defineProperty(process.stdin, "isTTY", originalTtyDescriptor);
     } else {
@@ -438,6 +543,27 @@ describe("setup credential loadability", () => {
     await setupCredentials(configure, runAsr, askHiddenFn);
 
     expect(configure).toHaveBeenCalledOnce();
+  });
+
+  it("stops before the ASR prompt when credential configuration reports failure", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    vi.spyOn(credentialManager, "getCredentials").mockReturnValue(null);
+    const configure = vi.fn(async () => false);
+    const runAsr = vi.fn(async () => ({ success: true }));
+    const askHiddenFn = vi.fn(async () => {
+      throw new Error("ASR prompt must not be reached after credential failure");
+    });
+    process.exitCode = undefined;
+
+    await setupCredentials(configure, runAsr, askHiddenFn);
+
+    expect(configure).toHaveBeenCalledOnce();
+    expect(askHiddenFn).not.toHaveBeenCalled();
+    expect(runAsr).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 
   it("default No does not call the ASR runner", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SUPPORTED_LANGUAGES } from "../src/bilibili/types.js";
+import {
+  DEFAULT_CONFIG,
+  getPreferredLanguage,
+} from "../src/config.js";
+
+describe("language configuration", () => {
+  it("uses the canonical supported-language list at runtime", () => {
+    expect(DEFAULT_CONFIG.supportedLanguages).toEqual(SUPPORTED_LANGUAGES);
+  });
+
+  it("preserves ai-zh as the requested language", () => {
+    expect(getPreferredLanguage("ai-zh")).toBe("ai-zh");
+  });
+
+  it("does not silently replace an unsupported language", () => {
+    expect(() => getPreferredLanguage("fr")).toThrow(
+      "Unsupported language. Supported values: zh-Hans, zh-CN, zh-Hant, en, ja, ko, ai-zh",
+    );
+  });
+});
+
+const NUMERIC_ENV_NAMES = [
+  "BILIBILI_RATE_LIMIT_MS",
+  "BILIBILI_REQUEST_TIMEOUT_MS",
+  "BILIBILI_CACHE_SIZE",
+] as const;
+
+const originalNumericEnv = new Map(
+  NUMERIC_ENV_NAMES.map((name) => [name, process.env[name]]),
+);
+
+async function importConfigWithEnv(name: string, value: string) {
+  process.env[name] = value;
+  vi.resetModules();
+  return import("../src/config.js");
+}
+
+describe("numeric environment configuration", () => {
+  beforeEach(() => {
+    for (const name of NUMERIC_ENV_NAMES) {
+      delete process.env[name];
+    }
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    for (const name of NUMERIC_ENV_NAMES) {
+      const original = originalNumericEnv.get(name);
+      if (original === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = original;
+      }
+    }
+    vi.resetModules();
+  });
+
+  it.each([
+    ["BILIBILI_RATE_LIMIT_MS", "17", "rateLimitMs", 17],
+    ["BILIBILI_RATE_LIMIT_MS", "2147483647", "rateLimitMs", 2147483647],
+    ["BILIBILI_REQUEST_TIMEOUT_MS", "2500", "requestTimeoutMs", 2500],
+    [
+      "BILIBILI_REQUEST_TIMEOUT_MS",
+      "2147483647",
+      "requestTimeoutMs",
+      2147483647,
+    ],
+    ["BILIBILI_CACHE_SIZE", "25", "maxCacheSize", 25],
+    [
+      "BILIBILI_CACHE_SIZE",
+      "9007199254740991",
+      "maxCacheSize",
+      Number.MAX_SAFE_INTEGER,
+    ],
+  ] as const)(
+    "loads %s only when it is a complete positive safe integer",
+    async (name, value, property, expected) => {
+      const { config: loadedConfig } = await importConfigWithEnv(name, value);
+      expect(loadedConfig[property]).toBe(expected);
+    },
+  );
+
+  const invalidNumericValues = [
+    "",
+    "NaN",
+    "12ms",
+    "1.5",
+    "0",
+    "-1",
+    "9007199254740992",
+  ];
+
+  it.each(
+    NUMERIC_ENV_NAMES.flatMap((name) =>
+      invalidNumericValues.map((value) => [name, value] as const),
+    ),
+  )(
+    "rejects invalid %s value %j with an actionable error",
+    async (name, value) => {
+      await expect(importConfigWithEnv(name, value)).rejects.toThrow(
+        `${name} must be a positive safe integer written in base-10 digits`,
+      );
+    },
+  );
+
+  it.each([
+    "BILIBILI_RATE_LIMIT_MS",
+    "BILIBILI_REQUEST_TIMEOUT_MS",
+  ] as const)("rejects %s above Node's timer range", async (name) => {
+    await expect(importConfigWithEnv(name, "2147483648")).rejects.toThrow(
+      `${name} must not exceed 2147483647 milliseconds`,
+    );
+  });
+});

--- a/tests/index-env-order.test.ts
+++ b/tests/index-env-order.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const savedCacheSize = process.env.BILIBILI_CACHE_SIZE;
+
+beforeEach(() => {
+  vi.resetModules();
+  delete process.env.BILIBILI_CACHE_SIZE;
+});
+
+afterEach(() => {
+  vi.doUnmock("dotenv");
+  if (savedCacheSize === undefined) {
+    delete process.env.BILIBILI_CACHE_SIZE;
+  } else {
+    process.env.BILIBILI_CACHE_SIZE = savedCacheSize;
+  }
+});
+
+describe("entrypoint environment loading order", () => {
+  it("validates values loaded by dotenv before the server imports runtime config", async () => {
+    vi.doMock("dotenv", () => ({
+      config: vi.fn(() => {
+        process.env.BILIBILI_CACHE_SIZE = "0";
+        return { parsed: { BILIBILI_CACHE_SIZE: "0" } };
+      }),
+    }));
+
+    await expect(import("../src/index.js")).rejects.toMatchObject({
+      name: "ConfigurationError",
+      message:
+        "BILIBILI_CACHE_SIZE must be a positive safe integer written in base-10 digits",
+    });
+  });
+});

--- a/tests/mcp-server-smoke.test.ts
+++ b/tests/mcp-server-smoke.test.ts
@@ -193,6 +193,25 @@ describe("MCP stdio entrypoint", () => {
       expect(JSON.parse(callResult.content[0].text)).not.toMatchObject({
         Cookie: expect.anything(),
       });
+
+      send({
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: {
+          name: "get_video_info",
+          arguments: {
+            bvid_or_url: "BV1T6PQzQErF",
+            preferred_lang: "fr",
+          },
+        },
+      });
+      const rejectedLanguage = await waitForId(4);
+      const rejectedLanguageResult = rejectedLanguage.result as CallToolResponse;
+      expect(rejectedLanguageResult.isError).toBe(true);
+      expect(JSON.parse(rejectedLanguageResult.content[0].text)).toMatchObject({
+        code: "VALIDATION_ERROR",
+      });
     } finally {
       child.stdin.end();
       const closed = new Promise<void>((resolve) => child.once("close", () => resolve()));

--- a/tests/server-error-next-steps.test.ts
+++ b/tests/server-error-next-steps.test.ts
@@ -179,6 +179,32 @@ describe("generic MCP error credential next_steps", () => {
     expect(JSON.stringify(payload)).not.toMatch(/SESSDATA|bili_jct|DedeUserID/i);
   });
 
+  it("returns resource-generic access guidance for Favorites access denial", async () => {
+    mockListBilibiliFavoriteVideos.mockRejectedValueOnce(
+      new BilibiliAPIError("Access denied", "ACCESS_DENIED"),
+    );
+
+    const handler = getCallToolHandler();
+    const response = await handler({
+      method: "tools/call",
+      jsonrpc: "2.0",
+      id: 5,
+      params: {
+        name: "list_bilibili_favorite_videos",
+        arguments: {},
+      },
+    });
+    const payload = JSON.parse(response.content[0].text);
+
+    expect(response.isError).toBe(true);
+    expectStructuredError(payload, "ACCESS_DENIED", {
+      retryable: false,
+      userActionRequired: true,
+    });
+    expect(payload.next_steps_en.join(" ")).toContain("resource");
+    expect(payload.next_steps_zh.join(" ")).toContain("资源");
+  });
+
   it("adds bilingual next_steps when transcript subtitles are unavailable", async () => {
     mockGetVideoTranscriptData.mockRejectedValueOnce(
       new NoSubtitleError("No subtitles"),

--- a/tests/server-handler-sanitization.test.ts
+++ b/tests/server-handler-sanitization.test.ts
@@ -91,6 +91,101 @@ describe("handler validation and transcript output", () => {
     vi.clearAllMocks();
   });
 
+  it("passes ai-zh unchanged to get_video_info subtitle selection", async () => {
+    mockGetVideoInfoWithSubtitle.mockResolvedValueOnce({
+      data_source: "subtitle",
+      video_info: { title: "AI subtitle fixture" },
+    });
+
+    const handler = getCallToolHandler();
+    await handler({
+      method: "tools/call",
+      jsonrpc: "2.0",
+      id: 21,
+      params: {
+        name: "get_video_info",
+        arguments: {
+          bvid_or_url: "BV1T6PQzQErF",
+          preferred_lang: "ai-zh",
+        },
+      },
+    });
+
+    expect(mockGetVideoInfoWithSubtitle).toHaveBeenCalledWith(
+      "BV1T6PQzQErF",
+      "ai-zh",
+      undefined,
+    );
+  });
+
+  it("passes ai-zh unchanged to get_video_transcript subtitle selection", async () => {
+    mockGetVideoTranscriptData.mockResolvedValueOnce({
+      bvid: "BV1T6PQzQErF",
+      data_source: "subtitle",
+      language: "ai-zh",
+      transcript: "AI subtitle fixture",
+      title: "AI subtitle fixture",
+      source_url: "https://www.bilibili.com/video/BV1T6PQzQErF/",
+    });
+
+    const handler = getCallToolHandler();
+    await handler({
+      method: "tools/call",
+      jsonrpc: "2.0",
+      id: 22,
+      params: {
+        name: "get_video_transcript",
+        arguments: {
+          bvid_or_url: "BV1T6PQzQErF",
+          preferred_lang: "ai-zh",
+        },
+      },
+    });
+
+    expect(mockGetVideoTranscriptData).toHaveBeenCalledWith(
+      "BV1T6PQzQErF",
+      "ai-zh",
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+    );
+  });
+
+  it.each([
+    ["get_video_info", mockGetVideoInfoWithSubtitle],
+    ["get_video_transcript", mockGetVideoTranscriptData],
+  ])(
+    "%s rejects a well-formed unsupported language before business work",
+    async (name, businessMock) => {
+      const handler = getCallToolHandler();
+      const result = await handler({
+        method: "tools/call",
+        jsonrpc: "2.0",
+        id: 23,
+        params: {
+          name,
+          arguments: {
+            bvid_or_url: "BV1T6PQzQErF",
+            preferred_lang: "fr",
+          },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result).not.toHaveProperty("structuredContent");
+      expect(JSON.parse(result.content[0].text)).toMatchObject({
+        code: "VALIDATION_ERROR",
+        message:
+          "Unsupported language. Supported values: zh-Hans, zh-CN, zh-Hant, en, ja, ko, ai-zh",
+      });
+      expect(businessMock).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([
     ["empty query", { query: "   " }],
     ["max_matches out of range", { query: "hello", max_matches: 999 }],

--- a/tests/server-tools.test.ts
+++ b/tests/server-tools.test.ts
@@ -93,9 +93,21 @@ describe("MCP tool list baseline", () => {
       expect(schema.inputSchema.required).toContain("bvid_or_url");
     });
 
-    it("accepts optional preferred_lang", () => {
+    it("publishes the supported preferred_lang values including ai-zh", () => {
       schema = toolsResult.tools.find((t) => t.name === "get_video_info")!;
-      expect(schema.inputSchema.properties).toHaveProperty("preferred_lang");
+      const prop = schema.inputSchema.properties.preferred_lang as {
+        type?: string;
+        enum?: string[];
+        description?: string;
+      };
+
+      expect(prop).toMatchObject({
+        type: "string",
+        enum: ["zh-Hans", "zh-CN", "zh-Hant", "en", "ja", "ko", "ai-zh"],
+      });
+      expect(prop.description).toContain("ai-zh");
+      expect(prop.description).toContain("未知值会被拒绝");
+      expect(prop.description).toContain("unsupported values are rejected");
     });
 
     it("accepts optional page with integer type and minimum 1", () => {
@@ -140,11 +152,26 @@ describe("MCP tool list baseline", () => {
       expect(prop.enum).toEqual(["brief", "detailed"]);
     });
 
-    it("accepts optional limit", () => {
+    it("defines limit as a 1-50 main-comment count and documents reply expansion", () => {
       schema = toolsResult.tools.find(
         (t) => t.name === "get_video_comments",
       )!;
-      expect(schema.inputSchema.properties).toHaveProperty("limit");
+      const prop = schema.inputSchema.properties.limit as {
+        type?: string;
+        minimum?: number;
+        maximum?: number;
+        description?: string;
+      };
+
+      expect(prop).toMatchObject({
+        type: "integer",
+        minimum: 1,
+        maximum: 50,
+      });
+      expect(prop.description).toContain("主评论");
+      expect(prop.description).toContain("main-comment");
+      expect(prop.description).toContain("comments[]");
+      expect(prop.description).toContain("超过 limit");
     });
 
     it("accepts optional sort with enum hot/time", () => {
@@ -188,11 +215,23 @@ describe("MCP tool list baseline", () => {
       expect(schema.inputSchema.required).toContain("bvid_or_url");
     });
 
-    it("accepts optional preferred_lang", () => {
+    it("publishes the supported preferred_lang values including ai-zh", () => {
       schema = toolsResult.tools.find(
         (t) => t.name === "get_video_transcript",
       )!;
-      expect(schema.inputSchema.properties).toHaveProperty("preferred_lang");
+      const prop = schema.inputSchema.properties.preferred_lang as {
+        type?: string;
+        enum?: string[];
+        description?: string;
+      };
+
+      expect(prop).toMatchObject({
+        type: "string",
+        enum: ["zh-Hans", "zh-CN", "zh-Hant", "en", "ja", "ko", "ai-zh"],
+      });
+      expect(prop.description).toContain("ai-zh");
+      expect(prop.description).toContain("未知值会被拒绝");
+      expect(prop.description).toContain("unsupported values are rejected");
     });
 
     it("accepts optional fallback_to_description (boolean)", () => {

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -69,6 +69,17 @@ describe("validateLanguage", () => {
     expect(() => validateLanguage("zh-Hans")).not.toThrow();
   });
 
+  it("accepts Bilibili AI-generated Chinese subtitles", () => {
+    expect(() => validateLanguage("ai-zh")).not.toThrow();
+  });
+
+  it("rejects a well-formed but unsupported language explicitly", () => {
+    expect(() => validateLanguage("fr")).toThrowError(ValidationError);
+    expect(() => validateLanguage("fr")).toThrow(
+      "Unsupported language. Supported values: zh-Hans, zh-CN, zh-Hant, en, ja, ko, ai-zh",
+    );
+  });
+
   it("rejects Chinese characters", () => {
     expect(() => validateLanguage("中文")).toThrow(
       "Invalid language code format",


### PR DESCRIPTION
## Summary

- make `get_video_comments.limit` an integer main-comment count from 1 to 50, with fixed-size pagination, bounded traversal, and fail-closed malformed-response handling
- preserve canonical `ai-zh` while centralizing supported-language validation
- reject blank credential replacement without mutating saved state
- strictly validate numeric runtime configuration and load project `.env` before config evaluation
- classify JSON `-403` by endpoint semantics and keep recovery guidance resource-generic

## Verification

- `npm test`: 41 files / 857 tests passed
- `npm run build`: passed
- public stdio JSON-RPC smoke: passed
- `npm pack --dry-run --json --ignore-scripts`: 185 files, required entrypoints present, forbidden paths zero
- `npm audit --omit=dev --json`: zero production vulnerabilities
- `git diff --check`: passed
- `package-lock.json`: unchanged from `1b97183`
- staged value-free secret scan: no private-key, GitHub, npm, AWS, JWT, or secret-filename findings
- independent standards and specification reviews: PASS, no remaining P0-P3

## Release boundary

This is source delivery only. Package version remains `1.11.3`; no tag, npm publication, MCP Registry publication, GitHub Release, or deployment is included.