### PR TITLE
fix: fail closed on malformed search responses

### DIFF
--- a/docs/agent-memory/active-work.md
+++ b/docs/agent-memory/active-work.md
@@ -7,6 +7,14 @@ remains intact. GitHub Actions run `31032259381` passed tests, build, and npm
 trusted publishing. The Official Registry reports version `1.11.3` as `active`
 and `isLatest=true`.
 
+Unreleased source delivery on 2026-08-09 comprises PR #26 for comments,
+language, credential, numeric-config, dotenv-order, and endpoint-aware `-403`
+contracts, plus PR #27 for fail-closed malformed search responses. Both keep
+the source package version at `1.11.3`; npm, GitHub Releases, and the Official
+Registry still expose the previously published `1.11.3` artifacts. Any public
+release of these source changes must use a new version such as `1.11.4` and
+requires separate release authorization.
+
 Release verification passed the TypeScript build, 39 files / 803 tests,
 production audit with zero vulnerabilities, a 181-file package with required
 dist entry points and no forbidden paths, Registry metadata validation,

--- a/docs/agent-memory/handoffs/2026-08-09-search-response-hardening-task-ticket.md
+++ b/docs/agent-memory/handoffs/2026-08-09-search-response-hardening-task-ticket.md
@@ -1,0 +1,73 @@
+# Task Ticket: Search Response Hardening
+
+## Ticket
+
+- ID: `SEARCH-2026-08-09`
+- Title: Distinguish empty search results from malformed upstream responses
+- Status: `done`
+- Owner: `Codex`
+- Source: User-authorized follow-up after the 2026-08-09 live search diagnosis
+
+## Objective
+
+Keep an explicit Bilibili `result: []` as a successful empty search while retrying a missing or non-array result once and then failing closed through the existing structured upstream-response error contract.
+
+## Scope
+
+In scope:
+
+- Endpoint-local validation of the successful search payload shape.
+- One additional request only for the search-specific malformed shape.
+- Focused search and public MCP error-boundary regressions.
+- Full build, test, stdio, package, audit, diff, and secret verification.
+- Isolated branch, commit, push, PR, and merge delivery.
+
+Out of scope:
+
+- Generic HTTP retry changes, anonymous search, schema/tool-name changes, reclassifying a non-empty result array whose rows all normalize away, or retrying an explicit empty array.
+- Real Cookie output, version bumping, tags, npm/MCP Registry publication, GitHub Releases, or deployment.
+
+## Files To Inspect Or Edit
+
+Expected edit:
+
+- `src/bilibili/search.ts`
+- `tests/bilibili-search.test.ts`
+- `tests/server-error-next-steps.test.ts`
+- This ticket, QA, and project-memory evidence.
+
+Do not touch:
+
+- Shared HTTP behavior, package dependencies, `package-lock.json`, generated `dist`, workflows, release metadata, or the dirty main user worktree.
+
+## Acceptance Criteria
+
+- [x] Explicit `{ result: [] }` succeeds with one search request.
+- [x] Missing or non-array `result` retries once, then throws `UpstreamResponseError`.
+- [x] A valid second response recovers after one malformed response.
+- [x] `NetworkError`, HTTP-status errors, and raw `ECONNRESET`-style errors are preserved without an extra endpoint-level retry.
+- [x] Aborting during the 500 ms shape backoff prevents the second request.
+- [x] The public MCP boundary returns text-only `UPSTREAM_RESPONSE_INVALID` without `structuredContent`.
+- [x] Public tool names, schemas, and successful response shapes remain unchanged.
+- [x] Credentials, Cookies, tokens, `.env` content, and private values are not printed or committed.
+- [x] `docs/agent-memory/codemap.md` was checked; the existing search-module and test navigation remains accurate.
+
+## Verification
+
+- `npx vitest run tests/bilibili-search.test.ts tests/server-error-next-steps.test.ts`
+- `npm run build`
+- `npm test`
+- Selected real stdio JSON-RPC smoke.
+- `npm pack --dry-run --json --ignore-scripts`
+- `npm audit --omit=dev --json`
+- `git diff --check`, lockfile fingerprint, value-free secret scan, and two-axis final review.
+
+## Risks And Rollback
+
+- Risk: a malformed successful payload can add one bounded request and 500 ms of abort-aware backoff. Normal, explicitly empty, network, HTTP-status, system-code, and API-error paths add no endpoint-level request.
+- Limitation: the original transient response envelope was not retained, so this patch does not claim that every explicit empty result is anomalous.
+- Rollback: before merge, abandon only this isolated branch; after merge, use a normal revert PR.
+
+## Stop And Report Conditions
+
+Stop if the fix requires generic HTTP behavior changes, more than one extra search request, a real credential value, a package/version change, or a public schema change.

--- a/docs/agent-memory/project-facts.md
+++ b/docs/agent-memory/project-facts.md
@@ -446,3 +446,13 @@
 - Impact: package version remains `1.11.3`; tag, npm publication, Official MCP
   Registry publication, GitHub Release, and deployment require a separate
   release decision.
+
+- Fact: The search adapter distinguishes an explicit empty result array from
+  a missing or non-array result container. Only the malformed shape receives
+  one endpoint-local retry and then fails as `UpstreamResponseError`.
+- Evidence: direct search regressions for explicit empty, missing, non-array,
+  transient recovery, NetworkError, HTTP 503, raw `ECONNRESET`, and abort
+  passthrough; plus the MCP text-only `UPSTREAM_RESPONSE_INVALID` regression.
+- Impact: malformed HTTP-200/code-0 search payloads can no longer silently
+  masquerade as no matches. Explicit empty arrays and non-empty arrays whose
+  rows all normalize away retain their previous successful-empty semantics.

--- a/docs/agent-memory/verification-log.md
+++ b/docs/agent-memory/verification-log.md
@@ -1439,3 +1439,30 @@
 - Delivery boundary: branch/commit/push/PR/merge was explicitly authorized;
   version bumping, tags, npm publication, MCP Registry publication, and a
   GitHub Release remain outside this work.
+
+## 2026-08-09 Search Response Hardening (Candidate)
+
+- Baseline: isolated branch from merge commit `741dcf0`, which delivered the
+  contract-correctness source changes through PR #26. Package version remains
+  `1.11.3` and no release metadata changed.
+- TDD: a missing `result` first reproduced the old successful-empty behavior,
+  then failed closed after exactly one search-specific retry. Explicit empty,
+  non-array, recovery-on-second-response, network-error, and public MCP error
+  boundary regressions all pass.
+- Result: focused 2 files / 36 tests; full 41 files / 862 tests; TypeScript
+  build; selected real stdio smoke; zero-vulnerability production audit; and
+  a 185-file package with required entrypoints and zero forbidden paths all
+  passed.
+- Boundary: an explicit `result: []` remains a one-request successful empty
+  result. The original transient envelope was not captured, so this change
+  does not claim that every observed empty array is an upstream defect.
+- Final checks: `git diff --check` passed; `package-lock.json` retained blob
+  `70cee9306932ebb2d32bc1cce4016770cd2963d4`; high-signal value-free scans
+  found no private key, provider token, AWS key, JWT, or secret filename.
+- Risk correction: an additional reviewer proved that shared `withRetry`
+  always retries raw `ECONNRESET`/`ETIMEDOUT` codes even with a narrow type
+  list. A raw-code regression failed at two calls, then passed at one after the
+  search layer adopted a local shape-only loop. HTTP 503 and abort-during-
+  backoff regressions also pass, preventing nested retry multiplication.
+- Final review: risk, standards, and specification re-reviews returned PASS
+  with no remaining P0-P3 after the local loop correction.

--- a/docs/qa/2026-08-09-search-response-hardening.md
+++ b/docs/qa/2026-08-09-search-response-hardening.md
@@ -1,0 +1,67 @@
+# QA: Search Response Hardening
+
+## QA Session
+
+- Title: Explicit-empty versus malformed search response
+- Date: 2026-08-09
+- Version or commit: unreleased `1.11.3` source baseline at `741dcf0`
+- Owner: Codex
+- Related ticket: `docs/agent-memory/handoffs/2026-08-09-search-response-hardening-task-ticket.md`
+- QA type: `MCP tool change | regression`
+
+## Scope
+
+In scope:
+
+- Search response shape validation and its one-retry boundary.
+- Direct search behavior and public MCP error mapping.
+- Full local regression and package-safety gates.
+
+Out of scope:
+
+- Live Cookie output, anonymous search, true-empty reclassification, external desktop clients, versioning, publication, and deployment.
+
+## Preconditions
+
+- [x] Isolated branch and `741dcf0` baseline recorded.
+- [x] Package version remains `1.11.3`.
+- [x] Tests use synthetic credential headers and mocked Bilibili responses.
+- [x] No real credential value is read or recorded by the tests.
+
+## Automated Baseline
+
+- Build: `npm run build` passed.
+- Focused tests: 2 files / 36 tests passed.
+- Full tests: 41 files / 862 tests passed.
+- Stdio: selected real child-process `initialize` -> exact `tools/list` -> representative `tools/call` passed, 1 selected / 11 skipped.
+- Pack: 185 files, 1,088,660 packed bytes, 1,718,633 unpacked bytes; required entrypoints present and forbidden paths zero.
+- Audit: zero production vulnerabilities across 97 dependencies.
+
+## MCP And Search Behavior
+
+- [x] Explicit `result: []` returns `{ query, results: [] }` after one request.
+- [x] Missing and non-array results each make at most two endpoint requests and then fail as `UpstreamResponseError`.
+- [x] A valid second response recovers after the first malformed response.
+- [x] A search `NetworkError` remains the original error and receives no outer retry.
+- [x] HTTP 503 and raw `ECONNRESET` errors receive no endpoint-level retry, so the search layer cannot multiply the shared HTTP retry policy.
+- [x] Aborting during the 500 ms shape backoff rejects as `AbortError` before a second request.
+- [x] The MCP error is text-only, sets `isError=true`, omits `structuredContent`, and reports `UPSTREAM_RESPONSE_INVALID`.
+- [x] Non-empty arrays continue to normalize/filter rows under the existing contract.
+
+## Security And Privacy Checks
+
+- [x] The endpoint-local shape retry emits no query, Cookie, response body, or credential value.
+- [x] No public success schema, credential requirement, or response-size limit changed.
+- [x] Package output excludes source, tests, QA, agent memory, local config, and credential paths.
+- [x] Value-free scan found zero private-key, GitHub-token, npm-token, AWS-key, JWT, or secret-filename findings; the only Cookie-shaped changed-file match is historical verification prose with no value.
+- [x] `git diff --check` passed and `package-lock.json` retained blob `70cee9306932ebb2d32bc1cce4016770cd2963d4`.
+
+## Result
+
+- Overall result: `pass with caveats`
+- Blocking issues: none
+- Non-blocking caveat: because the original transient raw envelope was not captured, this patch fixes the provable missing/non-array ambiguity but intentionally keeps an explicit empty array as a legitimate result.
+- Follow-up tickets: none; reconsider true-empty retry only with captured upstream evidence.
+- Codemap update status: checked and left unchanged; existing search navigation remains accurate.
+- Research note: not required because local source, tests, and captured runtime diagnosis are authoritative.
+- Independent review: initial review found the shared retry helper's raw-system-code fallback; after the local shape-only correction, risk, standards, and specification re-reviews returned PASS with no remaining P0-P3.

--- a/src/bilibili/search.ts
+++ b/src/bilibili/search.ts
@@ -2,7 +2,13 @@ import { credentialManager } from "../utils/credentials.js";
 import {
   BilibiliAPIError,
   ResourceLimitError,
+  UpstreamResponseError,
 } from "../utils/errors.js";
+import {
+  abortableDelay,
+  getOperationSignal,
+  throwIfAborted,
+} from "../security/operation-context.js";
 import { isValidBVId } from "../utils/bvid.js";
 import type { VideoSearchCandidate, VideoSearchData } from "./types.js";
 import { checkLoginStatus, fetchWithoutWBI } from "./http.js";
@@ -16,6 +22,7 @@ const MAX_SEARCH_ROWS = 100;
 const MAX_SEARCH_TITLE_BYTES = 512;
 const MAX_SEARCH_AUTHOR_BYTES = 128;
 const MAX_SEARCH_DESCRIPTION_BYTES = 512;
+const SEARCH_SHAPE_RETRY_DELAY_MS = 500;
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -107,6 +114,39 @@ function normalizeCandidate(value: unknown): VideoSearchCandidate | undefined {
   };
 }
 
+async function fetchSearchRows(
+  query: string,
+  limit: number,
+  authHeaders: Record<string, string>,
+): Promise<unknown[]> {
+  const signal = getOperationSignal();
+  const params = {
+    search_type: "video",
+    keyword: query,
+    page: 1,
+    page_size: limit,
+  };
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    throwIfAborted(signal);
+    const data = await fetchWithoutWBI(
+      VIDEO_SEARCH_PATH,
+      params,
+      authHeaders,
+    );
+    if (isRecord(data) && Array.isArray(data.result)) {
+      return data.result;
+    }
+    if (attempt === 0) {
+      await abortableDelay(SEARCH_SHAPE_RETRY_DELAY_MS, signal);
+    }
+  }
+
+  throw new UpstreamResponseError(
+    "Bilibili returned an invalid video search response",
+  );
+}
+
 export async function searchBilibiliVideos(
   query: string,
   limit = 5,
@@ -126,18 +166,8 @@ export async function searchBilibiliVideos(
     throw createCredentialError();
   }
 
-  const data = await fetchWithoutWBI(
-    VIDEO_SEARCH_PATH,
-    {
-      search_type: "video",
-      keyword: normalizedQuery,
-      page: 1,
-      page_size: limit,
-    },
-    authHeaders,
-  );
+  const rows = await fetchSearchRows(normalizedQuery, limit, authHeaders);
 
-  const rows = isRecord(data) && Array.isArray(data.result) ? data.result : [];
   if (rows.length > MAX_SEARCH_ROWS) {
     throw new ResourceLimitError(
       "Video search response exceeded its item limit",

--- a/tests/bilibili-search.test.ts
+++ b/tests/bilibili-search.test.ts
@@ -23,6 +23,9 @@ vi.mock("../src/utils/credentials.js", () => ({
 const { BilibiliAPIError, NetworkError } = await import(
   "../src/utils/errors.js"
 );
+const { runWithOperationSignal } = await import(
+  "../src/security/operation-context.js"
+);
 const { searchBilibiliVideos } = await import("../src/bilibili/search.js");
 
 describe("searchBilibiliVideos", () => {
@@ -200,18 +203,85 @@ describe("searchBilibiliVideos", () => {
     httpMocks.fetchWithoutWBI.mockRejectedValue(error);
 
     await expect(searchBilibiliVideos("MCP", 5)).rejects.toBe(error);
+    expect(httpMocks.fetchWithoutWBI).toHaveBeenCalledTimes(1);
   });
 
-  it.each([
-    ["missing result", {}],
-    ["non-array result", { result: "unexpected" }],
-    ["empty result", { result: [] }],
-  ])("returns a successful empty result for %s", async (_case, payload) => {
-    httpMocks.fetchWithoutWBI.mockResolvedValue(payload);
+  it("does not add an endpoint retry for a raw system-coded failure", async () => {
+    const error = Object.assign(new Error("Socket reset"), {
+      code: "ECONNRESET",
+    });
+    httpMocks.fetchWithoutWBI.mockRejectedValue(error);
+
+    await expect(searchBilibiliVideos("MCP", 5)).rejects.toBe(error);
+    expect(httpMocks.fetchWithoutWBI).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not add an endpoint retry for an HTTP status failure", async () => {
+    const error = new NetworkError(
+      "Service unavailable",
+      undefined,
+      undefined,
+      503,
+    );
+    httpMocks.fetchWithoutWBI.mockRejectedValue(error);
+
+    await expect(searchBilibiliVideos("MCP", 5)).rejects.toBe(error);
+    expect(httpMocks.fetchWithoutWBI).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts during shape-retry backoff without a second request", async () => {
+    const controller = new AbortController();
+    httpMocks.fetchWithoutWBI.mockResolvedValue({});
+
+    const searchPromise = runWithOperationSignal(controller.signal, () =>
+      searchBilibiliVideos("MCP", 5),
+    );
+    await vi.waitFor(() => {
+      expect(httpMocks.fetchWithoutWBI).toHaveBeenCalledTimes(1);
+    });
+    controller.abort();
+
+    await expect(searchPromise).rejects.toMatchObject({ name: "AbortError" });
+    expect(httpMocks.fetchWithoutWBI).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an explicit empty result without an extra request", async () => {
+    httpMocks.fetchWithoutWBI.mockResolvedValue({ result: [] });
 
     await expect(searchBilibiliVideos("nothing", 5)).resolves.toEqual({
       query: "nothing",
       results: [],
     });
+    expect(httpMocks.fetchWithoutWBI).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a missing result once before failing closed", async () => {
+    httpMocks.fetchWithoutWBI.mockResolvedValue({});
+
+    await expect(searchBilibiliVideos("nothing", 5)).rejects.toMatchObject({
+      name: "UpstreamResponseError",
+    });
+    expect(httpMocks.fetchWithoutWBI).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a non-array result once before failing closed", async () => {
+    httpMocks.fetchWithoutWBI.mockResolvedValue({ result: "unexpected" });
+
+    await expect(searchBilibiliVideos("nothing", 5)).rejects.toMatchObject({
+      name: "UpstreamResponseError",
+    });
+    expect(httpMocks.fetchWithoutWBI).toHaveBeenCalledTimes(2);
+  });
+
+  it("recovers when the retry returns an explicit empty result", async () => {
+    httpMocks.fetchWithoutWBI
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ result: [] });
+
+    await expect(searchBilibiliVideos("nothing", 5)).resolves.toEqual({
+      query: "nothing",
+      results: [],
+    });
+    expect(httpMocks.fetchWithoutWBI).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/server-error-next-steps.test.ts
+++ b/tests/server-error-next-steps.test.ts
@@ -50,6 +50,7 @@ const {
   NoSubtitleError,
   PaidVideoError,
   TimeoutError,
+  UpstreamResponseError,
 } = await import("../src/utils/errors.js");
 
 const { credentialManager } = await import("../src/utils/credentials.js");
@@ -148,6 +149,31 @@ describe("generic MCP error credential next_steps", () => {
       "npx -y @xzxzzx/bilibili-mcp@latest config",
     );
     expect(JSON.stringify(payload)).not.toContain("configured");
+  });
+
+  it("maps malformed search responses to a text-only upstream error", async () => {
+    mockSearchBilibiliVideos.mockRejectedValueOnce(
+      new UpstreamResponseError("Invalid search response"),
+    );
+
+    const handler = getCallToolHandler();
+    const response = await handler({
+      method: "tools/call",
+      jsonrpc: "2.0",
+      id: 3,
+      params: {
+        name: "search_bilibili_videos",
+        arguments: { query: "MCP" },
+      },
+    });
+    const payload = JSON.parse(response.content[0].text);
+
+    expect(response.isError).toBe(true);
+    expect(response).not.toHaveProperty("structuredContent");
+    expectStructuredError(payload, "UPSTREAM_RESPONSE_INVALID", {
+      retryable: false,
+      userActionRequired: false,
+    });
   });
 
   it("returns safe credential recovery guidance for authenticated favorites discovery", async () => {


### PR DESCRIPTION
## Summary

- distinguish an explicit empty Bilibili search result from a missing or non-array result container
- retry only the search-specific malformed shape once after an abort-aware 500 ms delay
- preserve NetworkError, HTTP-status, raw system-code, API-error, and explicit-empty paths without endpoint-level retry
- map repeated malformed responses through the existing text-only `UPSTREAM_RESPONSE_INVALID` MCP contract

## Verification

- focused search/error tests: 2 files / 36 tests passed
- `npm test`: 41 files / 862 tests passed
- `npm run build`: passed
- public stdio JSON-RPC smoke: passed
- `npm pack --dry-run --json --ignore-scripts`: 185 files, required entrypoints present, forbidden paths zero
- `npm audit --omit=dev --json`: zero production vulnerabilities
- `git diff --check`: passed
- `package-lock.json`: unchanged from `741dcf0`
- staged value-free secret scan: no new high-signal secret finding
- risk, standards, and specification reviews: PASS, no remaining P0-P3

## Compatibility boundary

An explicit `result: []` remains a legitimate one-request empty result, and a non-empty array whose rows normalize away keeps its existing semantics. The original transient raw envelope was not captured, so this PR intentionally fixes only the provable missing/non-array ambiguity.

## Release boundary

Package version remains `1.11.3`; no tag, npm publication, MCP Registry publication, GitHub Release, or deployment is included.