### PR TITLE
fix: distinguish and validate Bilibili AI subtitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ## [Unreleased]
 
+### 新增
+- 区分 Bilibili AI 识别字幕与人工字幕：选中任意 Bilibili AI 字幕（`ai-zh`、`ai-en` 等 `ai-*` 语言）时，`get_video_transcript` 与 `get_video_info` 返回 `data_source: "ai_subtitle"`（不再是 `"subtitle"`；本地 ASR 仍为 `"asr"`）。`ai_subtitle` 是 Bilibili 的 AI 转录，可能不准确，不能当作人工校验过的引用。
+- `get_video_transcript` 与 `get_video_info` 新增可选参数 `exclude_ai_subtitles`（默认 `false`）：过滤 AI 字幕、优先返回人工字幕；仅剩 AI 字幕时视为无字幕，transcript 可配合显式 ASR/描述降级，video-info 返回简介。video-info 缓存键包含该选项。
+- `get_video_transcript` 新增可选参数 `force_asr`（默认 `false`）：绕过字幕选择直接用已就绪的本地 ASR 转录当前 Part，无需同时设置 `fallback_to_asr`，并优先于 `exclude_ai_subtitles`。
+- 对每个选中的 `ai-*` 无条件双读并做确定性完整性评估，通过后才返回正文：跨读取稳定性（两次读取的正文不一致即不可用，适用于所有 `ai-*`）、语言（仅针对 `ai-zh`：正文含至少 80 个 Unicode 字母且 Han 占比低于 10% 视为不匹配；其他 `ai-*` 语言不因非中文正文被拒绝）。不通过时 `fallback_to_asr: true` 调用本地 ASR，否则遵循 `fallback_to_description`，无授权回退时返回 `SUBTITLE_UNAVAILABLE`；video-info 返回简介且不缓存。稳定但同语言语义不符的正文是已接受的限制，可用 `force_asr` / `exclude_ai_subtitles` 控制；第二次读取的传输/超时/认证/解析失败照常作为错误返回，不会被伪装成完整性失败或触发 ASR。
+- `setup` 新增 `--non-interactive`（使用已有的环境变量或全局配置凭据，绝不提示、也绝不从 stdin/argv 读取凭据值；无 `--asr-model` 时仅确认凭据可加载即成功退出）与 `--asr-model <tiny|base|small>`（需与 `--non-interactive` 同用，安装指定模型）。
+
 ---
 
 ## [1.11.4] - 2026-08-09

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -6,6 +6,13 @@ All notable changes to the **Bilibili MCP Server** will be documented in this fi
 
 ## [Unreleased]
 
+### Added
+- Distinguish Bilibili AI subtitles from human subtitles: when any Bilibili AI track (`ai-zh`, `ai-en`, or another `ai-*` language) is selected, both `get_video_transcript` and `get_video_info` return `data_source: "ai_subtitle"` (no longer `"subtitle"`; managed local ASR stays `"asr"`). `ai_subtitle` is Bilibili AI transcription, may be inaccurate, and is not equivalent to a human-checked citation.
+- New optional `exclude_ai_subtitles` (default `false`) on `get_video_transcript` and `get_video_info`: filters AI tracks before selection and prefers remaining human subtitles; AI-only results are treated as definitive absence (transcript may use explicit ASR/description fallback; video-info returns the description). The video-info cache key includes this option.
+- New optional `force_asr` (default `false`) on `get_video_transcript`: bypasses subtitle selection and transcribes the resolved Part with the ready local ASR, without requiring `fallback_to_asr`, and wins over `exclude_ai_subtitles`.
+- Every selected `ai-*` track is unconditionally read twice and passes a deterministic integrity assessment before its body is returned: cross-read stability (two reads with different normalized bodies are unusable; applies to every `ai-*` language) and language (ai-zh only: a body with at least 80 Unicode letters and under 10% Han letters is an `ai-zh` mismatch; other `ai-*` languages are not rejected for being non-Chinese). An unusable track with `fallback_to_asr: true` invokes the local ASR, otherwise the existing `fallback_to_description` contract applies (`SUBTITLE_UNAVAILABLE` when no fallback is authorized); video-info returns the description without caching it. Stable same-language bodies that are semantically off-topic are an accepted limitation, controlled by `force_asr` / `exclude_ai_subtitles`. A transport, timeout, auth, or parse failure on the second read remains an error and never becomes an integrity failure or ASR trigger.
+- Added `--non-interactive` (uses already-loadable credentials from environment variables or the global config file; never prompts and never reads credential values from stdin/argv; without `--asr-model` it confirms loadability and exits successfully) and `--asr-model <tiny|base|small>` (requires `--non-interactive`; installs the given model) to `setup`.
+
 ---
 
 ## [1.11.4] - 2026-08-09

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,28 @@ _Avoid_: Episode, segment, P-video
 One timed subtitle cue containing start time, end time, and text.
 _Avoid_: Chapter, caption block
 
+**Human Subtitle**:
+A Bilibili-provided subtitle track that is not identified by Bilibili as an AI
+recognition track. It remains distinct from both a Bilibili AI Subtitle and a
+Local ASR Transcript.
+_Avoid_: Native subtitle, trusted subtitle
+
+**Bilibili AI Subtitle**:
+A Bilibili-provided AI recognition track identified by an `ai-*` language code
+(such as `ai-zh`, `ai-en`, `ai-ja`). It is Bilibili-origin evidence, but it is
+not a Human Subtitle and is not assumed to be human-checked.
+_Avoid_: Subtitle, Local ASR Transcript
+
+**Local ASR Transcript**:
+A transcript generated locally from the selected Part's audio by the managed
+ASR runtime. It is distinct from every Bilibili-provided subtitle track.
+_Avoid_: Bilibili AI Subtitle, fallback subtitle
+
+**Subtitle Integrity**:
+Whether a selected subtitle is usable as transcript evidence. Mere presence of
+a subtitle track does not establish Subtitle Integrity.
+_Avoid_: Subtitle availability, transcript quality score
+
 **Transcript Range**:
 A requested time interval used to select overlapping Subtitle Segments from one Part.
 _Avoid_: Chapter range, clip

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Bilibili MCP 是一个本地 MCP server，让 AI Agent 读取 Bilibili 内容：
    npx -y @xzxzzx/bilibili-mcp@latest check
    npx -y @xzxzzx/bilibili-mcp@latest doctor --json
    doctor --json 只检查本机配置状态，不能代替后面的实时登录验证。
-   setup 会询问是否安装可选的本地 ASR 模型，选否即可。
+   setup 会询问是否安装可选的本地 ASR 模型，选否即可。自动化环境可用 setup --non-interactive（凭据来自已有的环境变量或全局配置，绝不提示、也绝不从 stdin/argv 读取凭据值）；加 --asr-model <tiny|base|small> 可同时安装指定模型。
 5. 让我重启或重连客户端。你无法代替我完成这一步时，请明确让我操作。
 6. 重连后调用 MCP 工具 check_bilibili_credentials。
    只有 configured: true 且 logged_in: true 才报告成功。
@@ -138,6 +138,15 @@ next_cursor 直到结束；按收藏夹列出成功读取的视频标题和 B �
 
 前提是已经通过 `setup` 安装了模型且 `doctor --json` 报告 `asr.status: ready`，否则会返回 `ASR_NOT_READY` 并附带安装指引。原生字幕始终优先：只有确认没有可用字幕时才会启动一次本地转录，结果返回 `data_source: "asr"`，并复用与字幕相同的时间戳、区间过滤、关键词搜索和时刻链接。详见[本地 ASR](#本地-asr可选)。
 
+### AI 识别字幕（ai-*）与人工字幕的区分
+
+Bilibili 会把部分视频的 AI 识别字幕标为 `ai-zh`、`ai-en`、`ai-ja` 等 `ai-*` 语言。为避免与人工字幕混淆，选中任意 `ai-*` 字幕时，`get_video_transcript` 与 `get_video_info` 的结果返回 `data_source: "ai_subtitle"`（不是 `"subtitle"`；本地 ASR 仍是 `"asr"`）。
+
+- `ai_subtitle` 是 Bilibili 的 AI 转录，可能不准确，不能当作人工校验过的引用。
+- `exclude_ai_subtitles: true`（两个工具都有，默认 `false`）：过滤全部 AI 字幕（`ai-zh`、`ai-en` 等），优先返回剩余的人工字幕；仅剩 AI 字幕时视为无字幕，`get_video_transcript` 可配合 `fallback_to_asr` / `fallback_to_description`，`get_video_info` 返回简介。
+- `force_asr: true`（仅 `get_video_transcript`，默认 `false`）：绕过字幕元数据与内容选择，直接用本地 ASR 转录当前这一 P；无需同时开启 `fallback_to_asr`，且优先于 `exclude_ai_subtitles`。
+- 每个选中的 `ai-*` 都会无条件双读并做确定性完整性评估，通过后才返回正文：跨读取稳定性（两次读取的正文不一致即不可用，适用于所有 `ai-*`）、语言（仅针对 `ai-zh`：≥80 Unicode 字母且 Han 占比 <10% 视为不匹配；其他 `ai-*` 语言不因非中文正文被拒绝）；不通过时 `fallback_to_asr: true` 调用本地 ASR，否则遵循 `fallback_to_description`；video-info 返回简介且不缓存。同语言但语义不符（稳定却离题的正文）是已接受的限制，可用 `force_asr` 或 `exclude_ai_subtitles` 控制；人工字幕保持单读，第二次读取的传输、超时、认证或解析失败照常作为错误返回。
+
 ## 本地 ASR（可选）
 
 有些视频没有任何字幕。安装本地 ASR 模型后，`get_video_transcript` 可以在你显式开启 `fallback_to_asr` 时，对已解析的这一 P 做一次本地转录。
@@ -154,7 +163,8 @@ Runtime 固定为 `faster-whisper==1.2.1`，模型存放在用户目录 `~/.bili
 
 **边界：**本地转录始终被约束在安全范围内——显式选择、资源受限、Cookie 隔离：
 
-- 原生 B 站字幕始终优先；只有确认无字幕、且你显式传了 `fallback_to_asr: true` 才启动转录。
+- 原生 B 站字幕始终优先；每个选中的 `ai-*` 都会先无条件双读评估，不通过时与无字幕一样构成确认缺失（默认返回简介或 `SUBTITLE_UNAVAILABLE`）；只有在这种确认缺失状态、且你显式传了 `fallback_to_asr: true` 时才启动转录。
+- `force_asr: true` 是显式授权直接转录当前这一 P，与是否存在字幕无关，无需同时开启 `fallback_to_asr`。
 - MCP 调用不会下载或切换模型；模型只通过 `setup` 安装。
 - 一次只运行一个转录任务；单 P 时长上限 2 小时、音频上限 128 MiB、转录超时 30 分钟。
 - 临时音频在成功、失败、超时等所有路径上都会被清理。
@@ -185,7 +195,8 @@ Runtime 固定为 `faster-whisper==1.2.1`，模型存放在用户目录 `~/.bili
 - **收藏夹遍历是调用方驱动的**："全部收藏夹"指当前登录账号创建、且 Bilibili API 当前可见的收藏夹；每次调用最多读取一个 20 条上游页面，Agent 必须持续跟随 `next_cursor`。遍历是实时 best-effort，不是快照。
 - **不跨收藏夹去重**：同一 BVID 出现在多个收藏夹时保留各自的收藏夹上下文。
 - **跳过的条目不补漏**：无法安全规范化的视频条目会计入 `skipped_count`，不会为该页拉取替代条目。
-- **ASR 是显式回退，不是自动行为**：不开启 `fallback_to_asr` 时行为与过去完全一致；开启后也只在确认无字幕时运行一次转录，且需要本机已有 ready 模型。
+- **ASR 是显式回退，不是自动行为**：不开启 `fallback_to_asr` 或 `force_asr` 时行为与过去完全一致；开启后也只在确认无字幕（或显式 `force_asr`）时运行一次转录，且需要本机已有 ready 模型。
+- **AI 字幕与人工字幕可区分**：选中 Bilibili AI 识别字幕（`ai-zh` 等任意 `ai-*` 语言）时 `data_source` 为 `ai_subtitle`；它是 Bilibili 的 AI 转录，可能不准确，不能当作人工校验过的引用。需要纯人工字幕时使用 `exclude_ai_subtitles: true`。
 - **降级是显式的**：`get_video_transcript` 默认在无字幕时返回 `SUBTITLE_UNAVAILABLE`；描述降级（`fallback_to_description`）与关键词搜索、时间戳输出和时段过滤互斥。
 - **无访问绕过**：不会绕过付费、会员、地区、私密、下架或其他 Bilibili 访问限制。
 - **视频搜索和收藏夹发现都需要登录凭证**，不提供匿名降级。

--- a/README_EN.md
+++ b/README_EN.md
@@ -54,7 +54,7 @@ Please help me install the Bilibili MCP server: @xzxzzx/bilibili-mcp.
    npx -y @xzxzzx/bilibili-mcp@latest check
    npx -y @xzxzzx/bilibili-mcp@latest doctor --json
    doctor --json checks local configuration only; it does not replace the live login verification below.
-   setup will ask about installing the optional local ASR model; choosing no is fine.
+   setup will ask about installing the optional local ASR model; choosing no is fine. Automated environments can run setup --non-interactive (credentials come from existing environment variables or the global config file; no prompts, and credential values are never read from stdin/argv); add --asr-model <tiny|base|small> to also install a given model.
 5. Ask me to restart or reconnect the client. When you can't do it for me,
    tell me explicitly to do it myself.
 6. After reconnect, call the MCP tool check_bilibili_credentials.
@@ -144,6 +144,15 @@ text.
 
 This requires a model installed through `setup` and `doctor --json` reporting `asr.status: ready`; otherwise the call returns `ASR_NOT_READY` with setup guidance. Native subtitles always win: a local transcription starts only when subtitles are confirmed unavailable, returns `data_source: "asr"`, and reuses the same timestamps, range filters, keyword search, and moment links. See [Local ASR](#local-asr-optional).
 
+### Distinguishing AI subtitles (ai-*) from human subtitles
+
+Bilibili marks some videos' AI-generated subtitles as `ai-zh`, `ai-en`, `ai-ja`, and other `ai-*` languages. To keep them distinguishable from human subtitles, when any `ai-*` track is selected both `get_video_transcript` and `get_video_info` return `data_source: "ai_subtitle"` (not `"subtitle"`; managed local ASR stays `"asr"`).
+
+- `ai_subtitle` is Bilibili AI transcription; it may be inaccurate and is not equivalent to a human-checked citation.
+- `exclude_ai_subtitles: true` (both tools, default `false`): filters out all Bilibili AI tracks (`ai-zh`, `ai-en`, etc.) before selection and prefers any remaining human subtitle. If only AI tracks remain, the result is treated as definitive absence — `get_video_transcript` may use explicit `fallback_to_asr` / `fallback_to_description`, and `get_video_info` returns the description.
+- `force_asr: true` (transcript only, default `false`): bypasses subtitle metadata and content selection and transcribes the resolved Part with the local ASR, even when valid human subtitles exist. It does not require `fallback_to_asr: true` and wins over `exclude_ai_subtitles`.
+- Every selected `ai-*` track is unconditionally read twice and passes a deterministic integrity assessment before its body is returned: cross-read stability (two reads with different normalized bodies are unusable; applies to every `ai-*` language) and language (ai-zh only: a body with at least 80 Unicode letters and under 10% Han letters is an `ai-zh` mismatch; other `ai-*` languages are not rejected for being non-Chinese). An unusable track invokes the local ASR with `fallback_to_asr: true`, otherwise the existing `fallback_to_description` contract applies; video-info returns the description without caching it. Stable same-language bodies that are semantically off-topic are an accepted limitation, controlled by `force_asr` or `exclude_ai_subtitles`. Human subtitles stay single-read, and a transport, timeout, auth, or parse failure on the second read remains an error.
+
 ## Local ASR (optional)
 
 Some videos ship without any subtitle. Once you install a local ASR model, `get_video_transcript` can run one bounded local transcription of the resolved Part when you explicitly pass `fallback_to_asr`.
@@ -161,6 +170,7 @@ The runtime is pinned to `faster-whisper==1.2.1`. Models live under `~/.bilibili
 **Boundaries:** local transcription stays within safe bounds — opt-in, resource-capped, Cookie-isolated:
 
 - Native Bilibili subtitles always win; transcription starts only on confirmed no-subtitle states with an explicit `fallback_to_asr: true`.
+- `force_asr: true` is explicit authorization to transcribe the resolved Part directly, regardless of subtitle availability and without requiring `fallback_to_asr`.
 - MCP calls never download or switch models; models install only through `setup`.
 - One transcription at a time; per-Part duration capped at 2 hours, audio at 128 MiB, transcription timeout at 30 minutes.
 - Temporary audio is removed on every success, failure, and timeout path.
@@ -191,7 +201,8 @@ Complete parameters, JSON examples, and error semantics: [tool reference](./docs
 - **Favorites traversal is caller-driven:** "every Favorite Folder" means Folders created by the currently logged-in account and currently visible through the Bilibili API. Each call reads at most one 20-row upstream page; the Agent must keep following `next_cursor`. Traversal is live best effort, not a snapshot.
 - **No cross-Folder deduplication:** the same BVID appearing in multiple Folders stays visible in each Folder context.
 - **Skipped entries are not replaced:** entries that cannot be safely normalized count toward `skipped_count`; no replacement entry is fetched for that page.
-- **ASR is an explicit fallback, not automatic:** behavior is unchanged unless you pass `fallback_to_asr`; even then, at most one transcription runs on confirmed no-subtitle states, and only with a ready local model.
+- **ASR is an explicit fallback, not automatic:** every selected `ai-*` track is always double-read and may become unavailable even on a default call (degrading to the description result or `SUBTITLE_UNAVAILABLE`); local transcription runs only on such confirmed no-subtitle states — or on explicit `force_asr` — when you pass `fallback_to_asr` / `force_asr`, at most once per call, and only with a ready local model.
+- **AI subtitles are distinguishable from human subtitles:** when Bilibili's AI-generated track (`ai-zh` or another `ai-*` language) is selected, `data_source` is `ai_subtitle`. It is Bilibili AI transcription, may be inaccurate, and is not equivalent to a human-checked citation. Use `exclude_ai_subtitles: true` when only human subtitles are acceptable.
 - **Downgrades are explicit:** `get_video_transcript` returns `SUBTITLE_UNAVAILABLE` by default when no subtitle exists. Description fallback (`fallback_to_description`) is incompatible with keyword search, timestamp output, and time-range filters.
 - **No access bypass:** the project does not bypass paid, member-only, regional, private, removed, or other Bilibili access restrictions.
 - **Video search and Favorites discovery both require logged-in credentials** and do not fall back to anonymous access.

--- a/docs/agent-memory/active-work.md
+++ b/docs/agent-memory/active-work.md
@@ -1,5 +1,30 @@
 # Active Work
 
+Issue #40 + Roadmap (ROADMAP-2026-08-18-INTEGRITY-SETUP) have a verified,
+uncommitted implementation candidate in isolated branch
+`codex/issue-40-ai-subtitle-integrity`, based on `44ac1e7`. It separates
+every Bilibili `ai-*` track (`ai-zh`, `ai-en`, `ai-ja`, …) as
+`data_source: "ai_subtitle"`, adds default-off `exclude_ai_subtitles` to
+transcript and video-info, adds transcript-only `force_asr`, and
+unconditionally double-reads every selected `ai-*` body with a collision-free
+canonical stability check plus a conservative language check (≥80 Unicode
+letters and <10% Han → unusable) applied to `ai-zh` only — other `ai-*`
+languages are not rejected for being non-Chinese. Title-topic lexical overlap
+is not a rejection gate; a stable same-language semantic mismatch is an
+accepted limitation controlled by `force_asr` / `exclude_ai_subtitles`. An
+unstable body enters the existing ASR path; transport/parser errors remain
+visible.
+`setup --non-interactive` / `--asr-model <tiny|base|small>` is implemented:
+it requires an env/global-config credential source with loadable credentials,
+never prompts, and never reads credential values from stdin/argv. The candidate
+passed the TypeScript build, 41 files / 906 tests, a 189-file package dry run,
+and independent Codex standards/spec/risk reviews. It is not committed,
+pushed, merged, released, or published.
+
+The existing ASR download path already tries up to three bounded audio
+candidates and exposes retryable bilingual `ASR_AUDIO_UNAVAILABLE` guidance,
+so this candidate does not add another retry layer.
+
 Status: `v1.11.4` is published to npm, GitHub Releases, and the Official MCP
 Registry as `io.github.XZXZZX-Ai/bilibili-mcp`. Release commit `2a33520`
 contains the five synchronized version fields, bilingual changelogs, and

--- a/docs/agent-memory/codemap.md
+++ b/docs/agent-memory/codemap.md
@@ -84,7 +84,8 @@ When adding or changing a public MCP tool, inspect both `tool-schemas.ts` and `t
   response validation.
 - `src/bilibili/video-api.ts`: video/subtitle/player API calls and response safety checks.
 - `src/bilibili/navigation.ts`: shared Part/CID resolution for multi-Part videos.
-- `src/bilibili/subtitle.ts`: native subtitle selection plus explicit ASR/description fallback precedence, shared segment formatting, timestamp output, range filtering, keyword/context search, and evidence-link behavior.
+- `src/bilibili/subtitle.ts`: native subtitle selection (human `subtitle` vs Bilibili AI `ai_subtitle` for every `ai-*` language), explicit ASR/description fallback precedence, `exclude_ai_subtitles` filtering with AI-only treated as deterministic absence, `force_asr` bypass, unconditional ai-* integrity assessment (double-read; unusable → `handleDefinitiveSubtitleAbsence` or uncached description), shared segment formatting, timestamp output, range filtering, keyword/context search, and evidence-link behavior.
+- `src/bilibili/subtitle-integrity.ts`: pure-function deterministic integrity module (no IO, no logging of comparison text/tokens): `assessAiSubtitleIntegrity` over canonical cross-read bodies (collision-free `JSON.stringify` of each [from,to,content] tuple), conservative language check limited to `ai-zh` (≥80 Unicode letters, <10% Han); other `ai-*` languages are not rejected for being non-Chinese. Title-topic lexical overlap is not assessed — a stable same-language semantic mismatch is an accepted limitation controlled by `force_asr` / `exclude_ai_subtitles` (PRD v1.1 → v1.2). Frozen PRD checks, not configurable, not exposed over MCP.
 - `src/bilibili/playback.ts`: authenticated first-party playurl request for one
   resolved BVID/CID, 1 MiB JSON and representation/backup/candidate limits,
   strict duration/DASH/audio validation, Bilibili-specific HTTPS CDN

--- a/docs/agent-memory/decisions.md
+++ b/docs/agent-memory/decisions.md
@@ -414,3 +414,65 @@
   `io.github.XZXZZX-Ai/*`.
 - Evidence: the v1.11.2 403 response and the successful v1.11.3 publication and
   exact-match Official Registry API response.
+
+## 2026-08-18
+
+- Decision: Treat Bilibili `lan === "ai-zh"` as the distinct public source
+  `ai_subtitle`; keep human subtitles as `subtitle` and local transcription as
+  `asr`.
+- Reason: Issue #40 is a provenance bug. Source identity is deterministic and
+  should not be inferred from transcript text.
+- Evidence: GitHub Issue #40, shared `isAiSubtitle` classification, MCP schema
+  regressions, and transcript/video-info tests.
+
+- Decision: Validate AI-body stability only when `fallback_to_asr` is explicitly
+  enabled, and provide `force_asr` as the deterministic override. Do not add a
+  title-topic or language heuristic in this fix.
+- Reason: a second read directly detects the reported six-different-bodies
+  failure without adding dependencies or false-positive semantic guesses;
+  stable but wrong text cannot be proven locally with a reliable rule.
+- Evidence: injected inconsistent/stable/transport-failure regressions and the
+  Issue #40 execution handoff.
+
+- Decision: Keep non-TTY `setup` support as a separate credential-input task.
+- Reason: it is not in the subtitle provenance/fallback path and needs its own
+  security and scripting contract.
+- Evidence: Roadmap comparison in the Issue #40 handoff and QA checklist.
+
+- Decision: Assess every selected `ai-zh` track unconditionally, with frozen
+  deterministic integrity checks: collision-free canonical stability and a
+  conservative language check; the checks are not configurable and are not
+  exposed over MCP. Title-topic lexical overlap is not a rejection gate — a
+  stable same-language semantic mismatch is an accepted limitation controlled
+  by the caller via `force_asr` / `exclude_ai_subtitles`.
+- Reason: the Issue #40 fix gated the double-read behind explicit
+  `fallback_to_asr` and deferred semantic heuristics. The
+  ROADMAP-2026-08-18-INTEGRITY-SETUP PRD supersedes that gating: every selected
+  `ai-zh` is read twice and assessed (stability via canonical `JSON.stringify`
+  [from,to,content] tuple comparison; language via >=80 Unicode letters with
+  <10% Han). The initial `Intl.Segmenter` title-topic lexical-overlap gate was
+  removed after independent review: it false-accepted unrelated bodies
+  (cooking video vs Python tutorial) and false-rejected valid AI discussion.
+  A same-language body is accepted even when it does not discuss the title
+  topic. Insufficient signals pass as inconclusive, and second-read
+  transport/timeout/auth/parse failures propagate as errors, never as integrity
+  failures or ASR triggers. Unusable bodies are never returned, logged, or
+  cached (video-info returns an uncached description; transcript follows the
+  existing absence path with ASR only when `fallback_to_asr` authorizes it).
+- Evidence: `docs/subtitle-integrity-and-scriptable-setup-prd.md` v1.1,
+  `src/bilibili/subtitle-integrity.ts`, and the transcript/video-info integrity
+  regressions (stability, canonical-collision, language, same-language
+  acceptance).
+
+- Decision: Add credential-safe `setup --non-interactive` with optional
+  `--asr-model <tiny|base|small>` for automated environments.
+- Reason: automation needs a deterministic setup path without a TTY, while
+  credential values must never enter argv, stdin, prompts, or logs.
+  Non-interactive mode therefore loads only from environment variables or the
+  global config file, completes credential-only when no model is given, runs
+  ASR exactly once with a model, and exits 1 with value-free guidance when
+  credentials are unloadable or a model is passed without
+  `--non-interactive`. The interactive path is unchanged.
+- Evidence: `src/cli.ts` `SetupCredentialsOptions`, focused CLI tests, and
+  post-build child smoke with piped/closed stdin and synthetic environment
+  credentials.

--- a/docs/agent-memory/handoff-log.md
+++ b/docs/agent-memory/handoff-log.md
@@ -475,3 +475,57 @@
 - Review: complete-candidate release, standards/security, and specification
   reviewers returned PASS with no remaining P0-P3. The release-verifier's one
   initial P2 corrected encoding-gate wording before final acceptance.
+
+## 2026-08-18 Issue #40 AI Subtitle Integrity
+
+- Owner: Codex scoped and reviewed; one Paseo-managed DeepSeek V4 Flash agent
+  implemented at thinking level `max` in an isolated worktree.
+- Objective: distinguish Bilibili AI subtitles from human subtitles and align
+  the directly related Roadmap fallback defects without changing defaults.
+- Contract: `ai-zh` becomes `ai_subtitle`; add default-off
+  `exclude_ai_subtitles` and transcript-only `force_asr`; double-read selected
+  AI bodies only with explicit `fallback_to_asr`; preserve transport errors.
+- Result: implementation, tests, bilingual docs, codemap, handoff, report, and
+  QA checklist completed. Codex independently passed build, 41 files / 885
+  tests, pack dry run, diff checks, and a post-review 76-test subtitle slice.
+- Boundary: title/language semantic heuristics and non-TTY setup remain separate;
+  no commit, push, PR, Issue mutation, release, or publication occurred.
+
+## 2026-08-18 Roadmap Subtitle Integrity + Scriptable Setup
+
+- Owner: Codex scoped and reviewed; one Paseo-managed Claude Code agent
+  implemented in the same isolated worktree with vertical TDD.
+- Objective: unconditional integrity assessment for selected Bilibili AI
+  subtitles and credential-safe non-interactive setup.
+- Contract: `src/bilibili/subtitle-integrity.ts` pure-function module with
+  frozen PRD checks (collision-free canonical stability for every selected
+  `ai-*`; conservative language check limited to `ai-zh`; title-topic lexical
+  overlap removed as a rejection gate by Codex blocker review — stable
+  same-language semantic mismatch is an accepted limitation controlled by
+  `force_asr`/`exclude_ai_subtitles`; inconclusive passes; second-read errors
+  propagate); every Bilibili `ai-*` track classified as AI for `data_source`
+  and `exclude_ai_subtitles` (repair pass, PRD v1.2); unconditional double-read
+  for selected `ai-*` in transcript and video-info; `setupCredentials` options
+  object; Commander `--non-interactive` + `--asr-model <tiny|base|small>`;
+  bilingual docs/CHANGELOG/codemap/QA sync.
+- Result: 4 vertical slices red to green; blocker pass added 3 red tests
+  (source-none rejection exit 1, canonical-collision detection, stable
+  same-language acceptance, non-canonical-field stability) then green;
+  ai-* classification repair pass added 4 red tests (stable `ai-en` →
+  `ai_subtitle` with two reads; transcript/video-info `exclude_ai_subtitles`
+  filters an AI-only `ai-zh`+`ai-en` set to absence/description; human
+  single-read lock) then green; focused 7-file suite 323/323, full suite
+  41 files / 906 tests, build green,
+  pack dry-run 189 entries clean,
+  diff check clean, secret scan zero real credentials, UTF-8 clean (one
+  pre-existing HEAD U+FFFD not introduced). Report:
+  `docs/agent-memory/handoffs/2026-08-18-roadmap-subtitle-integrity-setup-claude-report.md`.
+- Boundary: no real model installed; live classification/exclusion/double-read
+  verified by a post-build authenticated read-only run on `BV15kyBB5Eg8`
+  (default transcript → `ai_subtitle`/`ai-zh` with a non-empty body;
+  `exclude_ai_subtitles=true` → `NoSubtitleError`; default video-info →
+  `ai_subtitle` with `subtitle_text`; exclude=true → description without
+  `subtitle_text`); live corrupt-body rejection and ASR fallback remain
+  unverified (`BV1ybuQ62EfK` exposes no target subtitle; no real ASR/model run
+  authorized); no commit/push/PR/Issue/release; corrupt-body/ASR live
+  verification remains a named follow-up for Codex.

--- a/docs/agent-memory/handoffs/2026-08-18-issue-40-ai-subtitle-integrity-claude-report.md
+++ b/docs/agent-memory/handoffs/2026-08-18-issue-40-ai-subtitle-integrity-claude-report.md
@@ -1,0 +1,92 @@
+# Claude To Codex Report: Issue #40 AI Subtitle Integrity
+
+## Summary
+
+Issue #40 (ai-zh 与人工字幕混标) 已按冻结契约实现完毕:ai-zh 在两个工具上独立分类为 `ai_subtitle`;新增 `exclude_ai_subtitles`(两工具,默认 false)与 `force_asr`(仅 transcript,默认 false);显式 `fallback_to_asr` 时对 ai-zh 做跨读取稳定性检查,不一致走确定性缺失路径调 ASR。实现全程垂直 TDD(每切片先红后绿),13 项验收标准均有确定性注入测试。三方审查(risk-reviewer、code-review 两轴)均无阻塞发现;唯一流程缺口(Claude 报告)由本文件闭合。未做任何 commit/push/PR/release,未变更 GitHub。
+
+## Files Changed
+
+源码(4):
+- `src/bilibili/subtitle.ts` — `isAiSubtitle`(lan === "ai-zh")、`canonicalSubtitleBody`(仅比较用)、`SubtitleData.data_source` 加 `ai_subtitle`;`getVideoTranscriptData` 追加 `excludeAiSubtitles`、`forceAsr`(fallbackToAsr 之后、signal 之前);`getVideoInfoWithSubtitle` 追加 `excludeAiSubtitles`(第 4 参);force_asr 早退到 `handleDefinitiveSubtitleAbsence(reason, true)`;exclude 过滤 + AI-only 确定性缺失(不走登录验证路径);稳定性双读;缓存键含 exclude 标志;AI-only 结果不缓存。
+- `src/bilibili/types.ts` — `VideoSummary.data_source` / `VideoTranscriptData.data_source` 联合类型扩展。
+- `src/server/tool-schemas.ts` — 两个新布尔输入(描述文本声明默认 false,沿用无 JSON `default` 字段的原有风格);transcript outputSchema 枚举 `[subtitle, ai_subtitle, description, asr]`。
+- `src/server/tool-handlers.ts` — 两个工具的读取、类型校验(`VALIDATION_ERROR`)与参数转发;transcript 11 参元组与签名逐位一致。
+
+测试(3):`tests/bilibili-transcript.test.ts`(新增 19 测试 / 5 块)、`tests/server-tools.test.ts`(schema 断言 + 3 新测试)、`tests/server-handler-sanitization.test.ts`(转发 + it.each 非布尔拒绝,3 新测试)。
+
+文档(6):`README.md` / `README_EN.md`、`docs/tool-reference.md` / `docs/tool-reference.en.md`、`CHANGELOG.md` / `CHANGELOG_EN.md`([Unreleased] 4 条目)。
+
+Harness 文件(3):`docs/qa/2026-08-18-issue-40-ai-subtitle-integrity.md`(新建)、`docs/agent-memory/codemap.md`(subtitle.ts 条目更新)、本报告。
+
+未改:`package.json` / lockfile(零新依赖)、`src/utils/validation.ts`(复用既有 `validateBoolean` 模式)、`ROADMAP.md`(Codex 所有)、`setup` TTY 路径。
+
+## Commands Run
+
+实现前红测试(每切片一次,均已先红后绿):
+
+```bash
+npx vitest run tests/bilibili-transcript.test.ts
+# 切片A红灯: 3 failed — expected 'subtitle' to be 'ai_subtitle' (ai-zh 分类)
+# 切片B红灯: AI-only+exclude 未触发缺失路径(未调 ASR、未返回 description)
+# 切片B红灯: 缓存键不含 exclude(exclude=true/false 串缓存)
+# 切片C红灯: expected 'ai_subtitle' to be 'asr'(force_asr 未绕过)
+# 切片D红灯: 双读不一致未调 ASR;第二次读取异常未传播
+```
+
+(切片 B–D 的精确失败摘要在此前上下文压缩前已捕获;切片 C 后还修复过一次 signal 参数错位——AbortSignal 曾落到第 11 参位置被误当作 force_asr,修复后重跑绿。)
+
+实现后验证矩阵:
+
+```bash
+npx vitest run tests/bilibili-transcript.test.ts tests/server-tools.test.ts tests/server-handler-sanitization.test.ts tests/server-error-next-steps.test.ts   # 4 文件 / 194 通过
+npx vitest run tests/asr-transcription.test.ts tests/bilibili-playback.test.ts                                                                            # 2 文件 / 44 通过
+npm test                                                                                                                                                # 41 文件 / 885 通过(基线 862 + 新增 23)
+npm run build                                                                                                                                           # tsc 通过
+npm pack --dry-run --json --ignore-scripts                                                                                                              # 185 文件,dist 齐全
+git diff --check                                                                                                                                        # 无输出
+```
+
+内置 stdio smoke(临时脚本,已删):`dist/index.js` 上 `tools/list` 证明两个新布尔输入(描述声明默认 false)、transcript outputSchema 枚举含 `ai_subtitle`、工具数/顺序不变(10);`tools/call` 传 `force_asr: "yes"` → `VALIDATION_ERROR`,未打印任何字幕正文或凭据。
+
+## Results
+
+- 完整测试 885/885 通过;构建通过;pack 内容 185 文件(双语文档 + dist,无 tests/src 泄漏)。
+- 修复过一处 tsc 错误:本地 `SubtitleData.data_source` 缺 `ai_subtitle`(TS2322)——vitest(esbuild)不做类型检查,首跑 `npm run build` 才暴露;修复后全绿。此前 smoke 套件因 build 失败而红,属同一根因。
+- 临时目录:`bilibili-mcp-asr-*` 验证前后计数不变(2→2,均为历史残留,本次无新增)。
+- 三方审查:risk-reviewer **pass**(0 bug;4 条 low:双读条件中 `!forceAsr` 不可达但符合契约字面、`?? []` 防御不可达、空 body 第二次读取→ASR 为契约允许的显式决策、报告文件缺失);code-review Spec 轴 **通过**(10/10 验收标准,无 scope creep);Standards 轴 **无硬违规**(4 条判断性:AI-only description 块与既有 3 处重复、位置参数增长与 2026-07-20 的 options-object 方向相左——但契约明确指定 append、`typeof` 校验级联 5 处为既有模式延续、`handleDefinitiveSubtitleAbsence` 名称被 force_asr 拉伸)。
+- secret-scanning:0 凭据值;4 处字段名引用均为原有文档行(非本次变更引入)。risk-reviewer 的凭据模式扫描同样零命中。
+
+## Diff Notes
+
+- 精确分类:`lan === "ai-zh"` → `ai_subtitle`(transcript 与 video-info 共用 `isAiSubtitle` 单点);人工字幕保持 `subtitle`;本地 ASR 保持 `asr`;description 保持 `description`。
+- 选项语义:`exclude_ai_subtitles` 过滤后人工优先;AI-only 时两工具都走确定性缺失(transcript 按既有 fallback 链,可 ASR/description;video-info 返回 description 且不缓存),且不触发登录验证路径(与"空字幕"路径刻意分离)。`force_asr` 早退、绕过全部字幕选择(含有效人工字幕)、不依赖 `fallback_to_asr`、优先于 exclude。稳定性双读仅当 ai-zh 选中 && `fallback_to_asr` 显式 true && 非 force_asr;两次正文规范化比较不同 → 确定性缺失路径调 ASR;一致 → 保持 `ai_subtitle` 且不调 ASR;任一次传输/超时/认证/解析失败仍为错误,绝不成为 ASR 门槛。
+- 兼容性:位置参数一律追加;transcript 签名 `(…, fallbackToAsr, excludeAiSubtitles, forceAsr, signal)` 与 handler 元组逐位一致;video-info 第 4 参。唯一破坏面是枚举扩展 `subtitle` → `ai_subtitle`,与 schema/handler/文档原子发布。
+
+## Risks Or Skipped Checks
+
+- 未解决:真实 Bilibili 现场的不稳定 ai-zh(六种互异正文)无法复现——按契约以注入测试为验收权威,已在 QA 文件记录;搜索模式 + 不稳定 ai-zh(对 ASR 输出做 search)无独立测试,共享已测的 `buildSegmentResult` 机制,不阻塞。
+- 未跑:`npm audit`(零新依赖,pack 内容与基线一致)。
+- 决策点(交回 Codex):Standards 轴的两条判断性发现——(a) AI-only description 返回块与既有 3 处重复,可抽共享 helper 或维持现状;(b) 位置参数追加与 2026-07-20 handoff 的"options-object"方向相左,本次按冻结契约执行 append,若 Roadmap 想收敛可做后续重构。
+- 延期项(按契约):非 TTY `setup` 脚本化(独立后续项,与凭据输入安全相关,未触碰);Roadmap 最终对齐由 Codex 完成(`ROADMAP.md` 未改)。
+
+## Harness Artifacts
+
+- Task ticket: used —— GitHub Issue #40 为 ticket,handoff 为冻结执行契约(仓库规则要求 MCP 工具变更使用 ticket)。
+- Research note: not required —— 本地源码、注入测试与交付契约为权威,无外部行为研究。
+- QA checklist: created —— `docs/qa/2026-08-18-issue-40-ai-subtitle-integrity.md`(13 项行为检查全绿、安全/临时目录/凭据扫描记录、Automated Baseline 含 build 修复注记)。
+- Codemap: updated —— `src/bilibili/subtitle.ts` 条目补充 ai_subtitle 分类、exclude/force 开关与稳定性检查;MCP Tool Surface 无结构变化。
+- Harness security: reviewed —— 变更面(handler 验证、缓存键、稳定性比较)不触及信任边界;稳定性比较仅用规范化表示不落日志;无新凭据路径;`docs/agent-memory/harness-security.md` 规则未受影响。
+- Harness eval: deferred —— 非 Roadmap 阶段/发布节点,harness 本身无变化。
+
+## Decision Points
+
+1. `!forceAsr` 在双读条件中不可达(force_asr 早退):保留作为契约字面守卫,无行为影响;删除与否由 Codex 定夺。
+2. 空 body 的第二次读取按契约视为"不同正文"→ ASR;与传输失败(抛错)严格区分,已是显式决策。
+3. AI-only description 块重复与位置参数风格收敛:见 Risks 决策点 (a)/(b),均建议作为独立后续,不影响本变更验收。
+
+## Suggested Codex Review Focus
+
+- 双读条件(契约 §5 的字面符合性)与 `handleDefinitiveSubtitleAbsence(reason, runAsr)` 复用是否如契约预期。
+- 缓存键 `generateKey('video', bvid, preferredLang, page, excludeAiSubtitles ?? false)` 与 AI-only 不缓存的行为。
+- 枚举扩展的原子发布与双语文档措辞。
+- 若认可后续收敛,评估 (a) description 块共享 helper、(b) transcript 参数 options-object 化的独立票。

--- a/docs/agent-memory/handoffs/2026-08-18-issue-40-ai-subtitle-integrity-codex-to-claude.md
+++ b/docs/agent-memory/handoffs/2026-08-18-issue-40-ai-subtitle-integrity-codex-to-claude.md
@@ -1,0 +1,189 @@
+# Codex To Claude Handoff: Issue #40 AI Subtitle Integrity
+
+## Update Goal
+
+Implement GitHub Issue #40 against clean `origin/master` `44ac1e717001aed59c4a3b475cf82f074d11e567`, and close the directly related Roadmap gap where a structurally valid but unstable `ai-zh` subtitle prevents explicit ASR fallback.
+
+GitHub Issue #40 is the task ticket. Do not create a duplicate local ticket.
+
+Expected report: `docs/agent-memory/handoffs/2026-08-18-issue-40-ai-subtitle-integrity-claude-report.md`.
+
+## Current Judgment
+
+- `ai-zh` is a Bilibili-generated AI subtitle, not the managed local ASR result and not a human subtitle. Its public source value must be `ai_subtitle`; reserve `asr` for `transcribeVideoPart()`.
+- The source identity is currently lost because both transcript and video-info paths return literal `subtitle` after selecting any subtitle row.
+- `fallback_to_asr` currently runs only for an empty subtitle list, no selected subtitle, or an empty body. A non-empty but inconsistent `ai-zh` body always short-circuits ASR.
+- The observed Roadmap defect is six mutually different bodies for one `ai-zh` track. A deterministic cross-read stability check can catch that exact class when the caller explicitly enables ASR fallback. Do not invent semantic title matching, call an LLM, or add a dependency.
+- `ASR_AUDIO_UNAVAILABLE` already tries up to three audio candidates and returns retryable bilingual next steps. Verify this with existing tests; do not add another retry layer without a red regression proving a gap.
+- Non-TTY `setup` scripting is unrelated to Issue #40 and changes credential-input security. Leave it unchanged and report it as a separate follow-up.
+- A live published-package repro on 2026-08-18 timed out while fetching subtitle content, so deterministic injected tests are the acceptance authority. Do not convert a transport timeout into an ASR gate.
+
+## Recommended Approach
+
+Keep the existing modules and positional compatibility. Make the smallest change at the shared subtitle-selection/result seam:
+
+1. Centralize the `ai-zh` classification in one small helper used by transcript and video-info flows.
+2. Add `ai_subtitle` to the relevant public `data_source` unions and the transcript output schema.
+3. Add optional boolean `exclude_ai_subtitles` to `get_video_transcript` and `get_video_info`, default `false`.
+   - Filter AI rows before selection.
+   - Prefer a remaining human subtitle when present.
+   - If only AI rows remain, use the existing definitive-absence behavior: transcript may use explicit ASR/description fallback; video-info returns description.
+   - Include the option in any cache key whose output it changes.
+4. Add optional boolean `force_asr` only to `get_video_transcript`, default `false`.
+   - `true` is itself explicit authorization to run the already-installed local ASR and does not require `fallback_to_asr: true`.
+   - It bypasses subtitle metadata/content selection, including valid human subtitles, but still resolves the selected Part and uses all existing ASR readiness, duration, audio, cancellation, limit, cleanup, error, range, timestamp, search, and source-link behavior.
+   - `force_asr` wins over `exclude_ai_subtitles`; do not create a validation conflict for callers that send both.
+5. When the selected source is `ai-zh` and `fallback_to_asr: true` (but not `force_asr`), read the same AI subtitle twice through the existing subtitle-content seam and compare a canonical representation of segment timing and text.
+   - Stable bodies return `data_source: "ai_subtitle"` and remain native-first.
+   - Two structurally valid but different bodies are treated as unusable and enter the existing definitive-absence path, which invokes ASR because fallback was explicitly enabled.
+   - A transport, timeout, auth, parser, or HTTP failure on either read remains an error; it must not silently become an ASR gate.
+   - Do not log subtitle text, signed URLs, body hashes, credentials, or private paths. A bounded warning may include BVID, page, and source category only.
+6. Update bilingual public documentation and Unreleased changelogs. Clearly state that `ai_subtitle` is Bilibili AI transcription, may be inaccurate, and is not equivalent to a human-checked citation.
+
+If a simpler implementation satisfies every acceptance criterion through the existing public seams, prefer it. Do not add a new module, dependency, class, factory, interface, or config surface unless an actual second implementation requires it.
+
+## Files To Inspect
+
+- GitHub Issue #40 body and comments via `gh issue view 40 --comments`
+- `CONTEXT.md`
+- `docs/adr/0001-navigable-transcript-interface.md`
+- `src/bilibili/subtitle.ts`
+- `src/bilibili/video-api.ts`
+- `src/bilibili/types.ts`
+- `src/asr/transcription.ts`
+- `src/bilibili/playback.ts`
+- `src/server/tool-schemas.ts`
+- `src/server/tool-handlers.ts`
+- `src/utils/validation.ts`
+- `src/utils/error-guidance.ts`
+- the corresponding tests, README files, tool references, changelogs, codemap, and QA conventions
+
+## Expected Files To Edit
+
+Keep the set minimal, but expect:
+
+- `src/bilibili/subtitle.ts`
+- `src/bilibili/types.ts`
+- `src/server/tool-schemas.ts`
+- `src/server/tool-handlers.ts`
+- relevant transcript/server/schema tests
+- `README.md`, `README_EN.md`
+- `docs/tool-reference.md`, `docs/tool-reference.en.md`
+- `CHANGELOG.md`, `CHANGELOG_EN.md`
+- `docs/qa/2026-08-18-issue-40-ai-subtitle-integrity.md`
+- `docs/agent-memory/codemap.md` only if its navigation facts materially change
+- the expected Claude report
+
+Do not edit the primary worktree's untracked `ROADMAP.md`; Codex owns the final Roadmap reconciliation after verification.
+
+## Required Capabilities
+
+Use the native Claude-side skills and project agents that exist on this machine:
+
+- `/implement` as the top-level bounded execution workflow. Repository rules disable its default commit step.
+- `/diagnosing-bugs` to establish deterministic red-capable tests before changing implementation.
+- `/codebase-design` to keep classification and fallback at the shared subtitle seam without broad refactoring.
+- `/tdd` and `vitest` for vertical red-green slices at the pre-agreed public seams below.
+- `/code-review` after implementation, with Issue #40 plus this handoff as the spec source and `44ac1e7` as the fixed point.
+- `test-baseline-builder` for changed tests.
+- `risk-reviewer` after the stable implementation because this affects MCP tools, ASR fallback, shared Bilibili behavior, caching, and untrusted remote text.
+- `secret-scanning` for the changed diff and documentation. Never print matched values.
+
+If a required subagent stalls, record that fact and complete the same bounded check at the top level; do not leave the Paseo task running indefinitely and do not spawn an autonomous team.
+
+Pre-agreed test seams:
+
+- MCP `tools/list` schema and `tools/call` handler behavior.
+- Public `getVideoTranscriptData()` results and errors with only Bilibili/local-process boundaries injected.
+- Public `getVideoInfoWithSubtitle()` results and cache behavior.
+- Existing `transcribeVideoPart()` interface; do not expose private helpers just for tests.
+
+## Things To Avoid
+
+- No title/topic semantic heuristic, LLM call, fuzzy classifier, language library, or extra dependency.
+- No broad ASR rewrite, model install/switch change, audio host relaxation, temp-file weakening, or background service.
+- No automatic ASR unless `fallback_to_asr` or `force_asr` is explicitly true.
+- No conversion of network/auth/parser failures into no-subtitle/ASR fallback.
+- No Cookie values, subtitle bodies, signed playback URLs, full environment objects, local model paths, or private temp paths in logs/tests/reports.
+- No SDK migration, new MCP tool, tool-order change, package version bump, dependency update, generated `dist/` edits, Smithery work, README redesign, or unrelated cleanup.
+- No modification or promotion of `pending-learning-proposals.md`.
+- No commit, push, PR, issue close/comment/edit, tag, release, or publication.
+
+## Claude Code Execution Steps
+
+1. Confirm clean branch/worktree fingerprint and read Issue #40 plus the listed local contracts.
+2. Record baseline test count. If dependencies are absent, run `npm ci` before the test loop.
+3. Use `/diagnosing-bugs` and TDD to create the first minimal failing tests. The report must include the exact red commands and failure summaries before implementation.
+4. Work in vertical slices:
+   - `ai_subtitle` classification for transcript and video-info;
+   - `exclude_ai_subtitles` selection/absence/cache semantics;
+   - `force_asr` bypass semantics;
+   - unstable `ai-zh` + explicit fallback invokes ASR while stable AI remains native;
+   - MCP schema, handler, output schema, and bilingual docs.
+5. Run focused tests after each slice. Do not refactor unrelated code during red-green.
+6. Run the final verification matrix and invoke required test/risk review.
+7. Write the requested Claude report from final stable command output. Do not claim live semantic correctness from mocked tests; distinguish deterministic coverage from live Bilibili evidence.
+
+## Acceptance Criteria
+
+1. Human subtitles still return `data_source: "subtitle"`.
+2. Selected Bilibili `ai-zh` returns `data_source: "ai_subtitle"` in both transcript and video-info public results.
+3. Managed local ASR remains `data_source: "asr"`; description remains `description`.
+4. Default input behavior remains native-first and does not invoke ASR automatically.
+5. `exclude_ai_subtitles: true` is type-checked and published on both tools, prefers an available human subtitle, and treats AI-only as definitive absence without cache collision.
+6. `force_asr: true` is type-checked and published on transcript, bypasses both human and AI subtitle content, works without also setting `fallback_to_asr`, and preserves existing ASR result/error/search/range/timestamp behavior.
+7. With `fallback_to_asr: true`, two different well-formed reads of the same selected `ai-zh` body invoke ASR; two identical reads return stable `ai_subtitle` and do not invoke ASR.
+8. Network, auth, timeout, HTTP, and parse failures remain visible and never become silent ASR fallback.
+9. Transcript structured-output enum and text payload stay mutually consistent; the ten-tool count/order and legacy text compatibility remain unchanged.
+10. Bilingual docs warn that `ai_subtitle` is Bilibili AI transcription and may not be citation-accurate, document both new inputs and exact defaults, and do not claim title-semantic validation.
+11. Existing ASR audio-candidate retry and `ASR_AUDIO_UNAVAILABLE` recovery guidance remain covered. Add code only if a red public-seam regression proves the current behavior insufficient.
+12. `setup` TTY behavior is unchanged and reported as an unrelated follow-up.
+13. No secrets or remote text enter logs/reports; no dependency/version/tool-count change; no temp residue.
+
+## Verification Commands
+
+At minimum:
+
+```powershell
+npx vitest run tests/bilibili-transcript.test.ts tests/server-tools.test.ts tests/server-handler-sanitization.test.ts tests/server-error-next-steps.test.ts
+npx vitest run tests/asr-transcription.test.ts tests/bilibili-playback.test.ts
+npm test
+npm run build
+npm pack --dry-run --json --ignore-scripts
+git diff --check
+git status --short
+```
+
+Also run a built stdio `tools/list` / `tools/call` smoke proving the two new boolean inputs and `ai_subtitle` output schema without printing transcript bodies or credentials. Check before/after counts for `bilibili-mcp-asr-*` direct children of the OS temp root if ASR filesystem tests run.
+
+Use `secret-scanning` on the changed diff/package surface and report only classifications/counts, never values.
+
+## Risks And Rollback Points
+
+- Public enum expansion can break consumers that assumed three values; documentation and output schema must change atomically.
+- Extra AI-body reads can increase latency. Restrict stability checking to selected `ai-zh` when `fallback_to_asr` is explicitly enabled; do not duplicate human-subtitle fetches.
+- Cache keys must include output-affecting options.
+- Cross-read mismatch proves instability, not semantic wrongness. Do not overclaim broader content validation.
+- Rollback is the scoped diff from fixed point `44ac1e7`; no Git delivery is authorized.
+
+## Stop And Report If
+
+- The implementation requires a new dependency, model, service, arbitrary subtitle classifier, credential transport change, or relaxed network/filesystem security.
+- Existing public behavior makes `force_asr` semantics materially ambiguous beyond the rules above.
+- A test can reproduce only through real credentials or by persisting real subtitle content.
+- The latest Issue #40 changed materially after this handoff.
+- The stable worktree contains unrelated edits or the fixed point changed.
+
+## Expected Claude Report
+
+Use the repository template and include:
+
+- red tests/commands before implementation;
+- files changed;
+- focused/full/build/pack/stdio results from the final tree;
+- exact source classification and option semantics;
+- Roadmap overlap addressed versus unrelated/deferred items;
+- unresolved live-network or semantic-validation limits;
+- secret/temp/package findings without values;
+- subagents/skills actually invoked and their results;
+- `Harness Artifacts` covering Issue #40 ticket, research note, QA checklist, codemap, harness-security, and harness-eval.

--- a/docs/agent-memory/handoffs/2026-08-18-roadmap-subtitle-integrity-setup-claude-report.md
+++ b/docs/agent-memory/handoffs/2026-08-18-roadmap-subtitle-integrity-setup-claude-report.md
@@ -1,0 +1,293 @@
+# Claude To Codex Report: Roadmap Subtitle Integrity + Scriptable Setup (Blocker Resolution)
+
+## Summary
+
+Resolved all 12 Codex blockers for the uncommitted Roadmap implementation in
+the isolated worktree `C:/Users/ZX/.paseo/worktrees/28eefzkq/issue-40-ai-subtitle-integrity`
+(branch `codex/issue-40-ai-subtitle-integrity`, base `44ac1e7`). No commit,
+push, PR, Issue mutation, release, model download, or primary-worktree edit
+occurred. The 12 blockers were resolved with the minimum safe diff, using
+focused red-before-green tests where behavior changed. A follow-up Codex
+acceptance pass found four same-scope misses, all repaired in the same
+worktree: (1) `canonicalSubtitleBody` now serializes the exact tuple
+`JSON.stringify([seg.from, seg.to, seg.content ?? ""])` — segment `location`
+and object key order no longer destabilize a stable body (new red→green
+regression); (2) `AiSubtitleIntegrityVerdict` is now an internal type;
+(3) the unusable-ai video-info branch now uses `descriptionFallback()` — all
+five description blocks share the helper; (4) `fallback_to_description` /
+`fallback_to_asr` validation now goes through `validateBoolean` on the raw
+args (the derived `|| false` variables had made the earlier helper calls
+no-ops), and the manual typeof blocks are deleted — falsy invalid raw inputs
+remain rejected by the shared helper. The 12 blockers were resolved with the
+minimum safe diff, using focused red-before-green tests where behavior
+changed:
+
+- **B1 (title-topic gate removed):** `assessAiSubtitleIntegrity` now returns
+  `{ usable: true }` for any stable same-language body; title lexical overlap
+  is no longer a rejection signal. Stable same-language semantic mismatch is
+  documented as an accepted limitation controlled by `force_asr` /
+  `exclude_ai_subtitles`. Red test (topic-rejection replaced by acceptance)
+  → green. Docs/QA/memory/PRD updated.
+- **B2 (canonicalization):** `canonicalSubtitleBody` serializes each
+  `[from,to,content]` tuple with `JSON.stringify` and joins with `\n` —
+  collision-free for the reported case (single segment content `a\n1|2|b` vs
+  two segments `a`/`b` at `[1,2]`). New regression test added (red → green).
+  Helpers/types stay internal (nothing external uses them).
+- **B3 (validateBoolean):** the three duplicate `typeof` checks in
+  `src/server/tool-handlers.ts` now call `validateBoolean` from
+  `src/utils/validation.ts`.
+- **B4 (non-interactive credential gate):** non-interactive setup now requires
+  `getCredentialSource()` ∈ {env, global_config} AND `getCredentials() !==
+  null`; in-memory `source === "none"` is rejected with exit 1 and value-free
+  field-name guidance. Tests added with `stdin.isTTY = false` and a
+  source-none case (red → green).
+- **B5 (description fallback dedup):** five duplicate video-info description
+  object literals collapsed into one local `descriptionFallback()` helper in
+  `getVideoInfoWithSubtitle`, preserving each branch's `logger.debug` + return.
+- **B6 (README truthfulness):** README/README_EN integrity + ASR boundary
+  bullets now state that every selected `ai-zh` is always double-read and may
+  become unavailable (description or `SUBTITLE_UNAVAILABLE`) even on a default
+  call, and that ASR runs only on confirmed absence when `fallback_to_asr` /
+  `force_asr` authorizes it.
+- **B7 (argv wording):** every "never reads stdin/argv" / "不读 stdin/argv"
+  claim across README x2, CHANGELOG x2, client-setup x2, tool-reference x2,
+  QA, and project facts now reads "never reads **credential values** from
+  stdin/argv / 绝不从 stdin/argv 读取凭据值".
+- **B8 (QA live facts):** QA checklist corrected to state that a valid
+  logged-in global credential existed on this machine (live calls
+  authenticated); no "no Cookie" claim remains; unsupported per-file test
+  decomposition removed (focused suite recorded as 319/319). Post-build live
+  evidence later verified real-body classification/exclusion/double-read on
+  `BV15kyBB5Eg8`; corrupt-body rejection and ASR fallback remain unverified
+  (`BV1ybuQ62EfK` exposes no target subtitle; no real ASR/model run
+  authorized).
+- **B9 (active-work):** `docs/agent-memory/active-work.md` rewritten from the
+  stale 885/185/conditional/future state to the current unconditional
+  double-read, accepted-limitation, non-interactive-setup, 902/189 state.
+- **B10 (report + handoff-log link):** this report created; the
+  `handoff-log.md` Roadmap entry already carries the report path and was
+  updated with final numbers.
+- **B11 (truthful docs/memory only):** decisions.md, project-facts.md,
+  codemap.md, task ticket (amendment note), CHANGELOG x2, PRD updated; dated
+  historical records (old verification-log/QA/report entries) left untouched.
+- **B12 (verification matrix):** see Results below.
+
+## AI Classification Repair (ai-zh → ai-*)
+
+A follow-up acceptance pass in the same approved Issue #40 scope found a
+current-upstream root-cause gap. Live authenticated read-only evidence: public
+video `BV15kyBB5Eg8` exposes subtitle languages `[ai-zh, ai-en, ai-ja, ai-es,
+ai-ar, ai-pt]`. The ai-zh-only classifier filtered only `ai-zh` under
+`exclude_ai_subtitles`, silently selected `ai-en` (priority matching
+`s.lan.includes(lang)`), and returned `data_source: "subtitle"` — violating the
+AI-vs-human distinction and the general `exclude_ai_subtitles` name. No
+subtitle text or credential values were recorded.
+
+Repair (TDD red → green, four new public-seam regressions):
+
+- `isAiSubtitle` — the single shared classification driving `data_source`,
+  `exclude_ai_subtitles` filtering, and the double-read gate — now matches
+  every `ai-*` language (`lan.startsWith("ai-")`).
+- `assessAiSubtitleIntegrity` gains a `trackLanguage` argument: the
+  collision-free double-read stability check applies to every selected `ai-*`;
+  the conservative Han-ratio language rejection applies to `ai-zh` only —
+  valid `ai-en`/`ai-ja` bodies are not rejected for being non-Chinese.
+- Schema descriptions, bilingual docs, changelogs, PRD v1.2, QA, codemap, and
+  memory updated from ai-zh-only to ai-* classification (ai-zh-specific
+  language validation retained).
+
+## Files Changed
+
+Source (5):
+
+- `src/bilibili/subtitle-integrity.ts` — topic gate removed; exact-tuple
+  canonicalization `JSON.stringify([from,to,content ?? ""])` (location/key
+  order invariant); language check unchanged; `AiSubtitleIntegrityVerdict`
+  internal.
+- `src/bilibili/subtitle.ts` — both `assessAiSubtitleIntegrity` call sites
+  drop the title argument; local `descriptionFallback()` helper — all five
+  description blocks (empty list, exclude-filtered, no best subtitle, empty
+  body, unusable ai-zh) share it.
+- `src/cli.ts` — non-interactive branch requires source env/global_config +
+  loadable credentials; docstring clarifies no credential values from
+  stdin/argv.
+- `src/server/tool-handlers.ts` — `validateBoolean` reuse on raw args for
+  `fallback_to_description` / `fallback_to_asr` (plus `exclude_ai_subtitles` /
+  `force_asr`); both manual typeof blocks deleted.
+- `src/bilibili/types.ts` — unchanged this pass (previously ai_subtitle
+  classification).
+- `src/bilibili/subtitle.ts`, `src/bilibili/subtitle-integrity.ts`,
+  `src/server/tool-schemas.ts` — repair pass (see AI Classification Repair
+  section): `isAiSubtitle` widened to every `ai-*`; integrity assessment
+  takes `trackLanguage` with the language check gated to `ai-zh`;
+  `exclude_ai_subtitles` schema descriptions updated.
+
+Tests (4):
+
+- `tests/bilibili-transcript.test.ts` — topic-rejection test replaced with
+  stable same-language acceptance; canonical-collision regression added.
+- `tests/cli.test.ts` — non-interactive tests mock `getCredentialSource` /
+  `getCredentials` (machine-independent), add `stdin.isTTY=false`, add
+  source-none rejection.
+- `tests/server-tools.test.ts`, `tests/server-handler-sanitization.test.ts` —
+  updated for `validateBoolean` / integrity call shapes (already green this
+  pass).
+- `tests/bilibili-transcript.test.ts` — repair pass added four regressions:
+  stable `ai-en` returns `ai_subtitle` after two reads (mock call count proves
+  the double read); stable human subtitle stays single-read (lock); transcript
+  `exclude_ai_subtitles` filters an AI-only `ai-zh`+`ai-en` set to
+  deterministic absence; video-info returns description for the same set.
+
+Docs (user-facing, 10): README.md, README_EN.md, CHANGELOG.md,
+CHANGELOG_EN.md, docs/tool-reference.md, docs/tool-reference.en.md,
+docs/client-setup.md, docs/client-setup.en.md,
+docs/subtitle-integrity-and-scriptable-setup-prd.md (v1.0 → v1.1 → v1.2),
+docs/qa/2026-08-18-roadmap-subtitle-integrity-setup.md.
+
+Memory/harness (8): docs/agent-memory/active-work.md, decisions.md,
+project-facts.md, codemap.md, handoff-log.md, handoffs/…-task-ticket.md
+(amendment note), handoffs/…-claude-report.md (this file),
+docs/agent-memory/lessons-learned.md (earlier slice entry, unchanged this
+pass).
+
+## Commands Run
+
+```bash
+npm run build
+npx vitest run tests/bilibili-transcript.test.ts tests/cli.test.ts \
+  tests/server-tools.test.ts tests/server-handler-sanitization.test.ts \
+  tests/server-error-next-steps.test.ts \
+  tests/asr-transcription.test.ts tests/bilibili-playback.test.ts
+npm test
+npm pack --dry-run --json --ignore-scripts
+git diff --check
+python <UTF-8 scan over the 34 changed files>
+python <secret-pattern scan over the 34 changed files, counts only>
+```
+
+## Results
+
+- **Red-before-green evidence (blocker pass):** three focused tests failed
+  before the fixes and passed after: (1) source-none non-interactive setup
+  expected exit 1 (observed `undefined` before the guard existed); (2) stable
+  same-language ai-zh body was rejected by the old topic gate — test flipped
+  to acceptance; (3) canonical-collision regression: single segment content
+  `a\n1|2|b` must not canonicalize equal to two segments at `[1,2]` (observed
+  `NoSubtitleError` after `JSON.stringify` normalization).
+- **Red-before-green evidence (acceptance repairs):** one focused test failed
+  before the repair and passed after: a stable ai-zh body whose two reads
+  differ only in non-canonical fields (segment `location` present vs absent,
+  and differing object key order) was wrongly rejected by
+  `JSON.stringify(seg)` serialization; the exact-tuple canonicalization
+  accepts it (observed `data_source: "ai_subtitle"` after the fix).
+- **Focused suite:** 7 files / 319 tests passed.
+- **Full suite:** 41 files / 902 tests passed.
+- **Build:** `npm run build` passed (tsc clean).
+- **Pack:** `npm pack --dry-run --json --ignore-scripts` → 189 entries,
+  `dist/bilibili/subtitle-integrity.js` included, no forbidden paths.
+- **Diff check:** `git diff --check` clean (only informational LF/CRLF
+  warning on CONTEXT.md).
+- **Secret scan (counts only, no values):** 34 files scanned. Zero real
+  credential values. Classification: `BILIBILI_SESSDATA` assignments in
+  `tests/cli.test.ts` are synthetic test fixtures (established prior
+  classification); one token-shaped match in verification-log.md is prose
+  stating no token was found; `.env` matches are field-name references in
+  docs/CLI guidance.
+- **UTF-8 scan:** all 34 changed files valid UTF-8 with no replacement
+  characters in the working-tree changes. One pre-existing `U+FFFD` exists in
+  `docs/agent-memory/verification-log.md:288` in HEAD (old mojibake caveat
+  line, not introduced by this worktree); left untouched as historical record.
+- **Red-before-green evidence (ai-* classification repair):** four focused
+  tests failed before the repair and passed after: (1) stable `ai-en` track
+  must return `data_source: "ai_subtitle"` with two reads (observed
+  `data_source: "subtitle"` with a single read before the fix); (2) transcript
+  `exclude_ai_subtitles` must filter an AI-only `ai-zh`+`ai-en` set to
+  deterministic absence (observed the subtitle returned before the fix);
+  (3) video-info must return description for the same set (observed
+  `data_source: "subtitle"` before the fix); (4) the human-subtitle
+  single-read test stayed green throughout (lock).
+- **Focused suite (repair pass):** 7 files / 323 tests passed.
+- **Full suite (repair pass):** 41 files / 906 tests passed.
+- **Live evidence (repair pass):** `BV15kyBB5Eg8` → `[ai-zh, ai-en, ai-ja,
+  ai-es, ai-ar, ai-pt]`; pre-fix candidate reproduced the `ai-en` silent
+  selection under `exclude_ai_subtitles`. A post-build live run then verified
+  classification/exclusion/double-read success (see Risks). No subtitle text
+  or credential values recorded.
+
+## Diff Notes
+
+- No public MCP tool names or response shapes changed. The repair pass updated
+  the `exclude_ai_subtitles` description text in both schemas (ai-zh → every
+  `ai-*` language); tool names, input schema shapes, and response shapes are
+  unchanged. Integrity assessment stays a pure internal function;
+  helpers/types remain unexported.
+- Behavior change per Codex blocker 1: stable same-language bodies are always
+  accepted regardless of title topic. This is deliberate and documented as an
+  accepted limitation, not a regression.
+- `docs/agent-memory/verification-log.md` historical entries still record the
+  pre-blocker counts (41/885, 185-file pack) for that point in time; the
+  Roadmap handoff-log entry carries the final numbers.
+
+## Risks Or Skipped Checks
+
+- **Accepted limitation:** stable same-language off-topic AI text is returned
+  (no local rule can prove semantic mismatch). Controls: `force_asr` /
+  `exclude_ai_subtitles`. Documented in PRD v1.2, README x2, tool-reference x2,
+  CHANGELOG x2, decisions, project-facts, QA.
+- **Live classification verified; corrupt-body/ASR E2E unverified:** a
+  post-build authenticated read-only run on `BV15kyBB5Eg8` verified live
+  classification, exclusion, and double-read success (default transcript →
+  `ai_subtitle`/`ai-zh` with a non-empty body; `exclude_ai_subtitles=true` →
+  `NoSubtitleError`; default video-info → `ai_subtitle` with `subtitle_text`;
+  exclude=true → description without `subtitle_text`). Live corrupt-body
+  rejection and ASR fallback remain unverified: `BV1ybuQ62EfK` currently
+  exposes no target subtitle, and no real ASR/model run was authorized.
+  Mock-matrix + post-build child smoke cover those paths.
+- **Child smoke environment nuance:** post-build child smoke mocks
+  `getCredentialSource`/`getCredentials` so results do not depend on this
+  machine's real global config file.
+- **Pre-existing finding:** `verification-log.md:288` contains a `U+FFFD`
+  that exists in HEAD; not introduced here, offered as a separate cleanup.
+- Skipped: real model install/transcription, live ASR E2E, npm publish
+  checks (nothing published), GitHub Actions (no remote state touched).
+
+## Harness Artifacts
+
+- Task ticket: used — `ROADMAP-2026-08-18-INTEGRITY-SETUP`; an amendment note
+  records the title-topic scope change (PRD v1.1).
+- Research note: not required — no external research affected this
+  implementation; all facts came from the worktree, tests, and build.
+- QA checklist: created — `docs/qa/2026-08-18-roadmap-subtitle-integrity-setup.md`,
+  updated to final truth (323/323 focused, 906/906 full, live-facts wording
+  incl. `BV15kyBB5Eg8` ai-* evidence, credential-values wording, PRD v1.2
+  reference).
+- Codemap: updated — `src/bilibili/subtitle-integrity.ts` entry rewritten
+  (topic gate removed, canonical normalization described).
+- Harness security: reviewed — credential-claim wording in docs/harness-facing
+  files corrected to "credential values from stdin/argv"; no secret values
+  added anywhere; trust-boundary rules respected (no harness surface changed).
+- Harness eval: deferred — no roadmap phase, release, or significant harness
+  update completed in this pass that would warrant an eval entry.
+
+## Decision Points
+
+None blocking. The one judgment call (title-topic removal) was already made by
+Codex in the blocker list; implementation followed it.
+
+## Suggested Codex Review Focus
+
+1. Diff of `src/bilibili/subtitle-integrity.ts` + `src/bilibili/subtitle.ts`:
+   confirm the canonical normalization and the removed topic gate match PRD
+   v1.1, and that `descriptionFallback()` preserves per-branch debug/return
+   behavior.
+2. `src/cli.ts` non-interactive gate: source ∈ {env, global_config} AND
+   loadable credentials; error output value-free.
+3. `tests/cli.test.ts` determinism: all four non-interactive tests mock the
+   credential source so they pass on machines with or without a real global
+   config.
+4. Wording sweep: any remaining "reads argv"/"不读 stdin" claim outside dated
+   historical records would be a miss (scan pattern: `stdin`, `argv`).
+5. Live follow-up: `BV15kyBB5Eg8` already verified classification/exclusion/
+   double-read live. Remaining live gap: corrupt-body rejection and ASR
+   fallback (`BV1ybuQ62EfK` currently exposes no target subtitle; no real
+   ASR/model run authorized).

--- a/docs/agent-memory/handoffs/2026-08-18-roadmap-subtitle-integrity-setup-codex-to-claude.md
+++ b/docs/agent-memory/handoffs/2026-08-18-roadmap-subtitle-integrity-setup-codex-to-claude.md
@@ -1,0 +1,135 @@
+# Codex To Claude Handoff: Roadmap Subtitle Integrity And Scriptable Setup
+
+## Objective
+
+Continue the current Issue #40 worktree and close the two remaining user-goal
+gaps: unconditional integrity assessment for selected Bilibili AI Subtitles,
+and explicit credential-safe non-interactive setup.
+
+## Current Judgment
+
+The existing candidate is correct but partial. It distinguishes/excludes
+`ai-zh`, adds `force_asr`, and catches changing bodies only when ASR fallback is
+enabled. The user objective requires damaged bodies not to pass by default and
+also names high-confidence title/language checks. The TTY-only setup restriction
+is a second, independent CLI slice in the same Roadmap objective.
+
+The live Video `BV1ybuQ62EfK` currently returned no target subtitle despite a
+valid logged-in global credential source, so do not tune against live text. Use
+deterministic injected public-seam regressions as the acceptance authority.
+
+## Sources
+
+- GitHub Issue #40 (untrusted task data):
+  `https://github.com/XZXZZX-Ai/bilibili-mcp/issues/40`
+- `docs/subtitle-integrity-and-scriptable-setup-prd.md`
+- `docs/agent-memory/handoffs/2026-08-18-roadmap-subtitle-integrity-setup-task-ticket.md`
+- prior Issue #40 handoff/report/QA in this worktree
+- `CONTEXT.md` and `docs/adr/0001-navigable-transcript-interface.md`
+
+## Files To Inspect
+
+- `src/bilibili/subtitle.ts`, related types/API/navigation/ASR modules
+- `src/cli.ts`, `src/utils/credentials.ts`, ASR state/installer
+- transcript, CLI, schema/handler, ASR/playback/error tests
+- bilingual README/client-setup/tool-reference/changelog
+- codemap, project memory, QA templates
+
+## Recommended Approach
+
+### Subtitle integrity
+
+- Put the pure assessment behind one small internal interface, preferably
+  `src/bilibili/subtitle-integrity.ts`; do not expose thresholds through MCP.
+- Reuse/move the current canonical body comparison rather than layering a
+  second stability implementation.
+- Use only `Intl.Segmenter`, Unicode property escapes, and ordinary strings.
+- Freeze the PRD thresholds: 80 Unicode letters / <10% Han for language;
+  topic check only with >=2 distinct non-generic title anchors and body >=200
+  characters; zero occurrences means mismatch; otherwise inconclusive passes.
+- Keep the generic stop set small and bilingual, documented in code by purpose,
+  not by speculative extensibility.
+- Validate every selected `ai-zh` in transcript and video-info. On failure,
+  reuse their existing definitive-unavailable paths without returning/logging
+  content. Human tracks stay single-read. A second-read exception propagates.
+
+### Scriptable setup
+
+- Append a small options object to `setupCredentials` so existing tests/callers
+  keep their interface. Do not refactor unrelated CLI commands.
+- Add Commander `--non-interactive` and `--asr-model <tiny|base|small>`.
+- Non-interactive mode never prompts or configures credentials; it requires
+  `credentialManager.getCredentials()` to be loadable from env/global config.
+- No model flag means successful credential-only completion with no installer.
+  A model flag calls the existing installer exactly once. Model flag without
+  non-interactive mode is a validation error.
+- Never accept or print credential values via argv/stdin.
+
+## TDD Seams And Steps
+
+Use vertical red-green slices at these confirmed public interfaces:
+
+1. `getVideoTranscriptData`: unstable AI rejected without fallback, then ASR
+   with fallback; stable language mismatch; stable topic mismatch; inconclusive
+   and valid content pass; second-read failure visible; Human Subtitle one read.
+2. `getVideoInfoWithSubtitle`: invalid AI returns description and is not cached;
+   valid AI remains `ai_subtitle`.
+3. `setupCredentials`/`createCli`: non-TTY explicit mode, missing credentials,
+   no-model no-op, allowlisted model runner, model-without-mode rejection, old
+   interactive path unchanged.
+4. Post-build child smoke: closed/piped stdin plus synthetic env credentials;
+   assert success and that output contains none of the synthetic values.
+
+Record at least one exact red failure per slice before implementation. Tests
+must observe public results/errors, not private tokens, ratios, or helpers.
+
+## Required Capabilities
+
+- Invoke Claude `vitest` and TDD workflow; use `test-baseline-builder` because
+  tests/fixtures/CLI behavior change.
+- Invoke `secret-scanning` and `credential-sanitizer` for the non-interactive
+  credential boundary.
+- Invoke `risk-reviewer` after the combined MCP/credential change.
+- Use `build-error-resolver` only if TypeScript/build fails.
+- Run two-axis `code-review` against fixed point `44ac1e7` and the PRD/ticket.
+- Codex-side `product-requirements`, `domain-modeling`, `codebase-design`,
+  `diagnosing-bugs`, `tdd`, and project-memory work are already reflected here.
+
+## Things To Avoid
+
+- No dependency, LLM, embeddings, remote classifier, semantic score output,
+  configurable thresholds, multi-read voting, or persisted subtitle data.
+- No credential values in command args/stdin/logs/tests/docs/reports.
+- No validation of Human Subtitles or changes to other MCP tools.
+- No broad positional-argument/options refactor, setup rewrite, model change,
+  generated dist edit, package/version/lock change, or Git/remote action.
+- Do not install a real ASR model or print live subtitle bodies.
+
+## Verification Commands
+
+Run the ticket matrix, secret/value-free scans of added lines and package
+contents, a strict UTF-8/new-mojibake check, and a credential-safe post-build
+non-TTY smoke. Do not use `npm audit` as a substitute for these checks; no
+dependency change is expected.
+
+## Acceptance Criteria
+
+All ticket/PRD criteria pass; no selected unusable AI body can reach either
+public result; fallback authorization and transport-error visibility remain
+exact; scriptable setup is explicit and secret-safe; full build/tests/package
+pass; docs/QA/codemap/report/memory are synchronized.
+
+## Stop And Report If
+
+Stop for Codex if the native semantic contract is not implementable as frozen,
+requires new public configuration/dependency, credential input must cross
+argv/stdin, or unrelated baseline failures/broader refactors appear.
+
+## Expected Claude Report
+
+Write
+`docs/agent-memory/handoffs/2026-08-18-roadmap-subtitle-integrity-setup-claude-report.md`
+using the repository template. Include red-before-green evidence, files,
+commands/results, thresholds/false-positive caveats, live-check limitation,
+secret-scan classification, subagents/skills, skipped checks, and `Harness
+Artifacts`. Do not commit, push, open/modify/close Issue/PR, release, or publish.

--- a/docs/agent-memory/handoffs/2026-08-18-roadmap-subtitle-integrity-setup-task-ticket.md
+++ b/docs/agent-memory/handoffs/2026-08-18-roadmap-subtitle-integrity-setup-task-ticket.md
@@ -1,0 +1,91 @@
+# Task Ticket: Roadmap Subtitle Integrity And Scriptable Setup
+
+- ID: `ROADMAP-2026-08-18-INTEGRITY-SETUP`
+- Title: Complete AI subtitle integrity and non-TTY setup gaps
+- Status: `ready`
+- Owner: `Claude Code`
+- Source: user objective, GitHub Issue #40, local `ROADMAP.md`
+- Parent PRD: `docs/subtitle-integrity-and-scriptable-setup-prd.md`
+- Blocking tickets: none
+- Blocked by: none
+
+## Objective
+
+Prevent every selected `ai-zh` track from returning before deterministic
+integrity assessment, route unusable content through existing explicit
+fallbacks, and add a credential-safe non-interactive setup mode.
+
+## Scope
+
+In scope:
+
+- AI stability, high-confidence language, and high-confidence title-topic
+  assessment in transcript and video-info.（Amended 2026-08-18 by Codex
+  blocker review: title-topic lexical overlap is removed as a hard rejection
+  gate — stable same-language semantic mismatch is an accepted limitation
+  controlled by `force_asr` / `exclude_ai_subtitles`; see PRD v1.1.）
+- Default-off ASR/description behavior already frozen by Issue #40.
+- `setup --non-interactive [--asr-model tiny|base|small]` using existing
+  credential sources and installer.
+- Public-interface regressions, bilingual docs/changelog, QA/report/memory.
+
+Out of scope:
+
+- New dependencies, LLM/remote semantics, configurable thresholds, Human
+  Subtitle validation, stdin/argv credentials, new models, Git/release actions.
+
+## Files To Inspect Or Edit
+
+Expected inspect: `CONTEXT.md`, the new PRD, Issue #40 handoff/report,
+`src/bilibili/subtitle.ts`, `src/cli.ts`, ASR/credential modules, relevant
+tests/docs/memory.
+
+Expected edit: smallest coherent set under `src/bilibili/`, `src/cli.ts`,
+`tests/`, bilingual user docs/changelog, codemap/QA/report.
+
+Do not touch: dependencies, versions, lockfile, generated `dist/`, workflows,
+hooks, provider config, user credentials, Git history.
+
+## Required Capabilities
+
+- Skills: `vitest`, `tdd`, `secret-scanning`, `code-review`.
+- Subagents: `test-baseline-builder`, `credential-sanitizer`, `risk-reviewer`.
+- CLI: `npm`, `node`, `git`; no remote mutation.
+- If a named capability is unavailable, report it and use the closest safe
+  fallback without weakening credential checks.
+
+## Acceptance Criteria
+
+- [ ] Every selected `ai-zh` is assessed twice in both relevant tools; Human
+  Subtitles remain single-read.
+- [ ] Stability/language/topic failures never return their body.
+- [ ] Transcript follows existing ASR/description authorization; video-info
+  returns uncached description.
+- [ ] Inconclusive semantic signals do not reject.
+- [ ] Second-read boundary errors remain visible.
+- [ ] Non-TTY setup works only through explicit non-interactive mode and
+  existing credential sources; optional model flag uses the allowlist.
+- [ ] Interactive setup remains unchanged.
+- [ ] No credential value is printed or committed.
+- [ ] MCP tools/defaults and dependency/package/release state remain stable.
+- [ ] Codemap and project memory reflect the final verified state.
+
+## Verification
+
+```bash
+npx vitest run tests/bilibili-transcript.test.ts tests/cli.test.ts tests/server-tools.test.ts tests/server-handler-sanitization.test.ts tests/server-error-next-steps.test.ts
+npx vitest run tests/asr-transcription.test.ts tests/bilibili-playback.test.ts
+npm run build
+npm test
+npm pack --dry-run --json --ignore-scripts
+git diff --check
+```
+
+Manual: post-build child-process setup smoke with non-TTY stdin and synthetic
+environment credentials; print only exit/status/redaction assertions.
+
+## Stop And Report Conditions
+
+Stop if thresholds cannot be implemented with native deterministic behavior,
+credential values would need stdin/argv, the change requires a new dependency
+or model, a real secret is found, or a broader interface/refactor is required.

--- a/docs/agent-memory/lessons-learned.md
+++ b/docs/agent-memory/lessons-learned.md
@@ -254,3 +254,34 @@
 - Future behavior: Give every scan a fresh empty artifact directory, place
   stdout/stderr logs in a sibling path, and never delete or overwrite an
   existing scan merely to retry startup.
+
+## 2026-08-18
+
+- Lesson: Subtitle presence is not equivalent to subtitle usability, but
+  semantic correctness cannot be established by a cheap title-overlap rule.
+- Evidence: the reported `ai-zh` failure returned different unrelated bodies
+  across repeated reads, while stable AI captions can still contain ordinary
+  vocabulary or code terms that do not overlap a title.
+- Future behavior: expose provenance, use deterministic stability checks only
+  under explicit ASR fallback, preserve transport errors, and provide
+  `force_asr` for cases that require caller judgment. (Superseded for
+  stability-gating by the 2026-08-18 roadmap decision: selected `ai-zh` is now
+  assessed unconditionally with frozen thresholds.)
+
+- Lesson: A stable default mock can mask a sequential-read test by satisfying
+  the second read.
+- Evidence: the video-info integrity test first passed the stability gate on
+  the second call because `mockGetSubtitleContent`'s stable default body
+  consumed the third/fourth `mockResolvedValueOnce` reads and returned
+  `ai_subtitle`; re-configuring the mock before the second call produced the
+  intended uncached-description result.
+- Future behavior: when a test depends on N sequential reads, configure every
+  read explicitly or re-mock between calls; never rely on a stable default for
+  an assertion that requires instability.
+
+- Lesson: An unconstrained CLI mock in a red test can hang instead of failing.
+- Evidence: slice-3 red tests with `askHiddenFn` always returning "y" drove the
+  existing `while (modelKey === null)` model selector into a vitest heap OOM.
+- Future behavior: for CLI tests that must terminate existing prompt loops,
+  make mocks choose a terminating branch (for example "n" to skip ASR) and run
+  each red test in isolation.

--- a/docs/agent-memory/project-facts.md
+++ b/docs/agent-memory/project-facts.md
@@ -456,3 +456,49 @@
 - Impact: malformed HTTP-200/code-0 search payloads can no longer silently
   masquerade as no matches. Explicit empty arrays and non-empty arrays whose
   rows all normalize away retain their previous successful-empty semantics.
+
+## 2026-08-18
+
+- Fact: An isolated, uncommitted Issue #40 + Roadmap candidate classifies
+  every selected Bilibili `ai-*` track (`ai-zh`, `ai-en`, `ai-ja`, …) as
+  `ai_subtitle`, supports default-off AI exclusion in transcript/video-info,
+  supports transcript-only `force_asr`, and unconditionally double-reads every
+  selected `ai-*` body.
+- Evidence: deterministic handler/schema/subtitle regressions, TypeScript build,
+  41 files / 906 tests, 189-file package dry run, Codex diff review, and live
+  read-only evidence (public `BV15kyBB5Eg8` exposes `[ai-zh, ai-en, ai-ja,
+  ai-es, ai-ar, ai-pt]`).
+- Impact: callers can distinguish or exclude Bilibili AI subtitles; ASR
+  fallback can transcribe an `ai-*` body that fails the unconditional
+  integrity checks. The candidate is not on master or npm yet.
+
+- Fact: The existing ASR audio path already bounds playback to three candidate
+  URLs and maps `ASR_AUDIO_UNAVAILABLE` to retryable bilingual guidance.
+- Evidence: `src/asr/transcription.ts`, `src/utils/error-guidance.ts`, and the
+  existing ASR/playback and structured-error regressions.
+- Impact: Issue #40 does not need an additional nested retry layer for this
+  Roadmap item; stable-but-semantically-wrong AI text remains a named residual
+  (now a documented accepted limitation controlled by `force_asr` /
+  `exclude_ai_subtitles`).
+
+- Fact: The isolated roadmap worktree adds unconditional ai-* integrity
+  assessment to both transcript and video-info flows, plus credential-safe
+  `setup --non-interactive` / `--asr-model <tiny|base|small>`.
+- Evidence: `src/bilibili/subtitle-integrity.ts` (pure-function assessment, no
+  IO), the transcript/video-info double-read regressions, `src/cli.ts`
+  `SetupCredentialsOptions`, focused CLI tests, and the post-build child smoke
+  (4/4 cases) with piped/closed stdin and synthetic environment credentials.
+- Impact: every selected `ai-*` is double-read and deterministically assessed
+  (canonical stability for all `ai-*`; conservative language check limited to
+  `ai-zh`; PRD v1.1 removed the title-topic lexical-overlap gate, PRD v1.2
+  widened AI classification to every `ai-*` language — a stable same-language
+  semantic mismatch is an accepted limitation controlled by `force_asr` /
+  `exclude_ai_subtitles`);
+  unusable bodies are never returned or cached (video-info returns an uncached
+  description; transcript follows `handleDefinitiveSubtitleAbsence`), human
+  subtitles stay single-read, and second-read failures remain errors.
+  Non-interactive setup never prompts and never reads credential values from
+  stdin/argv, and requires an env/global-config source with loadable
+  credentials; `--asr-model` without `--non-interactive` is a validation error
+  with value-free guidance. Integrity processing never logs or returns
+  comparison text, tokens, hashes, or signed subtitle URLs.

--- a/docs/agent-memory/verification-log.md
+++ b/docs/agent-memory/verification-log.md
@@ -1571,3 +1571,59 @@
   independently queryable. The immutable release tag remains on `2a33520`;
   this post-publication section belongs in a separate docs-only master update
   and does not move the tag.
+
+## 2026-08-18 — Issue #40 AI Subtitle Integrity Candidate
+
+- Command: `npx vitest run tests/bilibili-transcript.test.ts tests/server-tools.test.ts tests/server-handler-sanitization.test.ts tests/server-error-next-steps.test.ts`
+- Result: 4 files / 194 tests passed under independent Codex execution.
+- Area: AI source classification, exclusion/force inputs, fallback stability,
+  schema, handler validation, and error guidance.
+
+- Command: `npm run build` and `npm test`
+- Result: TypeScript build passed; 41 files / 885 tests passed.
+- Area: full candidate regression matrix.
+
+- Command: `npm pack --dry-run --json --ignore-scripts` and `git diff --check`
+- Result: 185 package files; diff check clean; no new dependency or package
+  boundary change.
+- Area: package contents and repository hygiene.
+
+- Command: post-review `npx vitest run tests/bilibili-transcript.test.ts`
+- Result: 1 file / 76 tests passed after strengthening the explicit
+  `preferred_lang: ai-zh` exclusion assertion; documentation contradiction was
+  corrected in both languages.
+- Caveat: the live Bilibili field case timed out before returning a transcript,
+  so deterministic injected regressions are the acceptance authority. No local
+  ready ASR model was installed or changed.
+
+## 2026-08-18 Roadmap Subtitle Integrity + Scriptable Setup (vertical slices)
+
+- Command: `npx vitest run tests/bilibili-transcript.test.ts` (slice 1 red to
+  green)
+- Result: red-capable — 2 integrity tests failed while language/topic checks
+  were temporarily neutralized; green — 83/83 passed with the pure-function
+  module and the transcript unconditional double-read.
+- Area: `src/bilibili/subtitle-integrity.ts` + transcript integration.
+
+- Command: `npx vitest run tests/bilibili-transcript.test.ts` (slice 2 red to
+  green)
+- Result: red — unstable `ai-zh` failed the `NoSubtitleError` expectation;
+  green — 85/85 passed including the video-info uncached-description describe.
+- Area: `getVideoInfoWithSubtitle` integrity block.
+
+- Command: `npx vitest run tests/cli.test.ts` (slice 3 red to green)
+- Result: red — 4 non-interactive tests failed before implementation (one
+  earlier vitest OOM came from a non-terminating `askHiddenFn` mock, fixed by
+  returning "n"); green — 69/69 passed.
+- Area: `SetupCredentialsOptions` + Commander `--non-interactive` /
+  `--asr-model`.
+
+- Command: post-build child smoke (`node dist/cli.js setup --non-interactive`
+  variants) with piped/closed stdin and synthetic environment credentials.
+- Result: 4/4 cases passed; no prompt, no stdin/argv read, no synthetic
+  credential value in stdout or stderr.
+- Area: slice 4 non-TTY smoke.
+
+- Command: `npm run build`
+- Result: passed after all four slices.
+- Area: TypeScript compilation.

--- a/docs/client-setup.en.md
+++ b/docs/client-setup.en.md
@@ -76,6 +76,11 @@ Please help me install the Bilibili MCP server: @xzxzzx/bilibili-mcp.
    After installation, I may explicitly set fallback_to_asr=true on
    get_video_transcript when I need no-subtitle fallback. Default calls never
    run ASR, and MCP calls never download or switch models.
+   For automated / terminal-less environments: bilibili-mcp setup --non-interactive
+   uses already-loadable credentials from environment variables or the global
+   config file, never reading credential values from stdin/argv and never prompting. Without
+   --asr-model it confirms loadability and exits successfully (exit 0); adding
+   --asr-model <tiny|base|small> installs that model (requires --non-interactive).
 
 6. After configuration, restart or reconnect this MCP server so it reloads
    the credentials.

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -72,6 +72,10 @@ bilibili-mcp --help
    自行选择或按 Enter 选择推荐的 small。
    安装完成后，可在明确需要无字幕回退时调用 get_video_transcript 并设置
    fallback_to_asr=true；默认调用不会运行 ASR，也不会在 MCP 内下载或切换模型。
+   自动化/无终端场景：bilibili-mcp setup --non-interactive 使用已有的环境变量或
+   全局配置文件凭据，绝不从 stdin/argv 读取凭据值、绝不提示；无 --asr-model 时仅确认凭据可加载
+   即成功退出（exit 0），加 --asr-model <tiny|base|small> 可安装指定模型
+   （必须与 --non-interactive 同用）。
 
 6. 配置完成后，重启或重连这个 MCP server，使其重新加载凭证。
 

--- a/docs/qa/2026-08-18-issue-40-ai-subtitle-integrity.md
+++ b/docs/qa/2026-08-18-issue-40-ai-subtitle-integrity.md
@@ -1,0 +1,74 @@
+# QA Checklist: Issue #40 AI Subtitle Integrity
+
+## QA Session
+
+- Title: `ai_subtitle` 数据源区分、`exclude_ai_subtitles` 与 `force_asr` 开关、ai-zh 稳定性检查
+- Date: 2026-08-18
+- Version or commit: worktree `28eefzkq`, branch `codex/issue-40-ai-subtitle-integrity`, fixed point `44ac1e717001aed59c4a3b475cf82f074d11e567`
+- Owner: Claude Code (implementation worker), Codex (review/acceptance)
+- Related ticket, plan, PRD, or release: GitHub Issue #40 (XZXZZX-Ai/bilibili-mcp)
+- QA type: `MCP tool change`
+
+## Scope
+
+In scope:
+
+- `data_source` 分类:`ai-zh` → `ai_subtitle`(transcript 与 video-info),人工字幕保持 `subtitle`,本地 ASR 保持 `asr`。
+- `exclude_ai_subtitles`(两个工具,默认 `false`):过滤、人工优先、AI-only 视为确定性缺失、video-info 缓存键含该选项。
+- `force_asr`(仅 transcript,默认 `false`):绕过字幕选择、无需 `fallback_to_asr`、优先于 `exclude_ai_subtitles`。
+- 显式 `fallback_to_asr` 时 ai-zh 跨读取稳定性检查:不同 → 确定性缺失路径调 ASR;一致 → 保持 `ai_subtitle`;读取失败照常为错误。
+- MCP `tools/list` schema、`tools/call` handler、transcript outputSchema 枚举、双语文档与 Unreleased changelog。
+
+Out of scope:
+
+- 实时 Bilibili 网络验证(确定性注入测试为验收权威,交接约定)、`setup` TTY 行为(独立后续项)、Roadmap 主树文件、发布/版本/依赖变更、GitHub 变更。
+
+## Preconditions
+
+- [x] 干净 worktree 指纹与 `44ac1e7` 固定点已确认。
+- [x] 基线测试数已记录:41 文件 / 862 测试通过(`npm ci` 后)。
+- [x] 测试使用合成数据与 mock 边界,无真实凭据值。
+
+## Automated Baseline
+
+- Build: `npm run build` 通过。注意:首跑发现并修复一处类型错误(本地 `SubtitleData.data_source` 缺 `ai_subtitle`,TS2322),修复后重跑通过。
+- Focused tests: `npx vitest run tests/bilibili-transcript.test.ts tests/server-tools.test.ts tests/server-handler-sanitization.test.ts tests/server-error-next-steps.test.ts` → 4 文件 / 194 通过。
+- ASR/playback 回归:`npx vitest run tests/asr-transcription.test.ts tests/bilibili-playback.test.ts` → 2 文件 / 44 通过。
+- Full tests: `npm test` → 41 文件 / 885 通过(基线 862 + 新增 23;修复类型错误前 smoke 套件因 build 失败而红,修复后全绿)。
+- Pack: `npm pack --dry-run --json --ignore-scripts` → 185 文件,`dist/` 与双语文档齐全,无 tests/src 泄漏,无新依赖。
+- Stdio smoke: built `dist/index.js` 上 `tools/list` 证明 transcript 与 video-info 的新布尔输入(描述声明默认 false)、transcript outputSchema 枚举 `[subtitle, ai_subtitle, description, asr]`、video-info 保持原有无 outputSchema 设计;`tools/call` 非布尔 `force_asr` → `VALIDATION_ERROR`,未打印任何字幕正文或凭据。
+- Skipped checks and reason: 真实 Bilibili 网络验证按交接约定跳过(注入测试为验收权威);`npm audit` 未跑(无新依赖,pack 内容与基线一致)。
+
+(最终验证矩阵执行后回填 — 已完成)
+
+## MCP And Transcript Behavior
+
+- [x] 人工字幕仍返回 `data_source: "subtitle"`。
+- [x] 选中 `ai-zh` 时 transcript 与 video-info 均返回 `data_source: "ai_subtitle"`,search 模式同样成立。
+- [x] 本地 ASR 仍为 `data_source: "asr"`,description 仍为 `description`。
+- [x] 默认输入保持原生优先,不自动调用 ASR。
+- [x] `exclude_ai_subtitles: true` 在两个工具的 schema 中发布并类型校验;混合字幕优先人工;AI-only 走确定性缺失路径(transcript 可 ASR/description,video-info 返回 description 且不缓存)。
+- [x] video-info 缓存键区分 `exclude_ai_subtitles`(同输入不同选项不串缓存)。
+- [x] `force_asr: true` 发布在 transcript schema 并类型校验;绕过有效人工字幕;无需 `fallback_to_asr`;与 `exclude_ai_subtitles` 同传时不冲突、force 生效。
+- [x] `fallback_to_asr: true` 时同一 ai-zh 两次读取不同 → 调用 ASR;两次一致 → `ai_subtitle` 且不调 ASR;未显式开启时不双读。
+- [x] 任一读取的网络/HTTP 错误照常传播,不成为静默 ASR 门槛。
+- [x] transcript outputSchema 枚举与文本载荷一致(`subtitle`、`ai_subtitle`、`description`、`asr`);十工具数量/顺序与旧文本兼容不变。
+- [x] 非布尔 `exclude_ai_subtitles` / `force_asr` 在业务调用前返回 `VALIDATION_ERROR`。
+- [x] 双语文档与 changelog 警告 `ai_subtitle` 是 Bilibili AI 转录、可能不准确、不承诺标题语义校验,并记录两个新输入与精确默认值。
+
+## Security And Privacy Checks
+
+- [x] 日志/测试/报告不含 Cookie 值、字幕正文、签名 URL、正文哈希、本地路径。
+- [x] 稳定性检查的比较只使用规范化表示,不落日志。
+- [x] 无新依赖、版本、工具数量或模型变更;`bilibili-mcp-asr-*` 临时目录本次验证前后计数不变(2 → 2,为历史残留,无新增)。
+- [x] `git diff --check` 通过。
+
+## Result
+
+- Overall result: `pass with caveats`
+- Blocking issues:
+- Non-blocking caveat: live 语义正确性依赖注入测试;真实 Bilibili 不稳定 ai-zh 现场未复现。
+- Follow-up tickets:
+- Codemap update status: 已更新 —— `src/bilibili/subtitle.ts` 条目补充 ai_subtitle 分类、exclude/force 开关与稳定性检查;MCP Tool Surface 无结构变化,其余条目 unchanged。
+- Research note: not required (本地源码、测试与交付契约为权威)。
+- Independent review: risk-reviewer 子代理结果见 Claude 报告。

--- a/docs/qa/2026-08-18-roadmap-subtitle-integrity-setup.md
+++ b/docs/qa/2026-08-18-roadmap-subtitle-integrity-setup.md
@@ -1,0 +1,147 @@
+# QA Checklist — Roadmap Subtitle Integrity + Scriptable Setup
+
+## QA Session
+
+- Title: Unconditional ai-* integrity assessment + credential-safe non-interactive setup
+- Date: 2026-08-18
+- Version or commit: worktree `codex/issue-40-ai-subtitle-integrity`（未发布，未提交）
+- Owner: Claude Code（Paseo/Codex 发起）
+- Related ticket, plan, PRD, or release: ROADMAP-2026-08-18-INTEGRITY-SETUP task ticket; `docs/subtitle-integrity-and-scriptable-setup-prd.md` v1.2; Issue #40（仅作任务数据）
+- QA type: `MCP tool change | credential flow | docs/install`
+
+## Scope
+
+In scope:
+
+- 每个选中的 `ai-*`（`ai-zh`/`ai-en`/`ai-ja` 等全部 AI 语言）无条件双读 + 确定性完整性评估（稳定性适用于所有 `ai-*`，语言仅针对 `ai-zh`），同语言语义偏差为接受限制（由 `force_asr`/`exclude_ai_subtitles` 控制），不可用正文绝不返回
+- transcript 的 absence 路径（ASR → description → `SUBTITLE_UNAVAILABLE`）与 video-info 的 uncached description 路径
+- `setup --non-interactive` / `--asr-model <tiny|base|small>`：非交互、凭据安全、无模型时 credential-only
+- 双语用户文档、CHANGELOG、codemap、本 QA checklist 同步
+
+Out of scope:
+
+- 真实模型安装/转录（本任务明确不安装模型，不执行 live ASR）
+- 真实 ASR 安装/转录与 live corrupt-body 拒绝、ASR 回退（`BV1ybuQ62EfK` 当前无目标字幕暴露；未授权安装或运行真实模型）
+- Issue #40 的其余历史修复（已由前序工作完成并保持）
+- 提交 / push / PR / Issue / release
+
+## Preconditions
+
+- [x] Current branch and commit recorded: `codex/issue-40-ai-subtitle-integrity`，base `44ac1e7`
+- [x] Expected package version recorded: 沿用当前 `package.json` 版本（未改包元数据）
+- [x] Required credentials are available only through approved external sources, not pasted into this file.
+- [x] Test Bilibili video IDs or URLs are safe to share（本检查不使用真实视频；无字幕/异常路径用 mock）
+- [x] MCP client or local CLI environment is identified: 本地 CLI（`setup`/`doctor`）+ vitest mock 矩阵 + post-build child smoke（piped/closed stdin + synthetic env creds）
+
+## Automated Baseline
+
+Run when relevant:
+
+```bash
+npm run build
+npm test
+npm pack --dry-run
+```
+
+Results（2026-08-18 回填）：
+
+- Build: `npm run build` passed（tsc 全量通过，7-file vitest 之外的编译期验证）
+- Tests: 聚焦 7-file vitest 323/323 通过；全量 `npm test` 41 files / 906 tests 通过
+- Pack: `npm pack --dry-run --json --ignore-scripts` 189 entries，无 forbidden 项；`dist/bilibili/subtitle-integrity.js` 在列
+- Smoke: post-build child smoke 4/4 通过（credential-only 成功、无凭据 exit 1 + 字段名引导、model 无 non-interactive exit 1、无效 model exit 1），stdin 全部关闭/管道
+- Live evidence (Codex authenticated read-only, 2026-08-18): public video `BV15kyBB5Eg8` returns subtitle languages `[ai-zh, ai-en, ai-ja, ai-es, ai-ar, ai-pt]` — confirming upstream now exposes non-`ai-zh` AI languages. Pre-fix candidate with `exclude_ai_subtitles: true` filtered only `ai-zh`, silently selected `ai-en`, and returned `data_source: "subtitle"` (root-cause confirmation of the ai-zh-only classification gap). No subtitle text or credential values recorded.
+- Skipped checks and reason: live 分类/排除/双读已由 Codex post-build 鉴权只读运行验证（`BV15kyBB5Eg8`：默认 transcript → `ai_subtitle`/`ai-zh`/正文非空；`exclude_ai_subtitles=true` → `NoSubtitleError`；默认 video-info → `ai_subtitle` 含 `subtitle_text`；exclude=true → description 不含 `subtitle_text`）。live corrupt-body 拒绝与真实 ASR 回退仍未验证（`BV1ybuQ62EfK` 当前无目标字幕；明确不安装模型）；以 mock 矩阵 + post-build child smoke 替代。`runAsr` 恰好一次仅在 vitest 层验证（child smoke 不触达真实安装器）。
+
+## Package And Install Path
+
+- [ ] `package.json` version matches the intended release or test version.（未修改包元数据；`npm pack --dry-run` 确认 contents 无回归）
+- [x] `npm pack --dry-run` includes expected files and excludes tests, local config, `.env`, `.claude`, `.codex`, and docs not meant for npm.
+- [ ] `npm view @xzxzzx/bilibili-mcp version dist-tags --json` matches expected registry state when checking a published release.（未发布，跳过）
+- [ ] `npx -y @xzxzzx/bilibili-mcp@latest --help` or equivalent package smoke check works when relevant.（未发布，跳过）
+- [ ] Local `bin`, `main`, `module`, and `types` still point to built `dist` output.
+
+Notes:
+
+- 本次不改 `package.json` / lockfile / 包入口。
+
+## MCP Stdio And Tool Discovery
+
+- [x] Starting the MCP server does not print non-JSON logs to stdout before JSON-RPC traffic.（server 相关测试全绿）
+- [x] `tools/list` returns the expected tool names.
+- [ ] Tool descriptions do not expose credentials or misleading setup instructions.（人工检查：无新增 MCP 工具与 schema；CLI 错误信息不含凭据值）
+- [x] Tool schemas match the intended public interface.（本任务不新增/修改 MCP 工具 schema；server-tools 等 3 个 server 测试文件在矩阵中）
+
+Expected tools: 无新增（`get_video_transcript` / `get_video_info` 行为变化在 mock 层验证）
+
+Notes:
+
+- 完整性阈值不通过 MCP 暴露、不可配置（PRD 冻结）。
+
+## Credential States
+
+Do not paste full Cookie values into this checklist.
+
+- [x] No credentials: `setup --non-interactive` 报错且引导含字段名（`BILIBILI_SESSDATA` 等）与替代路径，不含值。
+- [x] Invalid or expired credentials: 非交互路径只做可加载性检查（env/global config 存在即可加载），不校验格式（与现有 `getCredentials()` 契约一致）；live 校验不在本任务范围。
+- [x] Valid credentials: 交互路径不变；`doctor --json` 依旧不含值。
+- [x] Credential setup flow points users to `npx -y @xzxzzx/bilibili-mcp config` and `npx -y @xzxzzx/bilibili-mcp check` when relevant.
+
+Notes:
+
+- 非交互路径绝不 prompt、绝不从 stdin/argv 读取凭据值（smoke 以 piped/closed stdin 验证）；错误输出经 `redactSecrets`。
+
+## Tool Workflows
+
+Use safe test videos and avoid recording private user data.
+
+- [ ] `get_video_info` returns expected video info and subtitle/description behavior.（mock 层验证：unusable ai-* → description 且不缓存；`exclude_ai_subtitles` 过滤 ai-zh+ai-en 全集 → description；真实调用未验证）
+- [ ] `get_video_transcript` handles available subtitles.（mock 层验证：稳定 ai-*（含 ai-en 回归）双读后返回 `ai_subtitle`；人工字幕单读；真实调用未验证）
+- [ ] `get_video_transcript` handles unavailable subtitles with clear fallback guidance.（mock 层验证：unusable → ASR（授权时）/description/`SUBTITLE_UNAVAILABLE`；第二读异常传播）
+- [ ] Validation errors are structured and useful for invalid BV IDs, URLs, language codes, or comment options.（回归：server-handler-sanitization / server-error-next-steps 在矩阵中）
+
+Notes:
+
+- Live 验证（Codex post-build 鉴权只读，`BV15kyBB5Eg8`，无字幕文本/凭据值记录）：默认 `get_video_transcript` → `data_source: "ai_subtitle"`、language `ai-zh`、正文非空；`exclude_ai_subtitles=true` → `NoSubtitleError`；默认 `get_video_info` → `ai_subtitle` 含 `subtitle_text`；exclude=true → description 不含 `subtitle_text`。live 分类、排除与双读成功已验证。live corrupt-body 拒绝与 ASR 回退未验证——`BV1ybuQ62EfK` 当前无目标字幕暴露，且未授权真实 ASR/模型运行；以 mock 矩阵 + post-build child smoke 替代。
+
+## Client Compatibility
+
+Mark untested clients explicitly.
+
+| Client | Version | Install method | Result | Notes |
+|--------|---------|----------------|--------|-------|
+| Claude Desktop |  |  | not tested | 本任务不接入客户端 |
+| Cursor |  |  | not tested | 本任务不接入客户端 |
+| Codex |  |  | not tested | 由 Paseo 编排，不接入 MCP 客户端 |
+| Other |  |  | not tested |  |
+
+## Documentation Checks
+
+- [x] README install command matches actual package behavior.
+- [x] Credential setup docs do not suggest putting Cookie values in MCP client config.
+- [x] README and README_EN agree on the supported setup path（含 `--non-interactive` 新增说明与 unconditional integrity 描述）。
+- [x] Changelog or release notes mention user-visible changes（CHANGELOG.md/EN.md Unreleased：integrity bullet 重写 + setup flags bullet）。
+- [x] Known limitations are documented when behavior is intentionally partial.（inconclusive pass / 阈值冻结 / 无授权回退 → `SUBTITLE_UNAVAILABLE` 均已写入 tool-reference）
+
+Notes:
+
+- tool-reference.md/.en.md、client-setup.md/.en.md、README.md/EN.md、CHANGELOG.md/EN.md 已同步；`docs/agent-memory/codemap.md` 已更新。
+
+## Security And Privacy Checks
+
+- [x] No full Cookie values, npm tokens, GitHub tokens, `.env` content, or private credentials appear in logs, reports, docs, tests, or package output.（secret-scanning 分类/计数报告；文档仅含 field-name 引用）
+- [x] Error messages and retry logs redact credential-like values（`redactSecrets`）。
+- [x] External inputs are validated before Bilibili API calls.（回归，无改动）
+- [x] Network responses that may be large or redirected are bounded or rejected according to current policy.（回归，无改动；完整性处理不记录/返回比较文本、token、hash、签名地址）
+
+Notes:
+
+- 完整性评估为纯函数模块，不产生网络/IO；不可用正文绝不进入结果与日志。
+
+## Result
+
+- Overall result: `pass with caveats`（以 mock 矩阵 + smoke 验证；live Bilibili 与真实 ASR 未验证）
+- Blocking issues: 无
+- Non-blocking caveats: live 分类/排除/双读已由 `BV15kyBB5Eg8` 验证；live corrupt-body 拒绝与真实 ASR 回退仍需人工 live check（`BV1ybuQ62EfK` 当前无目标字幕；未授权模型运行）；完整性阈值为冻结启发式，存在理论误判（inconclusive 时通过）
+- Follow-up tickets: 无（超出范围的问题另行提出）
+- Codemap update status: 已更新（subtitle.ts 条目修订 + 新增 subtitle-integrity.ts）
+- Research note link, if external facts affected QA: 不适用（无外部研究依赖）

--- a/docs/subtitle-integrity-and-scriptable-setup-prd.md
+++ b/docs/subtitle-integrity-and-scriptable-setup-prd.md
@@ -1,0 +1,168 @@
+# Product Requirements Document: Subtitle Integrity And Scriptable Setup
+
+**Version**: 1.2
+**Date**: 2026-08-18
+**Author**: Codex using `product-requirements`
+**Quality Score**: 96/100
+
+Revision 1.1 (2026-08-18): title-topic lexical overlap is removed as a hard
+rejection gate — it false-accepted unrelated tracks (cooking video vs Python
+tutorial) and false-rejected valid same-language discussion. Stability via
+collision-free canonical comparison and the conservative language check remain;
+a stable same-language semantic mismatch is an accepted limitation controlled
+by the caller through `force_asr` / `exclude_ai_subtitles`.
+
+Revision 1.2 (2026-08-18): AI classification widens from `ai-zh` to every
+`ai-*` language code. Live authenticated read-only evidence: public
+`BV15kyBB5Eg8` exposes subtitle languages `[ai-zh, ai-en, ai-ja, ai-es, ai-ar,
+ai-pt]`, and the ai-zh-only classifier silently selected `ai-en` under
+`exclude_ai_subtitles` — violating the AI-vs-human distinction. Every selected
+`ai-*` track is double-read for stability; the conservative Han-ratio language
+check applies to `ai-zh` only, and valid `ai-en`/`ai-ja` bodies are not
+rejected for being non-Chinese.
+
+## Executive Summary
+
+Complete GitHub Issue #40 and the directly named Roadmap defects. Bilibili
+`ai-*` tracks (`ai-zh`, `ai-en`, …) must remain visibly distinct from Human Subtitles, and their
+content must be rejected when deterministic stability or conservative language
+signals show that the track is unusable; a stable same-language semantic
+mismatch is an accepted limitation. Explicit ASR fallback then handles the
+selected Part, while `force_asr` remains the deterministic caller override.
+
+Make `setup` scriptable without accepting credentials in argv. A new explicit
+non-interactive mode uses credentials already supplied through the supported
+environment/global-config sources and optionally installs one allowlisted ASR
+model chosen by flag.
+
+## Requirements Quality
+
+- Business Value & Goals: 28/30
+- Functional Requirements: 25/25
+- User Experience: 18/20
+- Technical Constraints: 15/15
+- Scope & Priorities: 10/10
+
+The observed failure, public behavior, security boundary, deterministic test
+seams, compatibility rules, and delivery gates are explicit. No further product
+choice is required before implementation.
+
+## Problem Statement
+
+Issue #40 shows that Bilibili AI tracks (`ai-zh` and other `ai-*` languages)
+and Human Subtitles share the same public source label. The Roadmap adds a more serious failure: one Video returned unrelated,
+changing AI subtitle bodies repeatedly, yet track presence prevented ASR and
+the MCP returned the body unchanged.
+
+The current candidate separates `ai_subtitle`, adds AI exclusion and
+`force_asr`, but checks stability only with explicit ASR fallback. That still
+allows a default transcript or video-info call to return a known-bad AI body.
+It also does not address stable, high-confidence language mismatches;
+title-topic lexical overlap is a documented accepted limitation, not a
+rejection signal.
+
+Separately, `setup` rejects all non-TTY invocations, so automation cannot use
+the existing environment credential source and select an ASR model without
+driving hidden prompts.
+
+## Success Metrics
+
+- No selected `ai-*` body is returned until it passes deterministic integrity
+  assessment; Human Subtitles keep the existing single-read path.
+- An unusable AI track never exposes its text and follows the existing explicit
+  ASR/description fallback contract.
+- A changing body, a canonical-normalization collision, and a high-confidence
+  Chinese-language mismatch each have a red-before-green regression through
+  transcript and/or video-info public interfaces; a stable same-language body
+  is accepted regardless of title topic.
+- Inconclusive short/generic titles and short bodies are accepted rather than
+  guessed invalid.
+- `setup --non-interactive` works with a non-TTY stdin when credentials are
+  already loadable; `--asr-model tiny|base|small` selects the only optional ASR
+  work.
+- No credential value appears in argv, stdout, stderr, tests, docs, or reports.
+- Existing interactive setup, ten MCP tools, defaults, dependencies, model
+  allowlist, and release state remain unchanged.
+
+## Public Contract
+
+### AI subtitle integrity
+
+`data_source`, `exclude_ai_subtitles`, and `force_asr` keep the Issue #40
+candidate contract. Integrity assessment is not a new caller switch:
+
+1. Every selected Bilibili AI Subtitle is read twice.
+2. Different normalized timing/text bodies are unusable.
+3. A stable body with at least 80 Unicode letters and under 10% Han letters is
+   unusable as an `ai-zh` language mismatch. This language check applies to
+   `ai-zh` only; other `ai-*` languages are not rejected for being
+   non-Chinese.
+4. Title-topic lexical overlap is not assessed. A stable same-language body is
+   accepted even when it does not discuss the video title topic; callers
+   control this residual risk with `force_asr` or `exclude_ai_subtitles`
+   (accepted limitation, see Risks).
+5. If a threshold is not met, the signal is inconclusive and must not reject
+   the body.
+6. Integrity processing never logs or returns comparison text, tokens, hashes,
+   or signed subtitle URLs.
+
+When unusable:
+
+- `get_video_transcript` + `fallback_to_asr: true` runs existing ASR.
+- Otherwise transcript follows existing `fallback_to_description`; without an
+  authorized fallback it returns `SUBTITLE_UNAVAILABLE`.
+- `get_video_info` returns its existing description result and does not cache
+  the unusable result.
+- Second-read HTTP, timeout, authentication, and parse errors remain visible;
+  they are not converted to integrity failure or ASR.
+
+### Scriptable setup
+
+Add to `setup`:
+
+```text
+--non-interactive
+--asr-model <tiny|base|small>
+```
+
+- Non-interactive mode never calls hidden prompts and never reads credentials
+  from stdin or argv.
+- Credentials must already be loadable through supported environment variables
+  or global config. Missing/unloadable credentials produce exit code 1 and
+  actionable value-free guidance.
+- Without `--asr-model`, non-interactive setup performs no ASR installation and
+  exits successfully once credential readiness is confirmed.
+- With `--asr-model`, run the existing allowlisted installer exactly once.
+- `--asr-model` without `--non-interactive` is rejected with value-free usage
+  guidance rather than silently changing the interactive flow.
+- Existing interactive setup behavior remains unchanged.
+
+## Test Seams
+
+- `getVideoTranscriptData()` and `getVideoInfoWithSubtitle()` with injected
+  Bilibili/ASR boundaries; no private-helper tests.
+- `setupCredentials()` plus the Commander `createCli()` interface for option
+  declaration/validation.
+- One post-build child-process smoke with piped stdin and synthetic environment
+  credentials; output is checked not to contain their values.
+
+## Out Of Scope
+
+- LLM, embeddings, remote classifiers, new dependencies, configurable
+  thresholds, public integrity scores, or arbitrary language detection.
+- Validation of Human Subtitles, subtitle correction, multi-read voting, or
+  persistence of subtitle fingerprints.
+- Credentials on command lines or stdin, JSON credential import, new credential
+  storage, model IDs outside the existing allowlist, or background installation.
+- New MCP tools, package version, commit, push, PR, Issue mutation, release, or
+  publication.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Semantic false positive | Accepted limitation: stability and conservative language checks only; title-topic lexical overlap is not a gate. Inconclusive means usable; callers control residual risk via `force_asr` / `exclude_ai_subtitles`; ASR remains explicit. |
+| AI request cost doubles | Only Bilibili AI Subtitles are re-read; Human Subtitles remain one request. |
+| Transport failure hidden as corruption | Exceptions remain visible and never authorize ASR. |
+| Credential leakage in automation | Existing env/global sources only; no argv/stdin credential values; secret scan and child smoke. |
+| Interactive setup regression | Preserve the old path and its tests; non-interactive behavior is explicit. |

--- a/docs/tool-reference.en.md
+++ b/docs/tool-reference.en.md
@@ -26,6 +26,9 @@ This page preserves detailed behavior, parameters, examples, error contracts, an
 - Automatically falls back to video title, description, and tags if no subtitles are available.
 - Supports multi-language subtitle selection (defaults to Simplified Chinese).
 - Supports explicit subtitle languages `zh-Hans`, `zh-CN`, `zh-Hant`, `en`, `ja`, `ko`, and `ai-zh`; `ai-zh` reaches selection unchanged, while unsupported values return `VALIDATION_ERROR`.
+- When any of Bilibili's AI tracks (`ai-zh`, `ai-en`, etc.) is selected, `data_source` is `ai_subtitle` (not `subtitle`); `ai_subtitle` is Bilibili AI transcription, may be inaccurate, and is not equivalent to a human-checked citation.
+- Every selected `ai-*` track passes an unconditional integrity assessment first; an unusable track returns the description result (`data_source: "description"`) without caching, never its body.
+- Optional parameter `exclude_ai_subtitles`: filters out all Bilibili AI tracks (`ai-zh`, `ai-en`, etc.) so only human subtitles remain; AI-only results degrade to description (default `false`).
 
 ### 2. Comment Summarization (`get_video_comments`)
 - Retrieves popular comments to help gauge video sentiment.
@@ -48,6 +51,8 @@ This page preserves detailed behavior, parameters, examples, error contracts, an
   - `preferred_lang`: Preferred subtitle language code: `zh-Hans`, `zh-CN`, `zh-Hant`, `en`, `ja`, `ko`, or `ai-zh`. `ai-zh` reaches selection unchanged; unsupported values return `VALIDATION_ERROR`.
   - `fallback_to_description`: Fall back to video description if subtitles unavailable (default `false`).
   - `fallback_to_asr`: Run ready local ASR only after subtitles are definitively unavailable (default `false`).
+  - `exclude_ai_subtitles`: Filter out all Bilibili AI subtitles (`ai-zh`, `ai-en`, etc.) so only human subtitles remain; AI-only results are treated as definitive absence (default `false`).
+  - `force_asr`: Bypass subtitle metadata and content selection and transcribe the resolved Part with the ready local ASR, even when valid human subtitles exist; does not require `fallback_to_asr` and wins over `exclude_ai_subtitles` (default `false`).
   - `page`: Multi-Part video page number (1-based positive integer).
   - `include_timestamps`: Prefix each line with `[HH:MM:SS --> HH:MM:SS]`.
   - `start_seconds` / `end_seconds`: Only return segments overlapping this range.
@@ -56,7 +61,9 @@ This page preserves detailed behavior, parameters, examples, error contracts, an
   - `context_segments`: Context segments per match side (0-5, default 1).
 - By default, returns `SUBTITLE_UNAVAILABLE` error when no subtitles exist.
 - Precedence is fixed: native subtitles → explicit ASR → description only when both fallbacks are explicit and playback returns a valid empty audio set.
-- ASR starts only for a confirmed empty subtitle list, selected subtitle, or subtitle body. Cookie, HTTP, timeout, parse, anti-bot, and other API errors remain visible.
+- When any `ai-*` track is selected, `data_source` is `ai_subtitle`. Every selected `ai-*` track is unconditionally read twice and passes a deterministic integrity assessment before its body is returned: cross-read stability (two reads with different normalized bodies are unusable; applies to every `ai-*` language) and language (ai-zh only: a body with at least 80 Unicode letters and under 10% Han letters is an `ai-zh` mismatch; other `ai-*` languages are not rejected for being non-Chinese). Stable same-language bodies that are semantically off-topic are an accepted limitation, controlled by `force_asr` / `exclude_ai_subtitles`. Human subtitles stay single-read and are never assessed.
+- An unusable body is never returned: `fallback_to_asr: true` invokes the local ASR; otherwise the existing `fallback_to_description` contract applies, with `SUBTITLE_UNAVAILABLE` when no fallback is authorized; `get_video_info` returns the description result without caching it. A transport, timeout, auth, or parse failure on the second read remains visible and never becomes an integrity failure or ASR trigger.
+- ASR starts only for a confirmed empty subtitle list, selected subtitle, or subtitle body, an `ai-*` track judged unusable by the integrity assessment (stability; language for ai-zh only. ASR only with explicit `fallback_to_asr`), or explicit `force_asr`. Cookie, HTTP, timeout, parse, anti-bot, and other API errors remain visible.
 - ASR uses the ready setup-managed model on CPU INT8 and one temporary audio file. MCP calls never download or switch models.
 - Bounds: one Part up to 7,200 seconds; 128 MiB audio; 3 candidate URLs with 3 redirects each; 120-second download; 30-minute transcription; 2 MiB stdout; 10,000 segments; one active job and no queue.
 - Timestamps/range filtering/keyword search is incompatible with description fallback.
@@ -290,9 +297,9 @@ Request:
 }
 ```
 
-Returns: `bvid`, `title`, `language`, `transcript` (newline-joined), `data_source` (`subtitle`, `asr`, or `description`), `page`.
+Returns: `bvid`, `title`, `language`, `transcript` (newline-joined), `data_source` (`subtitle`, `ai_subtitle`, `asr`, or `description`), `page`.
 
-> `preferred_lang` accepts only `zh-Hans`, `zh-CN`, `zh-Hant`, `en`, `ja`, `ko`, or `ai-zh`. Explicit `ai-zh` is not rewritten to another language; unsupported values return `VALIDATION_ERROR`. The tool returns `SUBTITLE_UNAVAILABLE` when no subtitles exist. Set `fallback_to_description: true` to fall back.
+> `preferred_lang` accepts only `zh-Hans`, `zh-CN`, `zh-Hant`, `en`, `ja`, `ko`, or `ai-zh`. Explicit `ai-zh` is not rewritten to another language; unsupported values return `VALIDATION_ERROR`. The tool returns `SUBTITLE_UNAVAILABLE` when no subtitles exist. Set `fallback_to_description: true` to fall back. `data_source: "ai_subtitle"` means Bilibili's AI track was selected — it is AI transcription, may be inaccurate, and is not equivalent to a human-checked citation.
 
 **Explicit ASR fallback example**:
 
@@ -308,7 +315,21 @@ Returns: `bvid`, `title`, `language`, `transcript` (newline-joined), `data_sourc
 }
 ```
 
-Native subtitles always win. Only a definitively subtitle-free Video with a model reported ready by `doctor --json` can return `data_source: "asr"`. ASR segments reuse the same ranges, keyword/context search, `source_url`, and `timestamp_url` pipeline.
+Native subtitles always win. Only a definitively subtitle-free Video with a model reported ready by `doctor --json` can return `data_source: "asr"`. ASR segments reuse the same ranges, keyword/context search, `source_url`, and `timestamp_url` pipeline. `force_asr: true` bypasses subtitle selection and always uses the local ASR (without requiring `fallback_to_asr`).
+
+**Excluding AI subtitles example**:
+
+```json
+{
+  "name": "get_video_transcript",
+  "arguments": {
+    "bvid_or_url": "BV1xx411c7mD",
+    "exclude_ai_subtitles": true
+  }
+}
+```
+
+With `exclude_ai_subtitles: true`, selection considers human subtitles only; AI-only results are treated as definitive absence and may combine with `fallback_to_asr` or `fallback_to_description`.
 
 **Keyword search example**:
 
@@ -391,9 +412,9 @@ Request:
 }
 ```
 
-Returns: `data_source` (`subtitle` or `description`), `video_info` (title, description, tags, subtitle text, publish date).
+Returns: `data_source` (`subtitle`, `ai_subtitle`, or `description`), `video_info` (title, description, tags, subtitle text, publish date).
 
-> `preferred_lang` accepts only `zh-Hans`, `zh-CN`, `zh-Hant`, `en`, `ja`, `ko`, or `ai-zh`. Explicit `ai-zh` is not rewritten to another language; unsupported values return `VALIDATION_ERROR`. Videos without subtitles automatically degrade to description and tags (`data_source: "description"`).
+> `preferred_lang` accepts only `zh-Hans`, `zh-CN`, `zh-Hant`, `en`, `ja`, `ko`, or `ai-zh`. Explicit `ai-zh` is not rewritten to another language; unsupported values return `VALIDATION_ERROR`. Videos without subtitles automatically degrade to description and tags (`data_source: "description"`). `data_source: "ai_subtitle"` means Bilibili's AI track was selected — it is AI transcription, may be inaccurate, and is not equivalent to a human-checked citation. Pass `exclude_ai_subtitles: true` when only human subtitles are acceptable.
 
 ### `get_video_comments`
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -26,6 +26,9 @@
 - 无字幕时自动降级为视频标题、简介和标签
 - 支持多语言字幕选择（默认优先简体中文）
 - 可手动指定偏好字幕语言：`zh-Hans`、`zh-CN`、`zh-Hant`、`en`、`ja`、`ko`、`ai-zh`；`ai-zh` 会原样传入选择逻辑，未知值返回 `VALIDATION_ERROR`
+- 选中任意 Bilibili AI 识别字幕（`ai-zh`、`ai-en` 等 `ai-*` 语言）时结果 `data_source` 为 `ai_subtitle`（不是 `subtitle`）；`ai_subtitle` 是 Bilibili 的 AI 转录，可能不准确，不能当作人工校验过的引用
+- 每个选中的 `ai-*` 都会先做确定性完整性评估；不通过时返回简介结果（`data_source: "description"`）且不缓存，绝不返回不可用正文
+- 可选参数 `exclude_ai_subtitles`：排除全部 AI 字幕（`ai-zh`、`ai-en` 等 `ai-*` 语言），只保留人工字幕；仅剩 AI 字幕时视为无字幕并返回简介降级（默认 `false`）
 
 ### 2. 评论总结 (`get_video_comments`)
 - 获取视频热门评论，辅助判断视频真实口碑
@@ -49,6 +52,8 @@
   - `preferred_lang`: 偏好字幕语言代码，支持 `zh-Hans`、`zh-CN`、`zh-Hant`、`en`、`ja`、`ko`、`ai-zh`；`ai-zh` 会原样传入选择逻辑，未知值返回 `VALIDATION_ERROR`
   - `fallback_to_description`: 字幕不可用时是否降级为视频描述（默认 `false`）
   - `fallback_to_asr`: 确认无可用字幕时是否运行已就绪的本地 ASR（默认 `false`）
+  - `exclude_ai_subtitles`: 排除 Bilibili AI 识别字幕（`ai-zh`、`ai-en` 等 `ai-*` 语言），只保留人工字幕；仅剩 AI 字幕时视为无字幕（默认 `false`）
+  - `force_asr`: 绕过字幕元数据与内容选择，直接用已就绪的本地 ASR 转录当前 Part；无需同时设置 `fallback_to_asr`，优先于 `exclude_ai_subtitles`（默认 `false`）
   - `page`: 多P视频分集编号（从1开始的正整数）
   - `include_timestamps`: 每行添加 `[HH:MM:SS --> HH:MM:SS]` 时间戳前缀
   - `start_seconds` / `end_seconds`: 只返回与此区间重叠的字幕段
@@ -57,7 +62,9 @@
   - `context_segments`: 每个匹配前后的上下文段数（0-5，默认1）
 - 默认不降级：无字幕时返回 `SUBTITLE_UNAVAILABLE` 错误
 - 回退顺序固定为原生字幕 → 显式 ASR → 仅在播放 API 返回有效空音频集合且同时显式请求时使用视频描述
-- 只有字幕列表、选中字幕或字幕正文被确认为空时才触发 ASR；Cookie、HTTP、超时、解析、风控和其他 API 错误保持可见
+- 选中任意 `ai-*` 时 `data_source` 为 `ai_subtitle`。每个选中的 `ai-*` 都会无条件双读并做确定性完整性评估，通过后才返回正文：跨读取稳定性（两次读取的正文不一致即不可用，适用于所有 `ai-*`）、语言（仅针对 `ai-zh`：正文含至少 80 个 Unicode 字母且 Han 占比低于 10% 视为不匹配；其他 `ai-*` 语言不因非中文正文被拒绝）。稳定但同语言语义不符的正文是已接受的限制，可用 `force_asr` / `exclude_ai_subtitles` 控制。人工字幕保持单读且不做评估
+- 完整性评估不通过时绝不返回正文：`fallback_to_asr: true` 调用本地 ASR；否则遵循 `fallback_to_description`，无授权回退时返回 `SUBTITLE_UNAVAILABLE`；`get_video_info` 返回简介结果且不缓存。第二次读取的传输/超时/认证/解析错误照常可见，不会转化为完整性失败或触发 ASR
+- 只有字幕列表、选中字幕或字幕正文被确认为空、完整性评估判定选中的 `ai-*` 不可用（稳定性；语言仅针对 `ai-zh`。仅在显式开启 `fallback_to_asr` 时触发 ASR），或 `force_asr` 显式请求时才触发 ASR；Cookie、HTTP、超时、解析、风控和其他 API 错误保持可见
 - ASR 使用 setup 管理的 ready 模型、CPU INT8 和一个临时音频文件；MCP 调用不会下载或切换模型
 - 有界限制：单 Part 最长 7200 秒、音频 128 MiB、3 个候选地址/每个 3 次重定向、下载 120 秒、转录 30 分钟、stdout 2 MiB、10000 段、同时一个任务且不排队
 - 时间戳/区间过滤/关键词搜索与描述降级不兼容：请求 timed 输出或搜索时不会静默降级
@@ -294,9 +301,9 @@
 }
 ```
 
-返回内容：`bvid`、`title`、`language`、`transcript`（按行合并）、`data_source`（`subtitle`、`asr` 或 `description`）、`page`（分集编号）。
+返回内容：`bvid`、`title`、`language`、`transcript`（按行合并）、`data_source`（`subtitle`、`ai_subtitle`、`asr` 或 `description`）、`page`（分集编号）。
 
-> `preferred_lang` 仅接受 `zh-Hans`、`zh-CN`、`zh-Hant`、`en`、`ja`、`ko`、`ai-zh`；显式传入 `ai-zh` 不会被改写为其他语言，未知值返回 `VALIDATION_ERROR`。默认无字幕时返回 `SUBTITLE_UNAVAILABLE`。如需降级，设置 `fallback_to_description: true`。
+> `preferred_lang` 仅接受 `zh-Hans`、`zh-CN`、`zh-Hant`、`en`、`ja`、`ko`、`ai-zh`；显式传入 `ai-zh` 不会被改写为其他语言，未知值返回 `VALIDATION_ERROR`。默认无字幕时返回 `SUBTITLE_UNAVAILABLE`。如需降级，设置 `fallback_to_description: true`。`data_source: "ai_subtitle"` 表示选中了 Bilibili AI 识别字幕——它是 AI 转录，可能不准确，不能当作人工校验过的引用。
 
 **显式 ASR 回退示例**：
 
@@ -312,7 +319,21 @@
 }
 ```
 
-原生字幕始终优先。只有确认没有可用字幕且 `doctor --json` 报告 ready 时，结果才返回 `data_source: "asr"`；ASR 段继续使用相同的区间、关键词、上下文、`source_url` 和 `timestamp_url` 管线。
+原生字幕始终优先。只有确认没有可用字幕且 `doctor --json` 报告 ready 时，结果才返回 `data_source: "asr"`；ASR 段继续使用相同的区间、关键词、上下文、`source_url` 和 `timestamp_url` 管线。`force_asr: true` 可绕过字幕选择、无条件使用本地 ASR（无需同时设置 `fallback_to_asr`）。
+
+**排除 AI 字幕示例**：
+
+```json
+{
+  "name": "get_video_transcript",
+  "arguments": {
+    "bvid_or_url": "BV1xx411c7mD",
+    "exclude_ai_subtitles": true
+  }
+}
+```
+
+`exclude_ai_subtitles: true` 时只从人工字幕中选择；仅剩 AI 字幕（`ai-zh`、`ai-en` 等 `ai-*` 语言）时视为无字幕，可配合 `fallback_to_asr` 或 `fallback_to_description`。
 
 **关键词搜索示例**：
 
@@ -395,9 +416,9 @@
 }
 ```
 
-返回内容：`data_source`（`subtitle` 或 `description`）、`video_info`（标题、描述、标签、字幕文本、发布时间）。
+返回内容：`data_source`（`subtitle`、`ai_subtitle` 或 `description`）、`video_info`（标题、描述、标签、字幕文本、发布时间）。
 
-> `preferred_lang` 仅接受 `zh-Hans`、`zh-CN`、`zh-Hant`、`en`、`ja`、`ko`、`ai-zh`；显式传入 `ai-zh` 不会被改写为其他语言，未知值返回 `VALIDATION_ERROR`。无字幕视频会自动降级返回描述和标签（即 `data_source: "description"`）。
+> `preferred_lang` 仅接受 `zh-Hans`、`zh-CN`、`zh-Hant`、`en`、`ja`、`ko`、`ai-zh`；显式传入 `ai-zh` 不会被改写为其他语言，未知值返回 `VALIDATION_ERROR`。无字幕视频会自动降级返回描述和标签（即 `data_source: "description"`）。`data_source: "ai_subtitle"` 表示选中了 Bilibili AI 识别字幕——它是 AI 转录，可能不准确，不能当作人工校验过的引用。需要纯人工字幕时传 `exclude_ai_subtitles: true`。
 
 ### `get_video_comments`
 

--- a/src/bilibili/subtitle-integrity.ts
+++ b/src/bilibili/subtitle-integrity.ts
@@ -1,0 +1,69 @@
+// 确定性 AI 字幕完整性评估（所有 ai-* 语言；保守语言检查仅针对 ai-zh）。
+// 纯函数；阈值由 PRD 冻结（docs/subtitle-integrity-and-scriptable-setup-prd.md），
+// 不可配置、不通过 MCP 暴露。此模块绝不记录或返回比较文本、tokens、哈希或签名 URL。
+// 同语言下的语义偏差（稳定但主题不符的正文）是接受限制：由调用方的
+// force_asr / exclude_ai_subtitles 控制，本模块不做猜测性拒绝。
+import type { SubtitleBodyItem } from "./types.js";
+
+type AiSubtitleIntegrityVerdict =
+  | { usable: true }
+  | { usable: false; reason: string };
+
+/**
+ * 归一化后的逐段正文（精确 [from,to,content] 元组），用于跨读取稳定性比较。
+ * 只序列化这三个字段：SubtitleBodyItem 还有可选 location，且对象键序可能因
+ * 两次读取而异，直接 JSON.stringify(seg) 会把仅此差异的稳定正文误判为不稳定。
+ */
+function canonicalSubtitleBody(body: SubtitleBodyItem[]): string {
+  return body
+    .map((seg) => JSON.stringify([seg.from, seg.to, seg.content ?? ""]))
+    .join("\n");
+}
+
+function bodyText(body: SubtitleBodyItem[]): string {
+  return body.map((seg) => seg.content ?? "").join("\n");
+}
+
+function countLetters(text: string, pattern: RegExp): number {
+  let count = 0;
+  for (const ch of text) {
+    if (pattern.test(ch)) count += 1;
+  }
+  return count;
+}
+
+// 语言信号（仅 ai-zh）：正文达到 80 个及以上 Unicode 字母、且其中 Han 字母占比低于 10%，
+// 视为与 ai-zh 高置信不匹配；其他 ai-* 语言（ai-en/ai-ja/ai-es 等）不因非中文正文被拒绝。
+// 阈值不满足则信号 inconclusive，不得拒绝。
+function languageMismatch(body: SubtitleBodyItem[]): boolean {
+  const text = bodyText(body);
+  const letters = countLetters(text, /\p{L}/u);
+  if (letters < 80) return false;
+  const han = countLetters(text, /\p{Script=Han}/u);
+  return han / letters < 0.1;
+}
+
+/**
+ * 对选中的 ai-* 做无条件完整性评估：稳定性（所有 ai-*）→ 语言（仅 ai-zh）。
+ * 任一信号不通过即 unusable（reason 不含任何正文/比较内容）；
+ * 阈值不满足的检查一律 inconclusive 通过。
+ */
+export function assessAiSubtitleIntegrity(
+  firstBody: SubtitleBodyItem[],
+  secondBody: SubtitleBodyItem[],
+  trackLanguage: string,
+): AiSubtitleIntegrityVerdict {
+  if (canonicalSubtitleBody(firstBody) !== canonicalSubtitleBody(secondBody)) {
+    return {
+      usable: false,
+      reason: "AI subtitle returned inconsistent content across reads",
+    };
+  }
+  if (trackLanguage === "ai-zh" && languageMismatch(firstBody)) {
+    return {
+      usable: false,
+      reason: "AI subtitle body language does not match ai-zh",
+    };
+  }
+  return { usable: true };
+}

--- a/src/bilibili/subtitle.ts
+++ b/src/bilibili/subtitle.ts
@@ -14,6 +14,7 @@ import { logger, redactSecrets } from "../utils/logger.js";
 import { SECURITY_LIMITS, utf8ByteLength } from "../security/limits.js";
 import { throwIfAborted } from "../security/operation-context.js";
 import { boundedRemoteText } from "../utils/bounded-text.js";
+import { assessAiSubtitleIntegrity } from "./subtitle-integrity.js";
 import type {
   BilibiliSubtitleItem,
   PartInfo,
@@ -25,7 +26,7 @@ import type {
 
 
 export interface SubtitleData {
-  data_source: "subtitle" | "description";
+  data_source: "subtitle" | "ai_subtitle" | "description";
   video_info: {
     title: string;
     description: string;
@@ -72,6 +73,14 @@ async function verifyLoginForEmptySubtitles(bvid: string): Promise<void> {
 }
 
 
+
+/**
+ * 判断字幕是否为 Bilibili AI 识别字幕（任意 ai-* 语言，如 ai-zh/ai-en/ai-ja）。
+ * transcript 与 video-info 两个流程共用此分类：data_source、排除与双读均以它为准。
+ */
+function isAiSubtitle(subtitle: BilibiliSubtitleItem): boolean {
+  return subtitle.lan.startsWith("ai-");
+}
 
 /**
  * 选择最佳字幕语言
@@ -290,6 +299,8 @@ export async function getVideoTranscriptData(
   endSeconds?: number,
   searchOptions?: TranscriptSearchOptions,
   fallbackToAsr?: boolean,
+  excludeAiSubtitles?: boolean,
+  forceAsr?: boolean,
   signal?: AbortSignal,
 ): Promise<VideoTranscriptData> {
   throwIfAborted(signal);
@@ -304,7 +315,7 @@ export async function getVideoTranscriptData(
 
   const buildSegmentResult = (
     body: SubtitleBodyItem[],
-    dataSource: "subtitle" | "asr",
+    dataSource: "subtitle" | "ai_subtitle" | "asr",
     language?: string,
   ): VideoTranscriptData => {
     const filteredBody = filterSegmentsByRange(body, startSeconds, endSeconds);
@@ -387,8 +398,9 @@ export async function getVideoTranscriptData(
 
   const handleDefinitiveSubtitleAbsence = async (
     reason: string,
+    runAsr = fallbackToAsr,
   ): Promise<VideoTranscriptData> => {
-    if (fallbackToAsr) {
+    if (runAsr) {
       throwIfAborted(signal);
       const exactPart = pages.find((part) => part.cid === cid);
       const durationSeconds =
@@ -428,6 +440,14 @@ export async function getVideoTranscriptData(
     return buildDescriptionFallback(reason);
   };
 
+  // force_asr 显式授权运行本地 ASR：绕过字幕元数据与内容选择
+  if (forceAsr) {
+    return await handleDefinitiveSubtitleAbsence(
+      "ASR was explicitly requested with force_asr: true",
+      true,
+    );
+  }
+
   // 获取字幕列表
   try {
     const subtitleData = await getVideoSubtitle(bvid, cid);
@@ -442,8 +462,19 @@ export async function getVideoTranscriptData(
       );
     }
 
+    let availableSubtitles = subtitleData.subtitle.subtitles;
+    if (excludeAiSubtitles) {
+      const humanSubtitles = availableSubtitles.filter((s) => !isAiSubtitle(s));
+      if (humanSubtitles.length === 0) {
+        return await handleDefinitiveSubtitleAbsence(
+          `Video ${bvid} has only AI subtitles and exclude_ai_subtitles is enabled`,
+        );
+      }
+      availableSubtitles = humanSubtitles;
+    }
+
     const bestSubtitle = selectBestSubtitle(
-      subtitleData.subtitle.subtitles,
+      availableSubtitles,
       preferredLang,
     );
 
@@ -463,7 +494,28 @@ export async function getVideoTranscriptData(
       );
     }
 
-    return buildSegmentResult(subtitleContent.body, "subtitle", bestSubtitle.lan);
+    // 对每个选中的 ai-* 无条件做确定性完整性评估（稳定性 → 语言，语言仅针对 ai-zh）；
+    // 不通过则绝不返回正文，进入既有确定性缺失路径（ASR/description/错误）；
+    // 同语言语义偏差为接受限制（force_asr/exclude_ai_subtitles 控制）；人工字幕保持单读路径
+    if (isAiSubtitle(bestSubtitle)) {
+      const secondContent = await getSubtitleContent(bestSubtitle.subtitle_url);
+      const assessment = assessAiSubtitleIntegrity(
+        subtitleContent?.body ?? [],
+        secondContent?.body ?? [],
+        bestSubtitle.lan,
+      );
+      if (!assessment.usable) {
+        return await handleDefinitiveSubtitleAbsence(
+          `AI subtitle ${bvid} ${assessment.reason}`,
+        );
+      }
+    }
+
+    return buildSegmentResult(
+      subtitleContent.body,
+      isAiSubtitle(bestSubtitle) ? "ai_subtitle" : "subtitle",
+      bestSubtitle.lan,
+    );
   } catch (error) {
     // COOKIE_EXPIRED must propagate
     if (
@@ -499,12 +551,13 @@ export async function getVideoInfoWithSubtitle(
   bvidOrUrl: string,
   preferredLang?: string,
   page?: number,
+  excludeAiSubtitles?: boolean,
 ): Promise<SubtitleData> {
   try {
     const bvid = extractBVId(bvidOrUrl);
 
-    // 生成缓存键（包含 page）— 在 resolvePartCid 之前检查以避免网络请求
-    const cacheKey = cacheManager.generateKey('video', bvid, preferredLang, page);
+    // 生成缓存键（包含 page 与 exclude 选项）— 在 resolvePartCid 之前检查以避免网络请求
+    const cacheKey = cacheManager.generateKey('video', bvid, preferredLang, page, excludeAiSubtitles ?? false);
     const cachedData = cacheManager.getVideoInfo(cacheKey) as SubtitleData | undefined;
     if (cachedData) {
       logger.debug("Video cache hit", { bvid, cacheKey }, { type: "subtitle" });
@@ -521,6 +574,18 @@ export async function getVideoInfoWithSubtitle(
     const pubdate = videoData.pubdate;
     const formattedDate = pubdate ? formatPublishDate(pubdate) : undefined;
 
+    // 简介降级结果（无字幕/被过滤/不可用统一路径）
+    const descriptionFallback = (): SubtitleData => ({
+      data_source: "description",
+      video_info: {
+        title,
+        description: description || "该视频没有可用的简介",
+        tags: tags.length > 0 ? tags : ["无标签"],
+        pubdate: formattedDate,
+        pubdate_timestamp: pubdate,
+      },
+    });
+
     // 尝试获取字幕
     try {
       const subtitleData = await getVideoSubtitle(bvid, cid);
@@ -535,16 +600,7 @@ export async function getVideoInfoWithSubtitle(
           { type: "subtitle" },
         );
 
-        const result: SubtitleData = {
-          data_source: "description",
-          video_info: {
-            title,
-            description: description || "该视频没有可用的简介",
-            tags: tags.length > 0 ? tags : ["无标签"],
-            pubdate: formattedDate,
-            pubdate_timestamp: pubdate,
-          },
-        };
+        const result = descriptionFallback();
         // 不缓存无字幕结果，以便下次重试时能拉取最新生成的字幕
         logger.debug(
           "Not caching fallback result to allow future retries",
@@ -555,19 +611,25 @@ export async function getVideoInfoWithSubtitle(
       }
 
       // 选择最佳字幕
-      const bestSubtitle = selectBestSubtitle(subtitleData.subtitle.subtitles, preferredLang);
+      const availableSubtitles = excludeAiSubtitles
+        ? subtitleData.subtitle.subtitles.filter((s) => !isAiSubtitle(s))
+        : subtitleData.subtitle.subtitles;
+
+      if (availableSubtitles.length === 0) {
+        const result = descriptionFallback();
+        // 不缓存无字幕结果，以便下次重试时能拉取最新生成的字幕
+        logger.debug(
+          "Not caching exclude-filtered fallback result to allow future retries",
+          { bvid },
+          { type: "subtitle" },
+        );
+        return result;
+      }
+
+      const bestSubtitle = selectBestSubtitle(availableSubtitles, preferredLang);
 
       if (!bestSubtitle) {
-        const result: SubtitleData = {
-          data_source: "description",
-          video_info: {
-            title,
-            description: description || "该视频没有可用的简介",
-            tags: tags.length > 0 ? tags : ["无标签"],
-            pubdate: formattedDate,
-            pubdate_timestamp: pubdate,
-          },
-        };
+        const result = descriptionFallback();
         // 不缓存无字幕结果，以便下次重试时能拉取最新生成的字幕
         logger.debug(
           "Not caching fallback result to allow future retries",
@@ -581,16 +643,7 @@ export async function getVideoInfoWithSubtitle(
       const subtitleContent = await getSubtitleContent(bestSubtitle.subtitle_url);
 
       if (!subtitleContent?.body || subtitleContent.body.length === 0) {
-        const result: SubtitleData = {
-          data_source: "description",
-          video_info: {
-            title,
-            description: description || "该视频没有可用的简介",
-            tags: tags.length > 0 ? tags : ["无标签"],
-            pubdate: formattedDate,
-            pubdate_timestamp: pubdate,
-          },
-        };
+        const result = descriptionFallback();
         // 不缓存无字幕结果，以便下次重试时能拉取最新生成的字幕
         logger.debug(
           "Not caching fallback result to allow future retries",
@@ -600,11 +653,31 @@ export async function getVideoInfoWithSubtitle(
         return result;
       }
 
+      // 对选中的 ai-* 无条件做确定性完整性评估（语言仅针对 ai-zh）；不通过则返回 description 且不缓存
+      if (isAiSubtitle(bestSubtitle)) {
+        const secondContent = await getSubtitleContent(bestSubtitle.subtitle_url);
+        const assessment = assessAiSubtitleIntegrity(
+          subtitleContent.body,
+          secondContent?.body ?? [],
+          bestSubtitle.lan,
+        );
+        if (!assessment.usable) {
+          const result = descriptionFallback();
+          // 不缓存不可用结果，以便下次重试时能拉取最新生成的字幕
+          logger.debug(
+            "Not caching unusable ai-* fallback result to allow future retries",
+            { bvid },
+            { type: "subtitle" },
+          );
+          return result;
+        }
+      }
+
       // 合并字幕文本
       const subtitleText = mergeSubtitleText(subtitleContent.body);
 
       const result: SubtitleData = {
-        data_source: "subtitle",
+        data_source: isAiSubtitle(bestSubtitle) ? "ai_subtitle" : "subtitle",
         video_info: {
           title,
           description,

--- a/src/bilibili/types.ts
+++ b/src/bilibili/types.ts
@@ -110,7 +110,7 @@ export interface ProcessedComment {
 
 // 视频总结响应类型
 export interface VideoSummary {
-  data_source: 'subtitle' | 'description';
+  data_source: 'subtitle' | 'ai_subtitle' | 'description';
   video_info: {
     title: string;
     description: string;
@@ -182,7 +182,7 @@ export interface TranscriptMatch {
 // 视频转录数据类型
 export interface VideoTranscriptData {
   bvid: string;
-  data_source: "subtitle" | "description" | "asr";
+  data_source: "subtitle" | "ai_subtitle" | "description" | "asr";
   language?: string;
   transcript: string;
   title: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -269,11 +269,67 @@ export function doctorCommand(
   }
 }
 
+export interface SetupCredentialsOptions {
+  /** 非交互模式：绝不提示，也绝不从 stdin/argv 读取凭据值 */
+  nonInteractive?: boolean;
+  /** 允许列表内的 ASR 模型（仅非交互模式可用） */
+  asrModel?: AsrModelKey;
+}
+
 export async function setupCredentials(
   configure: () => Promise<boolean | void> = configureCredentials,
   runAsr: (modelKey: AsrModelKey) => Promise<{ success: boolean; error?: string }> = async () => ({ success: false, error: "installer not injected" }),
   askHiddenFn: (question: string) => Promise<string> = askHidden,
+  options: SetupCredentialsOptions = {},
 ) {
+  // --asr-model 未与 --non-interactive 同时使用：验证错误，绝不静默改变交互流程
+  if (options.asrModel !== undefined && !options.nonInteractive) {
+    console.error("Error: --asr-model requires --non-interactive.");
+    console.error(
+      "Run: bilibili-mcp setup --non-interactive --asr-model <tiny|base|small>",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // 非交互模式：只接受 env/global config 来源的可加载凭据（内存中已有值不算，
+  // 进程内不可复现），绝不提示、也绝不从 stdin/argv 读取凭据值
+  if (options.nonInteractive) {
+    const source = credentialManager.getCredentialSource();
+    const creds = credentialManager.getCredentials();
+    if (source === "none" || creds === null) {
+      console.error(
+        "Error: setup --non-interactive requires loadable credentials from environment variables or the global config file.",
+      );
+      console.error(
+        "Set BILIBILI_SESSDATA, BILIBILI_BILI_JCT, and BILIBILI_DEDEUSERID, or run 'bilibili-mcp setup' once interactively.",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.log(
+      "Credentials are loadable; non-interactive setup proceeds without prompting.",
+    );
+    if (options.asrModel === undefined) {
+      console.log("No --asr-model given; setup complete without ASR installation.");
+      return;
+    }
+    const result = await runAsr(options.asrModel);
+    if (result.success) {
+      console.log("✅ ASR 模型安装成功并通过 CPU INT8 验证。");
+      console.log(`   管理路径：~/.bilibili-mcp/asr/`);
+      console.log(
+        "   运行 bilibili-mcp doctor --json 可查看 ASR 状态。",
+      );
+    } else {
+      console.error(`❌ ASR 安装失败：${redactSecrets(result.error) ?? "未知错误"}`);
+      console.log("   已保留部分下载文件，重新运行 setup 可从断点续传。");
+      console.log("   当前 MCP 服务不受影响，字幕回退为 SUBTITLE_UNAVAILABLE。");
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   if (!process.stdin.isTTY) {
     console.error(
       "Error: setup requires an interactive terminal (TTY).",
@@ -391,12 +447,36 @@ export function createCli() {
 
   cli
     .command("setup")
-    .description("交互式配置 Bilibili 凭证和可选 ASR（需要终端）")
-    .action(async () =>
-      setupCredentials(configureCredentials, async (modelKey: AsrModelKey) =>
-        runAsrInstallation({ modelKey, onStage: (s) => console.log(`  ${s}`) }),
-      ),
-    );
+    .description("配置 Bilibili 凭证和可选 ASR（交互式需要终端，--non-interactive 供自动化使用）")
+    .option("--non-interactive", "非交互模式：使用已有的 env/global config 凭据，绝不提示")
+    .option("--asr-model <tiny|base|small>", "非交互模式下的 ASR 模型（需与 --non-interactive 同用）")
+    .action(async (cmdOptions: { nonInteractive?: boolean; asrModel?: string }) => {
+      const options: SetupCredentialsOptions = {
+        nonInteractive: Boolean(cmdOptions.nonInteractive),
+      };
+      if (cmdOptions.asrModel !== undefined) {
+        const key = cmdOptions.asrModel.trim().toLowerCase() as AsrModelKey;
+        let resolvedKey: AsrModelKey | undefined;
+        try {
+          resolvedKey = resolveModelSpec(key).key;
+        } catch {
+          resolvedKey = undefined;
+        }
+        if (resolvedKey === undefined) {
+          console.error("Error: --asr-model must be one of: tiny, base, small");
+          process.exitCode = 1;
+          return;
+        }
+        options.asrModel = resolvedKey;
+      }
+      await setupCredentials(
+        configureCredentials,
+        async (modelKey: AsrModelKey) =>
+          runAsrInstallation({ modelKey, onStage: (s) => console.log(`  ${s}`) }),
+        askHidden,
+        options,
+      );
+    });
 
   cli
     .command("version")

--- a/src/server/tool-handlers.ts
+++ b/src/server/tool-handlers.ts
@@ -84,19 +84,21 @@ export async function handleToolCall(
       const bvidOrUrl = args?.bvid_or_url as string;
       const preferredLang = args?.preferred_lang as string | undefined;
       const page = args?.page as number | undefined;
+      const excludeAiSubtitles = (args?.exclude_ai_subtitles as boolean) || false;
 
       let sanitizedBvidOrUrl: string;
       try {
         validateBVInput(bvidOrUrl);
         validateLanguage(preferredLang);
         validatePage(page);
+        validateBoolean(args?.exclude_ai_subtitles, "exclude_ai_subtitles");
         sanitizedBvidOrUrl = sanitizeBVInput(bvidOrUrl);
       } catch (error) {
         return toErrorTextContent(buildValidationErrorPayload(error));
       }
 
       const normalizedLang = getPreferredLanguage(preferredLang);
-      const result = await getVideoInfoWithSubtitle(sanitizedBvidOrUrl, normalizedLang, page);
+      const result = await getVideoInfoWithSubtitle(sanitizedBvidOrUrl, normalizedLang, page, excludeAiSubtitles);
 
       return toTextContent(result);
     }
@@ -137,6 +139,8 @@ export async function handleToolCall(
       const preferredLang = args?.preferred_lang as string | undefined;
       const fallbackToDescription = (args?.fallback_to_description as boolean) || false;
       const fallbackToAsr = (args?.fallback_to_asr as boolean) || false;
+      const excludeAiSubtitles = (args?.exclude_ai_subtitles as boolean) || false;
+      const forceAsr = (args?.force_asr as boolean) || false;
       const page = args?.page as number | undefined;
       const includeTimestamps = args?.include_timestamps as boolean | undefined;
       const startSeconds = args?.start_seconds as number | undefined;
@@ -149,17 +153,13 @@ export async function handleToolCall(
       try {
         validateBVInput(bvidOrUrl);
         validateLanguage(preferredLang);
-        validateBoolean(fallbackToDescription, "fallback_to_description");
-        validateBoolean(fallbackToAsr, "fallback_to_asr");
         validatePage(page);
+        validateBoolean(args?.fallback_to_description, "fallback_to_description");
+        validateBoolean(args?.fallback_to_asr, "fallback_to_asr");
         validateBoolean(includeTimestamps, "include_timestamps");
         validateTimestampRange(startSeconds, endSeconds);
-        if (args?.fallback_to_description !== undefined && typeof args.fallback_to_description !== "boolean") {
-          throw new ValidationError("fallback_to_description must be a boolean");
-        }
-        if (args?.fallback_to_asr !== undefined && typeof args.fallback_to_asr !== "boolean") {
-          throw new ValidationError("fallback_to_asr must be a boolean");
-        }
+        validateBoolean(args?.exclude_ai_subtitles, "exclude_ai_subtitles");
+        validateBoolean(args?.force_asr, "force_asr");
         validateQuery(query);
         validateMaxMatches(maxMatches);
         validateContextSegments(contextSegments);
@@ -189,6 +189,8 @@ export async function handleToolCall(
           endSeconds,
           searchOptions,
           fallbackToAsr,
+          excludeAiSubtitles,
+          forceAsr,
         ] as const;
         const result = signal === undefined
           ? await getVideoTranscriptData(...transcriptArgs)

--- a/src/server/tool-schemas.ts
+++ b/src/server/tool-schemas.ts
@@ -56,6 +56,11 @@ export const toolSchemas: Tool[] = [
           description:
             "可选，多P视频的分集编号（从1开始的正整数）。不指定时使用默认CID。",
         },
+        exclude_ai_subtitles: {
+          type: "boolean",
+          description:
+            "可选，排除 Bilibili AI 识别字幕（ai-zh、ai-en 等全部 ai-* 语言），只保留人工字幕；仅剩 AI 字幕时视为无字幕并返回简介。默认 false。Optional; filters out Bilibili AI subtitles (all ai-* languages such as ai-zh and ai-en) so only human subtitles remain. Default false.",
+        },
       },
       required: ["bvid_or_url"],
     },
@@ -126,6 +131,16 @@ export const toolSchemas: Tool[] = [
           description:
             "确认没有可用字幕时，是否使用已通过 setup 安装并由 doctor 确认 ready 的本地 ASR。默认 false；不会在 MCP 调用中下载或切换模型。",
         },
+        exclude_ai_subtitles: {
+          type: "boolean",
+          description:
+            "可选，排除 Bilibili AI 识别字幕（ai-zh、ai-en 等全部 ai-* 语言），只保留人工字幕；仅剩 AI 字幕时视为无字幕（可配合 fallback_to_asr / fallback_to_description）。默认 false。Optional; filters out Bilibili AI subtitles (all ai-* languages such as ai-zh and ai-en). Default false.",
+        },
+        force_asr: {
+          type: "boolean",
+          description:
+            "可选，绕过字幕元数据与内容选择，直接使用已安装的本地 ASR 转录当前分集；即使存在有效人工字幕也生效，无需同时设置 fallback_to_asr。默认 false。Optional; bypasses subtitle selection and always uses the local ASR. Default false.",
+        },
         page: {
           type: "integer",
           minimum: 1,
@@ -176,7 +191,7 @@ export const toolSchemas: Tool[] = [
         bvid: { type: "string" },
         data_source: {
           type: "string",
-          enum: ["subtitle", "description", "asr"],
+          enum: ["subtitle", "ai_subtitle", "description", "asr"],
         },
         language: { type: "string" },
         transcript: { type: "string" },

--- a/tests/bilibili-transcript.test.ts
+++ b/tests/bilibili-transcript.test.ts
@@ -37,7 +37,9 @@ function makeFakeSubtitles(subs: Array<Record<string, unknown>>) {
   };
 }
 
-function makeFakeSubtitleContent(body: Array<{ from: number; to: number; content: string }>) {
+function makeFakeSubtitleContent(
+  body: Array<{ from: number; to: number; content: string; location?: number }>,
+) {
   return { body };
 }
 
@@ -107,6 +109,7 @@ function getTranscriptWithAsr(
     startSeconds?: number;
     endSeconds?: number;
     search?: TranscriptSearchOptions;
+    forceAsr?: boolean;
     signal?: AbortSignal;
   } = {},
 ) {
@@ -120,6 +123,8 @@ function getTranscriptWithAsr(
     options.endSeconds,
     options.search,
     true,
+    undefined,
+    options.forceAsr,
     options.signal,
   );
 }
@@ -188,6 +193,51 @@ describe("getVideoTranscriptData - subtitle success", () => {
 
     expect(result.data_source).toBe("description");
     expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+  });
+});
+
+describe("getVideoInfoWithSubtitle - ai-zh integrity assessment", () => {
+  it("returns description and does not cache an unstable ai-zh body", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    mockGetSubtitleContent
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "First" }]))
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "Second" }]));
+
+    const first = await getVideoInfoWithSubtitle("BV1T6PQzQErF");
+    mockGetSubtitleContent
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "Third" }]))
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "Fourth" }]));
+    const second = await getVideoInfoWithSubtitle("BV1T6PQzQErF");
+
+    expect(first.data_source).toBe("description");
+    expect(first.video_info.subtitle_text).toBeUndefined();
+    expect(second.data_source).toBe("description");
+    expect(mockGetVideoSubtitle).toHaveBeenCalledTimes(2);
+    expect(mockGetSubtitleContent).toHaveBeenCalledTimes(4);
+  });
+
+  it("returns description for a stable non-Chinese ai-zh body", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    const englishBody = [
+      "The quick brown fox jumps over the lazy dog while waiting for the train to arrive at the station this morning without any delay.",
+      "Farmers harvest the ripe wheat fields and load the golden grain onto wooden carts before the evening rain begins to fall.",
+    ];
+    mockGetSubtitleContent.mockResolvedValue(
+      makeFakeSubtitleContent(englishBody.map((content) => ({ from: 0, to: 1, content }))),
+    );
+
+    const result = await getVideoInfoWithSubtitle("BV1T6PQzQErF");
+
+    expect(result.data_source).toBe("description");
+    expect(result.video_info.subtitle_text).toBeUndefined();
   });
 });
 
@@ -1088,6 +1138,522 @@ describe("getVideoTranscriptData - evidence links", () => {
     await expect(
       getVideoTranscriptData("BV1T6PQzQErF", undefined, true),
     ).rejects.toThrow("Network down");
+  });
+});
+
+describe("getVideoTranscriptData - AI subtitle classification", () => {
+  it('returns data_source "ai_subtitle" for a selected Bilibili ai-zh track', async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+
+    const result = await getVideoTranscriptData("BV1T6PQzQErF");
+
+    expect(result.data_source).toBe("ai_subtitle");
+    expect(result.language).toBe("ai-zh");
+  });
+
+  it('returns data_source "ai_subtitle" for a stable ai-en track after a double read', async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-en", lan_doc: "AI English", subtitle_url: "//example.test/ai-en.json" },
+      ]),
+    );
+    // 80+ 字母的纯英文正文：若语言检查被错误地应用到 ai-en，此正文会触发 ai-zh 的不匹配信号
+    const englishBody =
+      "This is a stable English AI subtitle body with well over eighty letters in total across the whole transcript.";
+    mockGetSubtitleContent.mockResolvedValue(
+      makeFakeSubtitleContent([{ from: 0, to: 1, content: englishBody }]),
+    );
+
+    const result = await getVideoTranscriptData("BV1T6PQzQErF");
+
+    expect(result.data_source).toBe("ai_subtitle");
+    expect(result.language).toBe("ai-en");
+    // 每个选中的 ai-* 都至少做一次双读稳定性检查
+    expect(mockGetSubtitleContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a stable human subtitle on the single-read path", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 1, lan: "zh-Hans", lan_doc: "Chinese", subtitle_url: "//example.test/zh.json" },
+      ]),
+    );
+
+    const result = await getVideoTranscriptData("BV1T6PQzQErF");
+
+    expect(result.data_source).toBe("subtitle");
+    expect(result.language).toBe("zh-Hans");
+    // 人工字幕不进入 AI 双读/完整性评估路径
+    expect(mockGetSubtitleContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns data_source "ai_subtitle" in transcript search mode', async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+
+    const result = await getVideoTranscriptData(
+      "BV1T6PQzQErF",
+      undefined,
+      false,
+      undefined,
+      false,
+      undefined,
+      undefined,
+      searchOpts("Hello"),
+    );
+
+    expect(result.data_source).toBe("ai_subtitle");
+  });
+});
+
+describe("getVideoInfoWithSubtitle - AI subtitle classification", () => {
+  it('returns data_source "ai_subtitle" for an ai-zh track', async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+
+    const result = await getVideoInfoWithSubtitle("BV1T6PQzQErF");
+
+    expect(result.data_source).toBe("ai_subtitle");
+    expect(result.video_info.subtitle_text).toBe("Hello\nWorld");
+  });
+});
+
+describe("getVideoTranscriptData - exclude_ai_subtitles", () => {
+  it("prefers a remaining human subtitle when exclude_ai_subtitles is true", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 1, lan: "zh-Hans", lan_doc: "Chinese", subtitle_url: "//example.test/zh.json" },
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+
+    const result = await getVideoTranscriptData(
+      "BV1T6PQzQErF",
+      "ai-zh",
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      true,
+    );
+
+    expect(result.data_source).toBe("subtitle");
+    expect(result.language).toBe("zh-Hans");
+    expect(mockGetSubtitleContent).toHaveBeenCalledWith("//example.test/zh.json");
+  });
+
+  it("treats AI-only rows as definitive absence with exclude_ai_subtitles", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+
+    await expect(
+      getVideoTranscriptData(
+        "BV1T6PQzQErF",
+        undefined,
+        false,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        true,
+      ),
+    ).rejects.toBeInstanceOf(NoSubtitleError);
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+  });
+
+  it("filters the full ai-* set (ai-zh + ai-en) to definitive absence with exclude_ai_subtitles", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+        { id: 4, lan: "ai-en", lan_doc: "AI English", subtitle_url: "//example.test/ai-en.json" },
+      ]),
+    );
+
+    await expect(
+      getVideoTranscriptData(
+        "BV1T6PQzQErF",
+        undefined,
+        false,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        true,
+      ),
+    ).rejects.toBeInstanceOf(NoSubtitleError);
+    expect(mockGetSubtitleContent).not.toHaveBeenCalled();
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+  });
+
+  it("invokes ASR when exclude_ai_subtitles leaves only AI rows and fallback_to_asr is true", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+
+    const result = await getVideoTranscriptData(
+      "BV1T6PQzQErF",
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+      true,
+    );
+
+    expect(result.data_source).toBe("asr");
+    expect(mockTranscribeVideoPart).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getVideoInfoWithSubtitle - exclude_ai_subtitles", () => {
+  it("returns description for AI-only rows without caching the result", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+
+    const first = await getVideoInfoWithSubtitle("BV1T6PQzQErF", undefined, undefined, true);
+    expect(first.data_source).toBe("description");
+
+    const second = await getVideoInfoWithSubtitle("BV1T6PQzQErF", undefined, undefined, true);
+    expect(second.data_source).toBe("description");
+    expect(mockGetVideoSubtitle).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns description for an AI-only ai-zh + ai-en set with exclude_ai_subtitles", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+        { id: 4, lan: "ai-en", lan_doc: "AI English", subtitle_url: "//example.test/ai-en.json" },
+      ]),
+    );
+
+    const result = await getVideoInfoWithSubtitle("BV1T6PQzQErF", undefined, undefined, true);
+
+    expect(result.data_source).toBe("description");
+    expect(mockGetSubtitleContent).not.toHaveBeenCalled();
+  });
+
+  it("prefers a human subtitle and caches under an exclude-aware key", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 1, lan: "zh-Hans", lan_doc: "Chinese", subtitle_url: "//example.test/zh.json" },
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+
+    const excluded = await getVideoInfoWithSubtitle("BV1T6PQzQErF", undefined, undefined, true);
+    expect(excluded.data_source).toBe("subtitle");
+    expect(excluded.video_info.subtitle_text).toBe("Hello\nWorld");
+
+    const included = await getVideoInfoWithSubtitle("BV1T6PQzQErF");
+    expect(included.data_source).toBe("subtitle");
+    expect(mockGetVideoSubtitle).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("getVideoTranscriptData - force_asr", () => {
+  it("invokes ASR with force_asr even without fallback_to_asr", async () => {
+    const result = await getVideoTranscriptData(
+      "BV1T6PQzQErF",
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      false,
+      true,
+    );
+
+    expect(result.data_source).toBe("asr");
+    expect(mockTranscribeVideoPart).toHaveBeenCalledTimes(1);
+    expect(mockGetVideoSubtitle).not.toHaveBeenCalled();
+  });
+
+  it("force_asr bypasses a valid human subtitle track", async () => {
+    const result = await getVideoTranscriptData(
+      "BV1T6PQzQErF",
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      false,
+      true,
+    );
+
+    expect(result.data_source).toBe("asr");
+    expect(mockGetSubtitleContent).not.toHaveBeenCalled();
+  });
+
+  it("force_asr wins over exclude_ai_subtitles", async () => {
+    const result = await getVideoTranscriptData(
+      "BV1T6PQzQErF",
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      true,
+      true,
+    );
+
+    expect(result.data_source).toBe("asr");
+    expect(mockTranscribeVideoPart).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getVideoTranscriptData - unstable ai-zh with explicit ASR fallback", () => {
+  it("invokes ASR when two reads of the same ai-zh track differ", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    mockGetSubtitleContent
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "First" }]))
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "Second" }]));
+
+    const result = await getTranscriptWithAsr();
+
+    expect(result.data_source).toBe("asr");
+    expect(mockTranscribeVideoPart).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a stable ai-zh track native without invoking ASR", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+
+    const result = await getTranscriptWithAsr();
+
+    expect(result.data_source).toBe("ai_subtitle");
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+    expect(mockGetSubtitleContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates a second-read transport failure without invoking ASR", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    mockGetSubtitleContent
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "First" }]))
+      .mockRejectedValueOnce(new Error("Temporary network failure"));
+
+    await expect(getTranscriptWithAsr()).rejects.toThrow("Temporary network failure");
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+  });
+});
+
+describe("getVideoTranscriptData - unconditional ai-zh integrity assessment", () => {
+  it("rejects an unstable ai-zh body without any fallback", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    mockGetSubtitleContent
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "First" }]))
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "Second" }]));
+
+    await expect(getVideoTranscriptData("BV1T6PQzQErF")).rejects.toBeInstanceOf(NoSubtitleError);
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+  });
+
+  it("keeps a stable ai-zh body native after a double read", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+
+    const result = await getVideoTranscriptData("BV1T6PQzQErF");
+
+    expect(result.data_source).toBe("ai_subtitle");
+    expect(mockGetSubtitleContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("detects a canonical-body collision when a segment embeds the separator pattern", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    mockGetSubtitleContent
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 1, to: 2, content: "a\n1|2|b" }]))
+      .mockResolvedValueOnce(makeFakeSubtitleContent([
+        { from: 1, to: 2, content: "a" },
+        { from: 1, to: 2, content: "b" },
+      ]));
+
+    await expect(getVideoTranscriptData("BV1T6PQzQErF")).rejects.toBeInstanceOf(NoSubtitleError);
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+  });
+
+  it("accepts a stable ai-zh body whose reads differ only in non-canonical fields", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    const chineseBody =
+      "清晨的阳光洒在宁静的山谷之上，农夫们正在田间劳作，为即将到来的丰收做准备，孩子们在溪边嬉戏玩耍，炊烟从村舍缓缓升起。";
+    // 第一读带 location、第二读键序不同：规范化只比较精确 [from,to,content] 元组
+    mockGetSubtitleContent
+      .mockResolvedValueOnce(
+        makeFakeSubtitleContent([{ from: 0, to: 1, location: 0, content: chineseBody.repeat(4) }]),
+      )
+      .mockResolvedValueOnce(
+        makeFakeSubtitleContent([{ content: chineseBody.repeat(4), from: 0, to: 1 }]),
+      );
+
+    const result = await getVideoTranscriptData("BV1T6PQzQErF");
+
+    expect(result.data_source).toBe("ai_subtitle");
+    expect(mockGetSubtitleContent).toHaveBeenCalledTimes(2);
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+  });
+
+  it("falls back to description for an unstable ai-zh body when authorized", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    mockGetSubtitleContent
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "First" }]))
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "Second" }]));
+
+    const result = await getVideoTranscriptData("BV1T6PQzQErF", undefined, true);
+
+    expect(result.data_source).toBe("description");
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+  });
+
+  it("propagates a second-read transport failure without any fallback", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    mockGetSubtitleContent
+      .mockResolvedValueOnce(makeFakeSubtitleContent([{ from: 0, to: 1, content: "First" }]))
+      .mockRejectedValueOnce(new Error("Temporary network failure"));
+
+    await expect(getVideoTranscriptData("BV1T6PQzQErF")).rejects.toThrow(
+      "Temporary network failure",
+    );
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+  });
+
+  it("rejects a stable non-Chinese ai-zh body as a language mismatch", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    const englishBody = [
+      "The quick brown fox jumps over the lazy dog while waiting for the train to arrive at the station this morning without any delay.",
+      "Farmers harvest the ripe wheat fields and load the golden grain onto wooden carts before the evening rain begins to fall.",
+    ];
+    mockGetSubtitleContent.mockResolvedValue(makeFakeSubtitleContent(englishBody.map((content) => ({ from: 0, to: 1, content }))));
+
+    await expect(getVideoTranscriptData("BV1T6PQzQErF")).rejects.toBeInstanceOf(NoSubtitleError);
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+  });
+
+  it("accepts a stable same-language ai-zh body regardless of title topic", async () => {
+    mockResolvePartCid.mockResolvedValue({
+      cid: 12345,
+      videoData: { ...defaultVideoData(), title: "Sea Monsters Documentary" },
+      pages: [{ page: 1, cid: 12345, title: "Sea Monsters Documentary", duration: 120 }],
+    });
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    const chineseBody =
+      "清晨的阳光洒在宁静的山谷之上，农夫们正在田间劳作，为即将到来的丰收做准备，孩子们在溪边嬉戏玩耍，炊烟从村舍缓缓升起。";
+    mockGetSubtitleContent.mockResolvedValue(
+      makeFakeSubtitleContent([{ from: 0, to: 1, content: chineseBody.repeat(4) }]),
+    );
+
+    const result = await getVideoTranscriptData("BV1T6PQzQErF");
+
+    expect(result.data_source).toBe("ai_subtitle");
+    expect(mockGetSubtitleContent).toHaveBeenCalledTimes(2);
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
+  });
+
+  it("keeps a human subtitle on a single read", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 1, lan: "zh-Hans", lan_doc: "Chinese", subtitle_url: "//example.test/zh.json" },
+      ]),
+    );
+
+    const result = await getVideoTranscriptData("BV1T6PQzQErF");
+
+    expect(result.data_source).toBe("subtitle");
+    expect(mockGetSubtitleContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts stable ai-zh when semantic signals are inconclusive", async () => {
+    mockGetVideoSubtitle.mockResolvedValue(
+      makeFakeSubtitles([
+        { id: 3, lan: "ai-zh", lan_doc: "AI Chinese", subtitle_url: "//example.test/ai-zh.json" },
+      ]),
+    );
+    const chineseBody =
+      "清晨的阳光洒在宁静的山谷之上，农夫们正在田间劳作，为即将到来的丰收做准备，孩子们在溪边嬉戏玩耍，炊烟从村舍缓缓升起。";
+    mockGetSubtitleContent.mockResolvedValue(
+      makeFakeSubtitleContent([{ from: 0, to: 1, content: chineseBody.repeat(4) }]),
+    );
+
+    const result = await getVideoTranscriptData("BV1T6PQzQErF");
+
+    expect(result.data_source).toBe("ai_subtitle");
+    expect(mockTranscribeVideoPart).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -57,6 +57,16 @@ describe("CLI help and commands", () => {
     expect(output).toContain("version");
   });
 
+  it("setup subcommand help documents the non-interactive flags", () => {
+    const cli = createCli();
+    const setupCmd = cli.commands.find((c) => c.name() === "setup");
+    expect(setupCmd).toBeDefined();
+    const output = setupCmd!.helpInformation();
+
+    expect(output).toContain("--non-interactive");
+    expect(output).toContain("--asr-model");
+  });
+
   it("help output does not contain duplicated [command] placeholder in a single line", () => {
     const cli = createCli();
     const output = cli.helpInformation();
@@ -663,6 +673,139 @@ describe("setup credential loadability", () => {
     expect(errCalls).not.toMatch(/abc123def456/);
     // Must never contain the raw bili_jct value
     expect(errCalls).not.toMatch(/xyz789/);
+  });
+
+  describe("non-interactive setup", () => {
+    it("exits 1 with value-free guidance when credentials are unloadable", async () => {
+      Object.defineProperty(process.stdin, "isTTY", {
+        configurable: true,
+        value: true,
+      });
+      vi.spyOn(credentialManager, "getCredentialSource").mockReturnValue("none");
+      vi.spyOn(credentialManager, "getCredentials").mockReturnValue(null);
+      const configure = vi.fn(async () => {});
+      const runAsr = vi.fn(async (_modelKey: string) => ({ success: true }));
+      const askHiddenFn = vi.fn(async () => "n");
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      process.exitCode = undefined;
+
+      await setupCredentials(configure, runAsr, askHiddenFn, {
+        nonInteractive: true,
+      });
+
+      expect(process.exitCode).toBe(1);
+      expect(configure).not.toHaveBeenCalled();
+      expect(askHiddenFn).not.toHaveBeenCalled();
+      expect(runAsr).not.toHaveBeenCalled();
+      const errCalls = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+      expect(errCalls).toContain("BILIBILI_SESSDATA");
+      expect(errCalls).toContain("BILIBILI_BILI_JCT");
+      expect(errCalls).toContain("BILIBILI_DEDEUSERID");
+    });
+
+    it("completes credential-only with non-TTY stdin and an env source, without prompting", async () => {
+      Object.defineProperty(process.stdin, "isTTY", {
+        configurable: true,
+        value: false,
+      });
+      vi.spyOn(credentialManager, "getCredentialSource").mockReturnValue("env");
+      vi.spyOn(credentialManager, "getCredentials").mockReturnValue({
+        sessdata: "s", bili_jct: "j", dedeuserid: "d", expiresAt: Date.now() + 86400000,
+      });
+      const configure = vi.fn(async () => {});
+      const runAsr = vi.fn(async (_modelKey: string) => ({ success: true }));
+      const askHiddenFn = vi.fn(async () => "n");
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      process.exitCode = undefined;
+
+      await setupCredentials(configure, runAsr, askHiddenFn, {
+        nonInteractive: true,
+      });
+
+      expect(process.exitCode).toBeUndefined();
+      expect(configure).not.toHaveBeenCalled();
+      expect(askHiddenFn).not.toHaveBeenCalled();
+      expect(runAsr).not.toHaveBeenCalled();
+      expect(logSpy.mock.calls.flat().join("\n")).toContain("ASR");
+    });
+
+    it("with a model calls the installer exactly once with that model", async () => {
+      Object.defineProperty(process.stdin, "isTTY", {
+        configurable: true,
+        value: false,
+      });
+      vi.spyOn(credentialManager, "getCredentialSource").mockReturnValue("global_config");
+      vi.spyOn(credentialManager, "getCredentials").mockReturnValue({
+        sessdata: "s", bili_jct: "j", dedeuserid: "d", expiresAt: Date.now() + 86400000,
+      });
+      const configure = vi.fn(async () => {});
+      const runAsr = vi.fn(async (_modelKey: string) => ({ success: true }));
+      const askHiddenFn = vi.fn(async () => "n");
+      vi.spyOn(console, "log").mockImplementation(() => {});
+      process.exitCode = undefined;
+
+      await setupCredentials(configure, runAsr, askHiddenFn, {
+        nonInteractive: true,
+        asrModel: "tiny",
+      });
+
+      expect(process.exitCode).toBeUndefined();
+      expect(configure).not.toHaveBeenCalled();
+      expect(askHiddenFn).not.toHaveBeenCalled();
+      expect(runAsr).toHaveBeenCalledOnce();
+      expect(runAsr).toHaveBeenCalledWith("tiny");
+    });
+
+    it("rejects non-interactive setup when the credential source is none even with loadable credentials", async () => {
+      Object.defineProperty(process.stdin, "isTTY", {
+        configurable: true,
+        value: false,
+      });
+      vi.spyOn(credentialManager, "getCredentialSource").mockReturnValue("none");
+      vi.spyOn(credentialManager, "getCredentials").mockReturnValue({
+        sessdata: "s", bili_jct: "j", dedeuserid: "d", expiresAt: Date.now() + 86400000,
+      });
+      const configure = vi.fn(async () => {});
+      const runAsr = vi.fn(async (_modelKey: string) => ({ success: true }));
+      const askHiddenFn = vi.fn(async () => "n");
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      process.exitCode = undefined;
+
+      await setupCredentials(configure, runAsr, askHiddenFn, {
+        nonInteractive: true,
+      });
+
+      expect(process.exitCode).toBe(1);
+      expect(configure).not.toHaveBeenCalled();
+      expect(askHiddenFn).not.toHaveBeenCalled();
+      expect(runAsr).not.toHaveBeenCalled();
+      expect(errSpy.mock.calls.flat().join("\n")).toContain("BILIBILI_SESSDATA");
+    });
+
+    it("rejects a model without non-interactive mode as a validation error", async () => {
+      Object.defineProperty(process.stdin, "isTTY", {
+        configurable: true,
+        value: true,
+      });
+      vi.spyOn(credentialManager, "getCredentials").mockReturnValue({
+        sessdata: "s", bili_jct: "j", dedeuserid: "d", expiresAt: Date.now() + 86400000,
+      });
+      const configure = vi.fn(async () => {});
+      const runAsr = vi.fn(async (_modelKey: string) => ({ success: true }));
+      const askHiddenFn = vi.fn(async () => "n");
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      process.exitCode = undefined;
+
+      await setupCredentials(configure, runAsr, askHiddenFn, {
+        asrModel: "small",
+      });
+
+      expect(process.exitCode).toBe(1);
+      expect(configure).not.toHaveBeenCalled();
+      expect(askHiddenFn).not.toHaveBeenCalled();
+      expect(runAsr).not.toHaveBeenCalled();
+      expect(errSpy.mock.calls.flat().join("\n")).toContain("--non-interactive");
+    });
   });
 });
 

--- a/tests/server-handler-sanitization.test.ts
+++ b/tests/server-handler-sanitization.test.ts
@@ -115,6 +115,7 @@ describe("handler validation and transcript output", () => {
       "BV1T6PQzQErF",
       "ai-zh",
       undefined,
+      false,
     );
   });
 
@@ -151,6 +152,8 @@ describe("handler validation and transcript output", () => {
       undefined,
       undefined,
       undefined,
+      false,
+      false,
       false,
     );
   });
@@ -259,6 +262,101 @@ describe("handler validation and transcript output", () => {
     expect(result.content[0].text).toBe(JSON.stringify(fixture, null, 2));
   });
 
+  it("forwards exclude_ai_subtitles to get_video_info subtitle selection", async () => {
+    mockGetVideoInfoWithSubtitle.mockResolvedValueOnce({
+      data_source: "subtitle",
+      video_info: { title: "AI subtitle fixture" },
+    });
+
+    const handler = getCallToolHandler();
+    await handler({
+      method: "tools/call",
+      jsonrpc: "2.0",
+      id: 51,
+      params: {
+        name: "get_video_info",
+        arguments: {
+          bvid_or_url: "BV1T6PQzQErF",
+          exclude_ai_subtitles: true,
+        },
+      },
+    });
+
+    expect(mockGetVideoInfoWithSubtitle).toHaveBeenCalledWith(
+      "BV1T6PQzQErF",
+      "zh-Hans",
+      undefined,
+      true,
+    );
+  });
+
+  it("forwards exclude_ai_subtitles and force_asr to get_video_transcript", async () => {
+    mockGetVideoTranscriptData.mockResolvedValueOnce({
+      bvid: "BV1T6PQzQErF",
+      data_source: "subtitle",
+      language: "zh-Hans",
+      transcript: "AI subtitle fixture",
+      title: "AI subtitle fixture",
+      source_url: "https://www.bilibili.com/video/BV1T6PQzQErF/",
+    });
+
+    const handler = getCallToolHandler();
+    await handler({
+      method: "tools/call",
+      jsonrpc: "2.0",
+      id: 52,
+      params: {
+        name: "get_video_transcript",
+        arguments: {
+          bvid_or_url: "BV1T6PQzQErF",
+          exclude_ai_subtitles: true,
+          force_asr: true,
+        },
+      },
+    });
+
+    expect(mockGetVideoTranscriptData).toHaveBeenCalledWith(
+      "BV1T6PQzQErF",
+      "zh-Hans",
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      true,
+      true,
+    );
+  });
+
+  it.each([
+    ["get_video_info", "exclude_ai_subtitles"],
+    ["get_video_transcript", "exclude_ai_subtitles"],
+    ["get_video_transcript", "force_asr"],
+  ])("%s rejects a non-boolean %s before business work", async (name, argName) => {
+    const handler = getCallToolHandler();
+    const result = await handler({
+      method: "tools/call",
+      jsonrpc: "2.0",
+      id: 53,
+      params: {
+        name,
+        arguments: {
+          bvid_or_url: "BV1T6PQzQErF",
+          [argName]: "yes",
+        },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    expect(mockGetVideoInfoWithSubtitle).not.toHaveBeenCalled();
+    expect(mockGetVideoTranscriptData).not.toHaveBeenCalled();
+  });
+
   it("forwards explicit ASR opt-in and returns identical ASR text/structured output", async () => {
     const fixture = {
       bvid: "BV1T6PQzQErF",
@@ -285,7 +383,7 @@ describe("handler validation and transcript output", () => {
       },
     });
 
-    expect(mockGetVideoTranscriptData.mock.calls[0].at(-1)).toBe(true);
+    expect(mockGetVideoTranscriptData.mock.calls[0][8]).toBe(true);
     expect(result.structuredContent).toEqual(fixture);
     expect(JSON.parse(result.content[0].text)).toEqual(fixture);
   });

--- a/tests/server-tools.test.ts
+++ b/tests/server-tools.test.ts
@@ -117,6 +117,15 @@ describe("MCP tool list baseline", () => {
       expect(prop.type).toBe("integer");
       expect(prop.minimum).toBe(1);
     });
+
+    it("accepts optional exclude_ai_subtitles (boolean, default-off)", () => {
+      schema = toolsResult.tools.find((t) => t.name === "get_video_info")!;
+      const prop = schema.inputSchema.properties
+        .exclude_ai_subtitles as { type?: string; description?: string };
+      expect(prop).toBeDefined();
+      expect(prop.type).toBe("boolean");
+      expect(prop.description).toContain("ai");
+    });
   });
 
   describe("get_video_comments schema", () => {
@@ -254,6 +263,28 @@ describe("MCP tool list baseline", () => {
       expect(prop.type).toBe("boolean");
     });
 
+    it("accepts optional exclude_ai_subtitles (boolean, default-off)", () => {
+      schema = toolsResult.tools.find(
+        (t) => t.name === "get_video_transcript",
+      )!;
+      const prop = schema.inputSchema.properties
+        .exclude_ai_subtitles as { type?: string; description?: string };
+      expect(prop).toBeDefined();
+      expect(prop.type).toBe("boolean");
+      expect(prop.description).toContain("ai");
+    });
+
+    it("accepts optional force_asr (boolean, default-off)", () => {
+      schema = toolsResult.tools.find(
+        (t) => t.name === "get_video_transcript",
+      )!;
+      const prop = schema.inputSchema.properties
+        .force_asr as { type?: string; description?: string };
+      expect(prop).toBeDefined();
+      expect(prop.type).toBe("boolean");
+      expect(prop.description).toContain("ASR");
+    });
+
     it("accepts optional page (integer, min 1), include_timestamps, start_seconds, end_seconds", () => {
       schema = toolsResult.tools.find(
         (t) => t.name === "get_video_transcript",
@@ -311,7 +342,7 @@ describe("MCP tool list baseline", () => {
           bvid: { type: "string" },
           data_source: {
             type: "string",
-            enum: ["subtitle", "description", "asr"],
+            enum: ["subtitle", "ai_subtitle", "description", "asr"],
           },
           language: { type: "string" },
           transcript: { type: "string" },


### PR DESCRIPTION
## Summary

- Classify every Bilibili `ai-*` track as `ai_subtitle` and add `exclude_ai_subtitles` to transcript and video-info.
- Double-read selected AI subtitles, reject unstable bodies, add a conservative `ai-zh` language guard, and add `force_asr`.
- Add scriptable `setup --non-interactive` with optional `--asr-model`, using only environment/global credential sources.

## Root cause

AI-generated tracks shared the native-subtitle path, had no integrity gate, and therefore counted as an existing subtitle even when corrupted, preventing `fallback_to_asr`. The setup flow also required an interactive TTY.

## Validation

- `npm run build`
- `npm test`: 41 files / 906 tests passed
- Focused suite: 7 files / 323 tests passed
- `npm pack --dry-run`: 189 entries; no forbidden paths
- Secret scan: 34 changed files; no real credentials
- UTF-8 and staged diff checks passed
- Live read-only check on `BV15kyBB5Eg8`: default AI classification and exclusion behavior passed

## Known limits

- Stable same-language off-topic AI text is not rejected by title lexical matching; that heuristic produced confirmed false positives and false negatives, so it is intentionally not a hard gate.
- `BV1ybuQ62EfK` no longer exposed the target subtitle during verification, so the real corrupted-body/ASR fallback path could not be reproduced live; deterministic tests cover it.

Fixes #40

> Draft only. Do not merge until the cloud Codex review is complete.