### PR TITLE
fix: support Node 25 pinned lookup arrays

### DIFF
--- a/docs/agent-memory/verification-log.md
+++ b/docs/agent-memory/verification-log.md
@@ -2497,3 +2497,27 @@ Six release blockers fixed; one regression proof per root cause (new tests
   102/102 with 15 environment-dependent skips. After recording this result,
   the final durable hashes were regenerated and the exact conformance test was
   rerun against the fixed receipt.
+
+## 2026-08-23 — Issue #54 Node 25 Pinned Lookup Repair
+
+- Red evidence: the focused regression invoked the injected HTTPS lookup with
+  `all: true` and received a single address string instead of the required
+  address-record array; the unmodified behavior failed 1 of 20 focused tests.
+- Green evidence: the lookup now returns the same validated pinned address as a
+  one-element array only when `all` is requested and preserves the legacy
+  address/family callback otherwise. Build passed; 42 files / 1058 tests passed;
+  the focused 20-test file passed on Node 20, 22, and 25.
+- Live evidence: on Node 25.6.1, the repaired `pinnedHttpsFetch` retrieved the
+  reported BVID's selected representation with HTTP 200, `video/mp4`, and
+  content length 12,050,979 bytes when supplied one public resolver result.
+- Release-gate live smoke: after the local resolver returned public CDN
+  addresses, the repaired Node 25.6.1 path downloaded the selected 12,050,979
+  byte audio candidate and the complete MCP `force_asr` call finished with
+  `isError=false` and `data_source=asr`. No transcript body or credential value
+  was recorded.
+- Review and boundary: Standards Review found no issue; Spec Review found no
+  implementation deviation. The previously retained resolver-environment caveat
+  is now cleared by the complete live smoke. Scoped added-line secret scanning
+  passed, with one unchanged synthetic test fixture. At verification-capture
+  time, no dependency, public MCP schema, commit, push, PR, tag, release, or
+  publication change had occurred.

--- a/docs/research/2026-08-23-node-lookup-all-contract.md
+++ b/docs/research/2026-08-23-node-lookup-all-contract.md
@@ -1,0 +1,72 @@
+# Node.js Custom Lookup `all` Contract
+
+## Research Topic
+
+- Topic: Node.js custom lookup callback shape when `all: true`
+- Date: 2026-08-23
+- Owner: Codex
+- Related task, PRD, ticket, or plan: GitHub Issue #54
+- Refresh before: Reusing this conclusion for a later Node major compatibility change
+
+## Question
+
+What result shape must a custom network lookup callback return when Node.js requests all addresses?
+
+## Context
+
+Why this matters for `@xzxzzx/bilibili-mcp`:
+
+- The ASR audio downloader pins one validated CDN address through a custom HTTPS lookup callback.
+- Node.js 25.6.1 calls that callback with `all: true` in the reproduced Issue #54 path.
+
+What decision or implementation this may affect:
+
+- Whether the existing pinned address should be returned as one record or as an array while preserving the DNS-rebinding defense.
+
+## Sources
+
+| Source | Type | Date checked | Notes |
+|--------|------|--------------|-------|
+| [Node.js v25.6.1 DNS documentation](https://nodejs.org/download/release/v25.6.1/docs/api/dns.html#dnslookuphostname-options-callback) | official docs | 2026-08-23 | `all: true` changes the callback result to an array of `{ address, family }` records. |
+| [Node.js v25.6.1 Net documentation](https://nodejs.org/download/release/v25.6.1/docs/api/net.html#socketconnectoptions-connectlistener) | official docs | 2026-08-23 | Family auto-selection sets `all: true` on the custom lookup. |
+
+## Findings
+
+- With `all: false` or absent, the callback receives one address and family.
+- With `all: true`, the callback receives an array of address records and no separate family argument.
+- Returning one already validated pinned address inside a one-element array satisfies the contract without allowing Node to resolve or select an unvalidated destination.
+
+## Applicability To This Project
+
+Applies:
+
+- Branching on the lookup options and returning the pinned address in the shape Node requests.
+- Regression coverage for both callback forms.
+
+Does not apply:
+
+- Removing the custom lookup, changing the resolver, broadening allowed media hosts, or returning additional DNS answers.
+
+## Decision Impact
+
+Recommended project action:
+
+- Preserve the current pinned address and security checks; change only the callback result shape for `all: true`.
+
+Rules or files that may need updates:
+
+- The pinned HTTPS implementation and its focused regression test only.
+
+## Risks And Unknowns
+
+- The exact runtime path that requests `all: true` may vary by Node version and connection options, so both callback forms must remain supported.
+
+## Staleness Notes
+
+Refresh this research when:
+
+- Node changes the custom lookup contract or the project changes its HTTPS/DNS pinning design.
+
+## Follow-Up
+
+- [x] Verify the focused regression on Node.js 20, 22, and 25.

--- a/harness/fixtures/pilot-artifacts/migration.json
+++ b/harness/fixtures/pilot-artifacts/migration.json
@@ -97,7 +97,7 @@
     "docs/agent-memory/harness-security.md": "b907339f85c0ba13c2a8642b475aa682ae1b313cb51cebec9977aca798df3430",
     "docs/agent-memory/lessons-learned.md": "6a0e45bc73159237fb3200a3725d12d54dd0d83aa5c8eebcec5ffb9bd2efb7d7",
     "docs/agent-memory/project-facts.md": "ce49559de2e1ed1ecb322ecd2f0d3ff62887c9ca1f7d885ab2b47ab9ff6b7e3c",
-    "docs/agent-memory/verification-log.md": "d9a64071f0f5512c714c8c05db135418cb4b9f016d4f637f268d44f366f77e58"
+    "docs/agent-memory/verification-log.md": "d86eb0b4a96ed4ee506d3496a1a814500d7231d4cef194460af7f172b6dcb940"
   },
   "package": {
     "output_digest": "b6de50873e84f83845f1db5add1b6a9a3e8758ef06f38e5e411f10f15c980938",

--- a/harness/fixtures/three-adapter-pilot-evidence.json
+++ b/harness/fixtures/three-adapter-pilot-evidence.json
@@ -8,7 +8,7 @@
       "product-verification": "pass"
     },
     "file": "migration.json",
-    "sha256": "b4114ea3a986bd896afc298034362a6d551e4594e87bb4ea91be7f26924da8ec"
+    "sha256": "76527fdc141ce3fd535f58141ecfee3e108e6c049d900fe3279c9f406eeefe4d"
   },
   "pilots": [
     {

--- a/src/security/pinned-https.ts
+++ b/src/security/pinned-https.ts
@@ -199,7 +199,11 @@ export async function pinnedHttpsFetch(
   headers.delete("authorization");
   headers.delete("proxy-authorization");
   const requestImpl = options.request ?? https.request;
-  const lookup: LookupFunction = (_hostname, _options, callback) => {
+  const lookup: LookupFunction = (_hostname, lookupOptions, callback) => {
+    if (lookupOptions.all) {
+      callback(null, [pinned]);
+      return;
+    }
     callback(null, pinned.address, pinned.family);
   };
 

--- a/tests/pinned-https.test.ts
+++ b/tests/pinned-https.test.ts
@@ -136,6 +136,26 @@ describe("pinned playback HTTPS", () => {
         },
       );
     });
+
+    await new Promise<void>((resolve, reject) => {
+      const lookup = capturedOptions?.lookup;
+      expect(lookup).toBeTypeOf("function");
+      lookup!(
+        "cdn.bilivideo.com",
+        { all: true },
+        (error, addresses) => {
+          try {
+            expect(error).toBeNull();
+            expect(addresses).toEqual([
+              { address: "8.8.8.8", family: 4 },
+            ]);
+            resolve();
+          } catch (assertionError) {
+            reject(assertionError);
+          }
+        },
+      );
+    });
   });
 
   it("rejects non-media hosts before DNS or network dispatch", async () => {


### PR DESCRIPTION
## Summary

- support the Node.js 25 custom lookup contract when HTTPS requests all addresses
- return only the already validated pinned address as a one-element record array
- preserve the legacy single-address callback and all existing HTTPS security controls
- add focused regression coverage and record the official Node contract plus verification evidence

## Verification

- Node 20 focused test: 20/20
- Node 22 focused test: 20/20
- Node 25 focused test: 20/20
- npm run build: passed
- npm test: 42 files / 1058 tests passed
- redacted Node 25 force_asr smoke: isError=false, data_source=asr
- scoped added-line credential scan: 0 findings
- Standards Review: 0 findings
- Spec Review: 0 findings
- Risk Review: 0 findings

## Security and scope

DNS pinning, public-address validation, approved-host enforcement, TLS SNI/Host handling, credential stripping, abort behavior, redirects, dependencies, and public MCP schemas remain unchanged.

Fixes #54
