### PR TITLE
fix(asr): diagnose standard Fake-IP DNS failures

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,6 +93,10 @@ A transcript generated locally from the selected Part's audio by the managed
 ASR runtime. It is distinct from every Bilibili-provided subtitle track.
 _Avoid_: Bilibili AI Subtitle, fallback subtitle
 
+**ASR Fake-IP DNS Diagnosis**:
+A user-actionable network diagnosis produced only when every attempted Bilibili media candidate resolves exclusively to the standard `198.18.0.0/15` Fake-IP placeholder range. It does not authorize connecting to that range.
+_Avoid_: Generic DNS failure, proxy failure, CDN IP allowlist
+
 **Subtitle Integrity**:
 Whether a selected subtitle is usable as transcript evidence. Mere presence of
 a subtitle track does not establish Subtitle Integrity.

--- a/docs/agent-memory/active-work.md
+++ b/docs/agent-memory/active-work.md
@@ -1,5 +1,14 @@
 # Active Work
 
+## Current Product Ticket
+
+GitHub Issue #57 implements the approved #56 Fake-IP DNS diagnostic. Work is
+isolated on `codex/issue-57-fake-ip-dns` from merged #54 base `5e3d2d9` and is
+directly executed by Codex without Paseo. The bounded scope is DNS
+classification, audio-candidate failure aggregation, structured MCP guidance,
+deterministic tests, and official IANA/Mihomo research. Commit, push, PR,
+release, and publication remain separate authority gates.
+
 ## Harness v2
 
 GitHub Issue #28 is the approved Harness v2 specification. Issues #29-#36 are

--- a/docs/agent-memory/codemap.md
+++ b/docs/agent-memory/codemap.md
@@ -27,9 +27,10 @@ This file is a navigation index for `@xzxzzx/bilibili-mcp`. It is not a design s
 - `src/security/operation-context.ts`: per-MCP-call `AbortSignal` propagation,
   linked abort helpers, and abortable delay.
 - `src/security/pinned-https.ts`: final playback-media HTTPS sink with
-  provider-host validation, all-answer public DNS checks, connection pinning,
-  original-host TLS validation, manual redirect responses, and credential
-  stripping. Callers must validate and pin every redirect hop.
+  provider-host validation, all-answer public DNS checks, exact all-answer
+  `198.18.0.0/15` Fake-IP classification, connection pinning, original-host TLS
+  validation, manual redirect responses, and credential stripping. Callers
+  must validate and pin every redirect hop.
 - `src/server/bounded-stdio-transport.ts`: fixed-buffer JSON-RPC line framing
   with 1 MiB inbound and 4 MiB outbound ceilings and write backpressure.
 - `src/server/error-response.ts`: shared successful/error response
@@ -52,8 +53,9 @@ This file is a navigation index for `@xzxzzx/bilibili-mcp`. It is not a design s
   requires trusted duration, owns one aggregate audio deadline/byte budget,
   unique temporary directories, one-active/no-queue concurrency, bounded
   Windows Job/POSIX `RLIMIT` managed-Python execution, strict NDJSON,
-  cancellation/tree kill, and guarded cleanup. MCP requests never install or
-  switch models.
+  cancellation/tree kill, guarded cleanup, and all-candidate Fake-IP failure
+  aggregation without preventing later-candidate success. MCP requests never
+  install or switch models.
 
 ## MCP Tool Surface
 
@@ -104,7 +106,7 @@ When adding or changing a public MCP tool, inspect both `tool-schemas.ts` and `t
 
 - `src/utils/credentials.ts`: global credential storage and credential source detection.
 - `src/utils/credential-guidance.ts`: safe credential setup instructions, status payloads, and next-step generation.
-- `src/utils/error-guidance.ts`: unified structured MCP error payload mapper with bilingual recovery guidance and category/retry metadata.
+- `src/utils/error-guidance.ts`: unified structured MCP error payload mapper with bilingual recovery guidance and category/retry metadata, including the user-actionable `ASR_FAKE_IP_DNS` network diagnosis.
 - `src/utils/validation.ts`: BV, language, detail-level, comment/search limits, sort, query, max_matches, context_segments, Favorites cursor (type/length/base64url charset), and Creator Content input (mid/section/cursor/container identity, including the Dynamic section) validation.
 - `src/utils/sanitization.ts`: BV/URL sanitization and output sanitization helpers.
 - `src/utils/errors.ts`: domain-specific error classes and codes.
@@ -129,7 +131,7 @@ When adding or changing a public MCP tool, inspect both `tool-schemas.ts` and `t
 - `tests/asr-installer.test.ts`: deterministic installer/state tests. State read/validation/write, Python discovery (override/path/version), venv/pip/download/verify subprocess gating, and full orchestration success/failure. No tests invoke real Python, pip, network, or model download.
 - `tests/asr-installer-process.test.ts`: mocked default subprocess deadlines,
   output ceilings, argv, stdio, and platform process-group settings.
-- `tests/asr-transcription.test.ts`: deterministic ready-state, download, redirect, size/MIME, child argv/environment, strict output, timeout/kill, cleanup, and concurrency tests with no real network, Python, audio, Cookie, or model.
+- `tests/asr-transcription.test.ts`: deterministic ready-state, download, redirect, size/MIME, Fake-IP candidate aggregation, child argv/environment, strict output, timeout/kill, cleanup, and concurrency tests with no real network, Python, audio, Cookie, or model.
 - `tests/bilibili-playback.test.ts`: deterministic playurl auth/parameter, malformed-versus-empty DASH, duration, CDN allowlist, and candidate-order tests.
 - `tests/bounded-stdio-transport.test.ts`: inbound/outbound framing ceilings,
   UTF-8 byte accounting, fixed-buffer chunking, and fail-closed overflow.
@@ -140,8 +142,9 @@ When adding or changing a public MCP tool, inspect both `tool-schemas.ts` and `t
   single-flight cancellation/deadline/waiter behavior.
 - `tests/mcp-response-budget.test.ts`: exact successful payload/envelope
   boundaries and text/structured parity.
-- `tests/pinned-https.test.ts`: DNS/public-address rejection, connection
-  pinning, TLS hostname retention, header stripping, and host enforcement.
+- `tests/pinned-https.test.ts`: DNS/public-address rejection, exact Fake-IP
+  range and mixed-answer classification, connection pinning, TLS hostname
+  retention, header stripping, and host enforcement.
 - `tests/publish-workflow-pins.test.ts`: full immutable SHA enforcement for
   every third-party Action across all repository workflows.
 - `tests/subtitle-fallback-security.test.ts`: malformed subtitle fail-closed
@@ -150,7 +153,7 @@ When adding or changing a public MCP tool, inspect both `tool-schemas.ts` and `t
 - `tests/server-tools.test.ts`: MCP tool discovery and public input/output schema coverage.
 - `tests/server-credential-tools.test.ts`: credential tool behavior and non-leak checks.
 - `tests/update-check.test.ts`: package update guidance behavior and registry-failure fallback.
-- `tests/server-error-next-steps.test.ts`: structured recovery guidance in tool errors.
+- `tests/server-error-next-steps.test.ts`: structured recovery guidance in tool errors, including bounded bilingual Fake-IP cause and remedy choices.
 - `tests/server-handler-sanitization.test.ts`: handler-level sanitization plus transcript/search structured-output contract checks.
 - `tests/credential-guidance.test.ts`: credential setup/status guidance.
 - `tests/bilibili-video-api.test.ts`: video/subtitle API safety and behavior checks.

--- a/docs/agent-memory/decisions.md
+++ b/docs/agent-memory/decisions.md
@@ -845,3 +845,17 @@
 - Evidence: `src/cli.ts` `SetupCredentialsOptions`, focused CLI tests, and
   post-build child smoke with piped/closed stdin and synthetic environment
   credentials.
+
+## 2026-08-23 — ASR Fake-IP DNS diagnosis
+
+- Decision: Emit `ASR_FAKE_IP_DNS` only when every attempted audio candidate
+  fails because all of that candidate's bounded DNS answers are IPv4 addresses
+  inside `198.18.0.0/15`.
+- Reason: This gives AI Agents an actionable diagnosis without weakening the
+  pinned-HTTPS SSRF boundary or mislabeling mixed DNS/media failures. Later
+  candidates still run, and any usable candidate preserves normal success.
+- Evidence: IANA's special-purpose registry marks `198.18.0.0/15` as
+  non-globally-reachable benchmarking space; Mihomo documents Fake-IP ranges,
+  domain-wildcard `fake-ip-filter`, rule-mode `real-ip`, and domain-specific DNS
+  policy. Issue #57 fixes the public category as `network`, non-retryable, and
+  user-action-required.

--- a/docs/agent-memory/verification-log.md
+++ b/docs/agent-memory/verification-log.md
@@ -2521,3 +2521,32 @@ Six release blockers fixed; one regression proof per root cause (new tests
   passed, with one unchanged synthetic test fixture. At verification-capture
   time, no dependency, public MCP schema, commit, push, PR, tag, release, or
   publication change had occurred.
+
+## 2026-08-23 — Issue #57 Fake-IP DNS Diagnosis
+
+- Red/green evidence: boundary DNS tests first reproduced generic rejection for
+  `198.18.0.0/15`; candidate aggregation first returned
+  `ASR_AUDIO_UNAVAILABLE`; the public MCP seam first returned `UNKNOWN_ERROR`;
+  and a later regression test reproduced a false `ASR_FAKE_IP_DNS` after a
+  successful public redirect hop. Each failed before its corresponding bounded
+  implementation change and passed afterward.
+- Final behavior: a candidate is classified only when its bounded first-hop DNS
+  answers are exclusively inside `198.18.0.0/15`. The addresses remain rejected;
+  a later usable candidate still succeeds; mixed DNS, redirect, special-address,
+  and media failures remain generic. Only all attempted candidates with the
+  exclusive first-hop cause produce public `ASR_FAKE_IP_DNS`, category `network`,
+  `retryable=false`, and `user_action_required=true`.
+- Verification: the focused DNS, aggregation, public MCP, and playback matrix
+  passed 103/103; the complete Vitest suite passed 42 files / 1072 tests;
+  TypeScript build and `npm pack --dry-run --json --ignore-scripts` passed.
+- Security: gitleaks 8.30.1 found zero secrets in the complete diff and the new
+  research note. `npm audit --omit=dev --json` found zero production
+  vulnerabilities. The full audit retained two high findings in the unchanged
+  Vitest/Vite development chain (`postcss` and `nanoid`); no dependency was
+  changed or auto-fixed under this ticket.
+- Review and boundary: Standards, Spec, and risk reviews passed after the
+  redirect-attribution repair. TLS, Host, SNI, redirect revalidation, credential
+  stripping, connection pinning, transcript success shape, and the three-candidate
+  cap remain unchanged. No Cookie, Authorization value, signed media URL, full
+  DNS response, proxy-node detail, local configuration, commit, push, PR, tag,
+  release, or publication was introduced.

--- a/docs/research/2026-08-23-fake-ip-dns-diagnosis.md
+++ b/docs/research/2026-08-23-fake-ip-dns-diagnosis.md
@@ -1,0 +1,94 @@
+# Research Note
+
+## Research Topic
+
+- Topic: Standard Fake-IP DNS classification and user remediation
+- Date: 2026-08-23
+- Owner: Codex
+- Related task, PRD, ticket, or plan: GitHub Issues #56 and #57
+- Refresh before: changing the classified range or vendor-specific guidance
+
+## Question
+
+Which address range can be diagnosed as the standard Fake-IP case without
+weakening playback-media connection safety, and which documented Mihomo
+controls can an AI Agent explain to the user?
+
+## Context
+
+Why this matters for `@xzxzzx/bilibili-mcp`:
+
+- Local ASR must reject special-purpose DNS answers but should distinguish the
+  common Fake-IP configuration problem from generic audio unavailability.
+
+What decision or implementation this may affect:
+
+- DNS classification in `src/security/pinned-https.ts` and bounded MCP recovery
+  guidance for `ASR_FAKE_IP_DNS`.
+
+## Sources
+
+| Source | Type | Date checked | Notes |
+|--------|------|--------------|-------|
+| [IANA IPv4 Special-Purpose Address Space](https://www.iana.org/assignments/iana-ipv4-special-registry) | official registry | 2026-08-23 | Lists `198.18.0.0/15` as benchmarking space and not globally reachable. |
+| [Mihomo DNS configuration](https://wiki.metacubex.one/en/config/dns/) | official docs | 2026-08-23 | Documents `fake-ip`, configurable `fake-ip-range`, domain-wildcard `fake-ip-filter`, rule-mode `real-ip`, and `nameserver-policy`. |
+
+## Findings
+
+- IANA defines the whole `198.18.0.0/15` block, not one observed address, as
+  special-purpose benchmarking space with `Globally Reachable = False`.
+- Mihomo's Fake-IP range is configurable. Its official example uses an address
+  within the IANA block, so one runtime-observed IP or one vendor default is not
+  a durable classifier.
+- Mihomo supports domain wildcards in `fake-ip-filter`; rule mode can return
+  `real-ip` for selected domains. `nameserver-policy` provides a separate
+  domain-specific resolver control.
+
+## Applicability To This Project
+
+Applies:
+
+- Recognize only a non-empty, bounded DNS answer set whose every answer is an
+  IPv4 address in `198.18.0.0/15`.
+- Continue rejecting the addresses. Explain Fake-IP filtering or equivalent
+  real-IP DNS rules for `*.bilivideo.com` and `*.bilivideo.cn` as user choices.
+
+Does not apply:
+
+- Do not infer the user's proxy product, node, route, or local configuration.
+- Do not classify mixed answers, other special-purpose addresses, ordinary DNS
+  failure, or media HTTP failure as Fake-IP.
+- Do not allowlist `198.18.0.0/15` in the MCP server.
+
+## Decision Impact
+
+Recommended project action:
+
+- Preserve pinned HTTPS, Host/SNI, TLS, redirect validation, credential
+  stripping, and public-address rejection; carry only a bounded reason marker
+  through candidate aggregation to MCP guidance.
+
+Rules or files that may need updates:
+
+- `src/security/pinned-https.ts`, `src/asr/transcription.ts`,
+  `src/utils/errors.ts`, `src/utils/error-guidance.ts`, and their existing test
+  seams.
+
+## Risks And Unknowns
+
+- Other proxy products can configure different Fake-IP ranges. Issue #57 is
+  intentionally limited to the standard `198.18.0.0/15` diagnosis.
+- UI steps vary by client. Public guidance should describe supported concepts,
+  not promise exact FlClash menu names.
+
+## Staleness Notes
+
+Refresh this research when:
+
+- IANA changes the registry entry, Mihomo changes Fake-IP configuration
+  semantics, or the project adds another explicitly supported Fake-IP range.
+
+## Follow-Up
+
+- [x] Implement and test the bounded standard-range diagnosis without changing
+  the connection allowlist.

--- a/harness/fixtures/pilot-artifacts/migration.json
+++ b/harness/fixtures/pilot-artifacts/migration.json
@@ -89,15 +89,15 @@
     }
   ],
   "durable_memory": {
-    "docs/agent-memory/active-work.md": "5085cc5857b6473ed3af34c8d18a782c47c670100adf90972faa290ce7063af3",
-    "docs/agent-memory/codemap.md": "ac38a1997d647222e05b0ace3c90a85aaab874fbfd8735a09f840cab88f0fc58",
-    "docs/agent-memory/decisions.md": "ee99b8c1ea5572de4003143bbe4d513e151b14776defecf879a494436ff2d0fc",
+    "docs/agent-memory/active-work.md": "3bb70b8fe8f34be48d0080b1c341b2ecbcaa77db9dab035b1867c836f17343d6",
+    "docs/agent-memory/codemap.md": "976aa6e7233dacdad3f1c150b5334a5ce9caef37a450296dec14b7640aec97bd",
+    "docs/agent-memory/decisions.md": "302b443c014aa57294dfe2eaed16c18677c89a7fdb653919041304a46afa672e",
     "docs/agent-memory/executions/2026-08-14-github-36-codex-direct-report.md": "439b169470c2ab1ec3af3625b8ca3e247d6ccd4f01bc39ff967deff673853570",
     "docs/agent-memory/harness-eval.md": "f531cc2d0e69ccc8d41c882c9aefdae03d5583789bc19c51dd45a4188fe9a370",
     "docs/agent-memory/harness-security.md": "b907339f85c0ba13c2a8642b475aa682ae1b313cb51cebec9977aca798df3430",
     "docs/agent-memory/lessons-learned.md": "6a0e45bc73159237fb3200a3725d12d54dd0d83aa5c8eebcec5ffb9bd2efb7d7",
     "docs/agent-memory/project-facts.md": "ce49559de2e1ed1ecb322ecd2f0d3ff62887c9ca1f7d885ab2b47ab9ff6b7e3c",
-    "docs/agent-memory/verification-log.md": "d86eb0b4a96ed4ee506d3496a1a814500d7231d4cef194460af7f172b6dcb940"
+    "docs/agent-memory/verification-log.md": "f357cc6246488440464ebcbc8df389271d643138605ed00215b4da6fbba07d40"
   },
   "package": {
     "output_digest": "b6de50873e84f83845f1db5add1b6a9a3e8758ef06f38e5e411f10f15c980938",

--- a/harness/fixtures/three-adapter-pilot-evidence.json
+++ b/harness/fixtures/three-adapter-pilot-evidence.json
@@ -8,7 +8,7 @@
       "product-verification": "pass"
     },
     "file": "migration.json",
-    "sha256": "76527fdc141ce3fd535f58141ecfee3e108e6c049d900fe3279c9f406eeefe4d"
+    "sha256": "a3edf5ad8d98a404a4379edcb68392b4e6d483191ab94851789118b597c0c638"
   },
   "pilots": [
     {

--- a/src/asr/transcription.ts
+++ b/src/asr/transcription.ts
@@ -17,7 +17,10 @@ import {
   linkAbortSignal,
   throwIfAborted,
 } from "../security/operation-context.js";
-import { pinnedHttpsFetch } from "../security/pinned-https.js";
+import {
+  FakeIpDnsError,
+  pinnedHttpsFetch,
+} from "../security/pinned-https.js";
 import { sanitizeRemoteText } from "../utils/bounded-text.js";
 import { AsrError } from "../utils/errors.js";
 import { buildAsrChildEnv } from "./installer.js";
@@ -293,16 +296,24 @@ async function fetchAudioResponse(
 ): Promise<Response> {
   let currentUrl = validatePlaybackMediaUrl(initialUrl);
   for (let redirects = 0; redirects <= MAX_ASR_REDIRECTS; redirects += 1) {
-    const response = await fetchFn(currentUrl, {
-      method: "GET",
-      headers: {
-        "User-Agent": config.userAgent,
-        Referer: config.referer,
-        Accept: "audio/mp4,audio/*;q=0.9,application/octet-stream;q=0.5",
-      },
-      redirect: "manual",
-      signal,
-    });
+    let response: Response;
+    try {
+      response = await fetchFn(currentUrl, {
+        method: "GET",
+        headers: {
+          "User-Agent": config.userAgent,
+          Referer: config.referer,
+          Accept: "audio/mp4,audio/*;q=0.9,application/octet-stream;q=0.5",
+        },
+        redirect: "manual",
+        signal,
+      });
+    } catch (error) {
+      if (redirects > 0 && error instanceof FakeIpDnsError) {
+        throw new Error("Media redirect resolution failed");
+      }
+      throw error;
+    }
 
     if (response.status >= 300 && response.status < 400) {
       if (redirects === MAX_ASR_REDIRECTS) {
@@ -378,6 +389,8 @@ export async function downloadPlaybackAudio(
   }
 
   let lastError: unknown;
+  let attemptedCandidates = 0;
+  let fakeIpDnsFailures = 0;
   const aggregateBudget = { remainingBytes: maxBytes };
   const controller = new AbortController();
   const unlinkAbort = linkAbortSignal(signal, controller);
@@ -389,40 +402,50 @@ export async function downloadPlaybackAudio(
   try {
     for (const candidate of candidates.slice(0, 3)) {
       throwIfAborted(signal);
-    try {
-      await fs.promises.rm(destination, { force: true });
-      const response = await fetchAudioResponse(candidate.url, controller.signal, fetchFn);
-      await readBoundedBody(response, destination, aggregateBudget);
-      return;
-    } catch (error) {
-      await fs.promises.rm(destination, { force: true });
-      if (signal?.aborted) {
-        throw createAbortError();
-      }
-      if (error instanceof AsrError && error.code === "ASR_LIMIT_EXCEEDED") {
-        throw error;
-      }
-      if (
-        timedOut &&
-        error instanceof Error &&
-        error.name === "AbortError"
-      ) {
-        lastError = new AsrError(
-          "ASR_AUDIO_UNAVAILABLE",
-          "The temporary audio download timed out.",
-          true,
-        );
-      } else {
-        lastError = error;
+      attemptedCandidates += 1;
+      try {
+        await fs.promises.rm(destination, { force: true });
+        const response = await fetchAudioResponse(candidate.url, controller.signal, fetchFn);
+        await readBoundedBody(response, destination, aggregateBudget);
+        return;
+      } catch (error) {
+        await fs.promises.rm(destination, { force: true });
+        if (signal?.aborted) {
+          throw createAbortError();
+        }
+        if (error instanceof AsrError && error.code === "ASR_LIMIT_EXCEEDED") {
+          throw error;
+        }
+        if (error instanceof FakeIpDnsError) {
+          fakeIpDnsFailures += 1;
+        }
+        if (
+          timedOut &&
+          error instanceof Error &&
+          error.name === "AbortError"
+        ) {
+          lastError = new AsrError(
+            "ASR_AUDIO_UNAVAILABLE",
+            "The temporary audio download timed out.",
+            true,
+          );
+        } else {
+          lastError = error;
+        }
       }
     }
-  }
   } finally {
     clearTimeout(timer);
     unlinkAbort();
     controller.abort();
   }
 
+  if (attemptedCandidates > 0 && fakeIpDnsFailures === attemptedCandidates) {
+    throw new AsrError(
+      "ASR_FAKE_IP_DNS",
+      "All temporary audio candidates resolved only to the standard Fake-IP range.",
+    );
+  }
   if (lastError instanceof AsrError) throw lastError;
   throw new AsrError(
     "ASR_AUDIO_UNAVAILABLE",

--- a/src/security/pinned-https.ts
+++ b/src/security/pinned-https.ts
@@ -14,6 +14,13 @@ export type AddressResolver = (
   hostname: string,
 ) => Promise<ResolvedAddress[]>;
 
+export class FakeIpDnsError extends Error {
+  constructor() {
+    super("Media hostname resolved only to the standard Fake-IP range");
+    this.name = "FakeIpDnsError";
+  }
+}
+
 function parseIpv4(address: string): number[] | null {
   if (isIP(address) !== 4) return null;
   const octets = address.split(".").map(Number);
@@ -37,6 +44,11 @@ function isPublicIpv4(address: string): boolean {
   if (a === 203 && b === 0 && c === 113) return false;
   if (a >= 224) return false;
   return true;
+}
+
+function isStandardFakeIpv4(address: string): boolean {
+  const octets = parseIpv4(address);
+  return octets !== null && octets[0] === 198 && (octets[1] === 18 || octets[1] === 19);
 }
 
 function parseIpv6(address: string): number[] | null {
@@ -130,6 +142,15 @@ export async function resolvePinnedAddress(
     answers = await resolver(hostname);
   } catch {
     throw new Error("Media hostname resolution failed");
+  }
+  if (
+    answers.length > 0 &&
+    answers.length <= 32 &&
+    answers.every(
+      (answer) => answer.family === 4 && isStandardFakeIpv4(answer.address),
+    )
+  ) {
+    throw new FakeIpDnsError();
   }
   if (
     answers.length === 0 ||

--- a/src/utils/error-guidance.ts
+++ b/src/utils/error-guidance.ts
@@ -173,6 +173,20 @@ export function buildStructuredErrorPayload(
         stepsEn: ["Retry later; Bilibili playback URLs are temporary."],
         stepsZh: ["请稍后重试；Bilibili 播放地址是临时的。"],
       },
+      ASR_FAKE_IP_DNS: {
+        en: "The 198.18.0.0/15 addresses are standard Fake-IP placeholders that this server rejects by design.",
+        zh: "198.18.0.0/15 地址是标准 Fake-IP 占位地址，本服务会按安全设计拒绝连接。",
+        stepsEn: [
+          "Your proxy DNS returned placeholder addresses instead of the real Bilibili media addresses; the server keeps rejecting them to prevent unsafe redirected connections.",
+          "Choose how to continue: configure a fake-ip-filter or equivalent real-IP DNS rule for `*.bilivideo.com` and `*.bilivideo.cn`, keep those domains on your intended routing policy, then restart the proxy and reconnect the MCP client; or temporarily disable Fake-IP for this request.",
+          "Do not allowlist 198.18.0.0/15 in the MCP server.",
+        ],
+        stepsZh: [
+          "你的代理 DNS 返回了占位地址，而不是 Bilibili 媒体域名的真实地址；本服务会继续拒绝这些地址，以防止不安全的重定向连接。",
+          "请由你选择后续方案：配置 fake-ip-filter 或等效的真实 IP DNS 规则，使 `*.bilivideo.com` 和 `*.bilivideo.cn` 返回真实地址，保持这些域名使用你预期的路由策略，然后重启代理并重连 MCP 客户端；或者仅为本次请求临时停用 Fake-IP。",
+          "不要在 MCP 服务中放行 198.18.0.0/15。",
+        ],
+      },
       ASR_LIMIT_EXCEEDED: {
         en: "The selected Part exceeds a bounded ASR safety limit.",
         zh: "所选分集超出了 ASR 安全限制。",
@@ -205,15 +219,16 @@ export function buildStructuredErrorPayload(
       },
     };
     const selected = guidance[error.code];
+    const fakeIpDns = error.code === "ASR_FAKE_IP_DNS";
     return withCompatibilityNextSteps({
       error: true,
       message: selected.en,
       message_en: selected.en,
       message_zh: selected.zh,
       code: error.code,
-      category: "runtime",
-      retryable: error.retryable,
-      user_action_required: error.code === "ASR_NOT_READY" || error.code === "ASR_LIMIT_EXCEEDED",
+      category: fakeIpDns ? "network" : "runtime",
+      retryable: fakeIpDns ? false : error.retryable,
+      user_action_required: fakeIpDns || error.code === "ASR_NOT_READY" || error.code === "ASR_LIMIT_EXCEEDED",
       next_steps_en: selected.stepsEn,
       next_steps_zh: selected.stepsZh,
     });

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -97,6 +97,7 @@ export class NoSubtitleError extends Error {
 export type AsrErrorCode =
   | "ASR_NOT_READY"
   | "ASR_AUDIO_UNAVAILABLE"
+  | "ASR_FAKE_IP_DNS"
   | "ASR_LIMIT_EXCEEDED"
   | "ASR_BUSY"
   | "ASR_TRANSCRIPTION_TIMEOUT"

--- a/tests/asr-transcription.test.ts
+++ b/tests/asr-transcription.test.ts
@@ -18,6 +18,7 @@ import {
   transcribeVideoPart,
 } from "../src/asr/transcription.js";
 import type { PlaybackAudioCandidate } from "../src/bilibili/playback.js";
+import { FakeIpDnsError } from "../src/security/pinned-https.js";
 import { AsrError } from "../src/utils/errors.js";
 
 const tempDirs: string[] = [];
@@ -274,6 +275,99 @@ describe("temporary audio download", () => {
     await downloadPlaybackAudio([candidate], destination, fetchFn);
 
     expect(await fs.promises.readFile(destination)).toEqual(Buffer.from([1, 2, 3]));
+  });
+
+  it("returns ASR_FAKE_IP_DNS only when every attempted candidate resolves to Fake-IP", async () => {
+    const dir = await createAsrTempDir(ASR_TEMP_PREFIX);
+    tempDirs.push(dir);
+    const destination = path.join(dir, "audio.m4a");
+    const candidates = [
+      candidate,
+      { ...candidate, url: "https://upos-sz-mirrorcoso2.bilivideo.com/audio.m4s" },
+    ];
+    const fetchFn = vi.fn(async () => {
+      throw new FakeIpDnsError();
+    });
+
+    await expect(
+      downloadPlaybackAudio(candidates, destination, fetchFn),
+    ).rejects.toMatchObject({
+      code: "ASR_FAKE_IP_DNS",
+      retryable: false,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues to a usable candidate after a Fake-IP DNS failure", async () => {
+    const dir = await createAsrTempDir(ASR_TEMP_PREFIX);
+    tempDirs.push(dir);
+    const destination = path.join(dir, "audio.m4a");
+    const candidates = [
+      candidate,
+      { ...candidate, url: "https://upos-sz-mirrorcoso2.bilivideo.com/audio.m4s" },
+    ];
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new FakeIpDnsError())
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "audio/mp4", "content-length": "3" },
+        }),
+      );
+
+    await downloadPlaybackAudio(candidates, destination, fetchFn);
+
+    expect(await fs.promises.readFile(destination)).toEqual(Buffer.from([1, 2, 3]));
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [new FakeIpDnsError(), new Error("synthetic resolution failure")],
+    [new Error("synthetic resolution failure"), new FakeIpDnsError()],
+    [
+      new FakeIpDnsError(),
+      new AsrError("ASR_AUDIO_UNAVAILABLE", "synthetic media failure", true),
+    ],
+    [
+      new AsrError("ASR_AUDIO_UNAVAILABLE", "synthetic media failure", true),
+      new FakeIpDnsError(),
+    ],
+  ])("keeps mixed candidate failures generic", async (firstError, secondError) => {
+    const dir = await createAsrTempDir(ASR_TEMP_PREFIX);
+    tempDirs.push(dir);
+    const destination = path.join(dir, "audio.m4a");
+    const candidates = [
+      candidate,
+      { ...candidate, url: "https://upos-sz-mirrorcoso2.bilivideo.com/audio.m4s" },
+    ];
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(firstError)
+      .mockRejectedValueOnce(secondError);
+
+    await expect(
+      downloadPlaybackAudio(candidates, destination, fetchFn),
+    ).rejects.toMatchObject({ code: "ASR_AUDIO_UNAVAILABLE" });
+  });
+
+  it("keeps a public redirect followed by Fake-IP generic", async () => {
+    const dir = await createAsrTempDir(ASR_TEMP_PREFIX);
+    tempDirs.push(dir);
+    const destination = path.join(dir, "audio.m4a");
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: "https://upos-sz-mirrorcoso2.bilivideo.com/audio.m4s" },
+        }),
+      )
+      .mockRejectedValueOnce(new FakeIpDnsError());
+
+    await expect(
+      downloadPlaybackAudio([candidate], destination, fetchFn),
+    ).rejects.toMatchObject({ code: "ASR_AUDIO_UNAVAILABLE" });
   });
 
   it("revalidates every redirect and never exposes the signed location", async () => {

--- a/tests/pinned-https.test.ts
+++ b/tests/pinned-https.test.ts
@@ -37,6 +37,57 @@ describe("pinned playback HTTPS", () => {
     },
   );
 
+  it.each([
+    ["lower boundary", "198.18.0.0"],
+    ["upper boundary", "198.19.255.255"],
+  ])("classifies all-%s DNS answers as standard Fake-IP", async (_label, address) => {
+    await expect(
+      resolvePinnedAddress("cdn.bilivideo.com", async () => [
+        { address, family: 4 },
+      ]),
+    ).rejects.toMatchObject({ name: "FakeIpDnsError" });
+  });
+
+  it("classifies a multi-answer candidate only when every answer is standard Fake-IP", async () => {
+    await expect(
+      resolvePinnedAddress("cdn.bilivideo.com", async () => [
+        { address: "198.18.0.1", family: 4 },
+        { address: "198.19.255.254", family: 4 },
+      ]),
+    ).rejects.toMatchObject({ name: "FakeIpDnsError" });
+  });
+
+  it.each(["198.17.255.255", "198.20.0.0"])(
+    "does not classify adjacent address %s as standard Fake-IP",
+    async (address) => {
+      await expect(
+        resolvePinnedAddress("cdn.bilivideo.com", async () => [
+          { address, family: 4 },
+        ]),
+      ).resolves.toMatchObject({ address, family: 4 });
+    },
+  );
+
+  it("does not classify mixed Fake-IP and other DNS answers as standard Fake-IP", async () => {
+    for (const answers of [
+      [
+        { address: "198.18.0.1", family: 4 as const },
+        { address: "8.8.8.8", family: 4 as const },
+      ],
+      [
+        { address: "198.19.255.254", family: 4 as const },
+        { address: "127.0.0.1", family: 4 as const },
+      ],
+    ]) {
+      await expect(
+        resolvePinnedAddress("cdn.bilivideo.com", async () => answers),
+      ).rejects.toMatchObject({
+        name: "Error",
+        message: "Media hostname did not resolve to public addresses",
+      });
+    }
+  });
+
   it("rejects empty, mixed-publicity, and resolver-failure answers", async () => {
     await expect(
       resolvePinnedAddress("cdn.bilivideo.com", async () => []),

--- a/tests/server-error-next-steps.test.ts
+++ b/tests/server-error-next-steps.test.ts
@@ -330,6 +330,48 @@ describe("generic MCP error credential next_steps", () => {
 });
 
 describe("structured MCP error categories", () => {
+  it("explains standard Fake-IP DNS and lets the user choose a safe remedy", async () => {
+    mockGetVideoTranscriptData.mockRejectedValueOnce(
+      new AsrError(
+        "ASR_FAKE_IP_DNS",
+        "safe bounded Fake-IP diagnosis",
+      ),
+    );
+    const handler = getCallToolHandler();
+    const response = await handler({
+      method: "tools/call",
+      jsonrpc: "2.0",
+      id: 29,
+      params: {
+        name: "get_video_transcript",
+        arguments: { bvid_or_url: "BV1T6PQzQErF", force_asr: true },
+      },
+    });
+    const payload = JSON.parse(response.content[0].text);
+    const rendered = JSON.stringify(payload);
+
+    expect(response.isError).toBe(true);
+    expectStructuredError(payload, "ASR_FAKE_IP_DNS", {
+      retryable: false,
+      userActionRequired: true,
+    });
+    expect(payload.category).toBe("network");
+    expect(`${payload.message_en} ${payload.next_steps_en.join(" ")}`).toMatch(
+      /198\.18\.0\.0\/15.*Fake-IP.*reject/is,
+    );
+    expect(`${payload.message_zh} ${payload.next_steps_zh.join(" ")}`).toMatch(
+      /198\.18\.0\.0\/15.*Fake-IP.*拒绝/is,
+    );
+    expect(payload.next_steps_en.join(" ")).toMatch(
+      /choose.*fake-ip-filter.*\*\.bilivideo\.com.*\*\.bilivideo\.cn.*reconnect/is,
+    );
+    expect(payload.next_steps_zh.join(" ")).toMatch(
+      /选择.*fake-ip-filter.*\*\.bilivideo\.com.*\*\.bilivideo\.cn.*重连/is,
+    );
+    expect(rendered).toContain("Do not allowlist 198.18.0.0/15");
+    expect(rendered).not.toMatch(/SESSDATA|bili_jct|DedeUserID|token=|audio\.m4s|Authorization/i);
+  });
+
   it.each([
     ["ASR_NOT_READY", false, true],
     ["ASR_AUDIO_UNAVAILABLE", true, false],


### PR DESCRIPTION
Closes #57

## Summary
- classify standard 198.18.0.0/15 Fake-IP DNS answers without weakening pinned HTTPS rejection
- aggregate candidate failures into ASR_FAKE_IP_DNS only when every attempted candidate has the exclusive cause
- return bounded bilingual MCP guidance and preserve generic errors for mixed failures

## Verification
- npm test (42 files, 1072 tests)
- npm run build
- npm pack --dry-run --json --ignore-scripts (193 files)
- production npm audit: 0 vulnerabilities
- gitleaks staged diff: 0 findings
- Harness migration receipt and 102-test core suite passed
- Standards, Spec, and risk reviews: PASS