### PR TITLE
test: complete Fake-IP cross-Node and FlClash acceptance

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -47,6 +47,32 @@ jobs:
       - name: Check package contents
         run: npm pack --dry-run
 
+  fake_ip_node:
+    name: Fake-IP Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 25]
+    steps:
+      # v7.0.1 resolved from the official actions/checkout repository on 2026-08-16.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      # v7.0.0 resolved from the official actions/setup-node repository on 2026-08-16.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test Fake-IP contracts
+        run: npm run test:fake-ip
+
   harness:
     name: Harness (${{ matrix.os }}, ${{ matrix.shard }})
     runs-on: ${{ matrix.os }}
@@ -109,6 +135,7 @@ jobs:
     if: always()
     needs:
       - product
+      - fake_ip_node
       - harness
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -116,5 +143,9 @@ jobs:
       - name: Require all verification jobs
         env:
           PRODUCT_RESULT: ${{ needs.product.result }}
+          FAKE_IP_NODE_RESULT: ${{ needs.fake_ip_node.result }}
           HARNESS_RESULT: ${{ needs.harness.result }}
-        run: test "$PRODUCT_RESULT" = success && test "$HARNESS_RESULT" = success
+        run: >-
+          test "$PRODUCT_RESULT" = success &&
+          test "$FAKE_IP_NODE_RESULT" = success &&
+          test "$HARNESS_RESULT" = success

--- a/docs/agent-memory/active-work.md
+++ b/docs/agent-memory/active-work.md
@@ -2,17 +2,16 @@
 
 ## Current Product Ticket
 
-GitHub Issue #58 completes the approved #56 Fake-IP DNS user guidance after
-#57 merged. Work is isolated on `codex/issue-58-fake-ip-guidance` from merged
-#57 base `c95d05d2b2efd355241b3fcc202140a66cda14b3` and is directly executed by
-Codex without Paseo. The bounded scope is the structured MCP remedy choices,
-public response regression coverage, and bilingual tool-reference
-troubleshooting. The implementation is committed and pushed under PR #62. A
-Codex P2 review correctly identified that the migration artifact's package
-receipt had not been refreshed; the scoped review repair regenerates that
-receipt and adds a cross-platform freshness assertion. Merge is authorized
-only after the repaired head passes review and hosted CI; release and
-publication remain separate authority gates.
+GitHub Issue #59 completes the approved #56 Fake-IP DNS acceptance after #57
+and #58 merged and closed. Work is isolated on
+`codex/issue-59-fake-ip-qa` from merged PR #62 base
+`03ccb8bf2e1172a7591b893d79f2af699c2532c3` and is directly executed by Codex
+without Paseo. The bounded scope is a Node 20/22/25 focused CI gate plus
+redacted real FlClash Rule + TUN + Fake-IP evidence. Local focused, build,
+complete-suite, package, production-audit, and real pre/post-filter acceptance
+all pass. The user-controlled override was restored and reloaded after QA;
+push, PR, Issue close, release, and publication remain separate authority
+gates.
 
 ## Harness v2
 

--- a/docs/agent-memory/codemap.md
+++ b/docs/agent-memory/codemap.md
@@ -155,6 +155,8 @@ When adding or changing a public MCP tool, inspect both `tool-schemas.ts` and `t
 - `tests/update-check.test.ts`: package update guidance behavior and registry-failure fallback.
 - `tests/server-error-next-steps.test.ts`: structured recovery guidance in tool errors, including bounded bilingual Fake-IP cause and remedy choices.
 - `tests/fake-ip-guidance-docs.test.ts`: bilingual tool-reference regression for the Fake-IP cause, exact proxy rules, alternatives, and explicit user-choice boundary.
+- `tests/fake-ip-node-matrix.test.ts`: regression for the focused package
+  script, Node 20/22/25 Verify matrix, and Required-gate dependency.
 - `tests/server-handler-sanitization.test.ts`: handler-level sanitization plus transcript/search structured-output contract checks.
 - `tests/credential-guidance.test.ts`: credential setup/status guidance.
 - `tests/bilibili-video-api.test.ts`: video/subtitle API safety and behavior checks.
@@ -184,7 +186,9 @@ Default verification:
 - `package.json`: npm metadata, binary mapping, scripts, dependencies, and publish file allowlist.
 - `package-lock.json`: npm lockfile; update through npm tooling, not manual edits.
 - `.github/workflows/verify.yml`: read-only pull-request/default-branch CI for
-  product build/test/package checks and sharded Windows/Linux Harness tests.
+  product build/test/package checks, the focused Node 20/22/25 Fake-IP contract
+  matrix, and sharded Windows/Linux Harness tests. `Required` aggregates all
+  three groups.
 - `.github/workflows/publish.yml`: trusted-publishing npm release workflow for version tags.
 - `README.md`, `README_EN.md`: concise bilingual landing pages with project value, verified evidence workflow, installation and verification flow, task-oriented tool selection, CLI status gates, product limits, privacy and safety boundaries, plus prominent links to the canonical setup and tool references; they do not duplicate exhaustive installation or configuration methods.
 - `docs/client-setup.md`, `docs/client-setup.en.md`: canonical bilingual source for the Agent installation prompt, npm/global/source installation, all supported MCP client configurations, credential setup and login validation, and optional runtime configuration.

--- a/docs/agent-memory/executions/2026-08-23-github-59-codex-direct-report.md
+++ b/docs/agent-memory/executions/2026-08-23-github-59-codex-direct-report.md
@@ -1,0 +1,100 @@
+# Execution Report: GitHub Issue #59
+
+## Contract
+
+- Task/source: GitHub Issue #59; parent #56; dependencies #57 and #58 closed.
+- Mode: `codex-direct` (the user explicitly requested direct Codex execution).
+- Canonical worktree/base: `C:\Users\ZX\.codex\worktrees\issue-59\bilibili-mcp` at `03ccb8bf2e1172a7591b893d79f2af699c2532c3`.
+- Writer/acceptance owner: Codex.
+- Terminal state: locally accepted; hosted CI and all remote effects remain pending separate authority.
+
+## Summary
+
+The existing Fake-IP regression seams now run as one focused package script on
+Node 20, 22, and 25 in GitHub Actions, and the aggregate `Required` job blocks
+unless the matrix succeeds. A redacted real FlClash Rule + TUN + Fake-IP check
+proved both sides of the user flow: without the two Bilibili media filters the
+same public `force_asr` request returned `ASR_FAKE_IP_DNS` before model work;
+after restoring the filters it completed the existing CPU ASR path.
+
+No product runtime code, MCP schema, dependency, model, proxy node, TUN mode,
+rule mode, release, or publication changed.
+
+## Files Changed And Diff Scope
+
+- Added the focused `test:fake-ip` package script and Node 20/22/25 workflow job.
+- Added one workflow-configuration regression test.
+- Added current official Actions research and a redacted real-environment QA record.
+- Updated active work, codemap, verification evidence, and the existing Harness
+  package/durable-memory receipt chain.
+
+## Commands And Results
+
+- Matrix configuration regression: failed 2/2 before the workflow/script change,
+  then passed 2/2.
+- `npm run test:fake-ip`: 92/92 passed on Node 20.20.2, 22.23.2, and 25.9.0.
+- `npm run build`: passed.
+- `npm test`: 44 files / 1,076 tests passed.
+- `npm pack --dry-run --json --ignore-scripts`: 193 files; canonical LF receipt synchronized.
+- `npm audit --omit=dev`: zero production vulnerabilities.
+- Exact real-pilot conformance: 1/1 passed.
+- Harness contracts, events, adapters, and memory: 102 passed, 15 skipped.
+- `git diff --check`: passed with Windows line-ending warnings only.
+- gitleaks 8.30.1 staged-diff scan: zero findings.
+
+## Acceptance Criteria
+
+- Node 20/22/25 focused DNS, pinned HTTPS, candidate aggregation, and MCP error
+  checks: passed locally; the hosted matrix remains a later PR gate.
+- Build and complete tests: passed.
+- Real unfiltered FlClash state: returned the dedicated diagnostic before model work.
+- Restored `+.bilivideo.com` and `+.bilivideo.cn`: same CPU request completed ASR.
+- Redaction and CPU-only hardware boundary: passed.
+
+## Repairs And Failure Fingerprints
+
+- A first harness-only MCP client used the SDK default 60-second timeout; the
+  repeated request passed after supplying the product's existing request ceiling.
+  Product timeout behavior was not changed.
+- Standards review found that the workflow test did not assert the final
+  `FAKE_IP_NODE_RESULT` success predicate and that this unified report was
+  missing. Both same-scope gaps were repaired without runtime changes.
+- Adding the package script and memory evidence invalidated existing Harness
+  receipts. The canonical package output, durable-memory hashes, and outer
+  migration hash were regenerated and conformance passed.
+
+## Risks, Skipped Checks, Recovery Bundle
+
+- GitHub-hosted Node matrix execution is skipped until push/PR authority exists;
+  `Required` must pass before merge.
+- Real FlClash evidence is deliberately redacted and cannot be fully replayed
+  from the repository alone.
+- No Recovery Bundle or unresolved local blocker exists.
+
+## Capabilities Used
+
+- Manual Skills and invocation evidence: user invoked Matt `implement` for #59.
+- Model-invoked Skills: Matt `code-review`, `github-actions-docs`,
+  `bilibili-mcp-memory`, and `git-local-commit`.
+- Unavailable Skills: `vitest` and `secret-scanning` were not exposed in this
+  runtime; repository Vitest commands and installed gitleaks were used instead.
+- Agents/reviewers: Standards, Spec, and project risk review; Spec and risk had
+  no findings, while Standards supplied the two repaired gaps above.
+- MCP/tools/CLI: local Git, GitHub CLI, npm, Node, Vitest, Python unittest,
+  gitleaks, FlClash/Mihomo control surface, and MCP stdio smoke client.
+
+## Harness Artifacts
+
+- Task ticket: live GitHub Issue #59; no duplicate local ticket.
+- Research: `docs/research/2026-08-23-fake-ip-node-matrix.md`.
+- QA checklist: `docs/qa/2026-08-23-fake-ip-dns-flclash.md`.
+- Security: `docs/agent-memory/harness-security.md` reviewed; no secret or new authority.
+- Codemap: updated for the focused script, workflow matrix, and regression test.
+- Memory: active work and verification log updated with bounded, redacted evidence.
+- Harness eval: unchanged; this ticket adds CI coverage but does not redesign an adapter.
+
+## Local Commit
+
+Initial accepted implementation commit: `7742fee`. Review repairs and this
+report are retained as one additional local commit. No push, PR, merge, Issue
+close, tag, release, or npm publication occurred.

--- a/docs/agent-memory/verification-log.md
+++ b/docs/agent-memory/verification-log.md
@@ -2590,3 +2590,31 @@ Six release blockers fixed; one regression proof per root cause (new tests
   file sizes. The exact conformance gate and Harness core suite passed after the
   refreshed three-level receipt chain; no dependency, product behavior, proxy
   configuration, tag, release, or publication changed.
+
+## 2026-08-23 — Issue #59 Cross-Node And Real FlClash Acceptance
+
+- Automation: `test:fake-ip` runs the pinned-HTTPS DNS contract, all-candidate
+  ASR aggregation, and public MCP error structure. The same 92 tests passed on
+  Node 20.20.2, 22.23.2, and 25.9.0. Verify now carries a three-version matrix,
+  and the aggregate `Required` job depends on it. The matrix configuration
+  regression failed 2/2 before the workflow change and passed afterward.
+- Full verification: TypeScript build passed; Vitest passed 44 files / 1,076
+  tests; npm pack dry-run contained 193 files; `npm audit --omit=dev` reported
+  zero production vulnerabilities.
+- Real environment: with FlClash Rule mode, TUN, and Fake-IP active, temporarily
+  removing only `+.bilivideo.com` and `+.bilivideo.cn` produced exclusively
+  standard Fake-IP answers. The same public `force_asr` MCP request returned
+  `ASR_FAKE_IP_DNS` in 2,223 ms before model work, with category `network`,
+  non-retryable, and user-action-required.
+- Recovery evidence: after the user restored and reloaded the approved override,
+  both filters returned, sampled media DNS resolved outside the standard
+  Fake-IP range, and the same CPU `small` ASR path completed with
+  `data_source=asr` and a non-empty 1,744-character transcript. The transcript,
+  Cookie, signed URL, full DNS answers, proxy node, and private profile content
+  were not retained.
+- Boundary: no product runtime code, dependency, MCP schema, proxy node, TUN,
+  rule mode, model, release, or publication changed. Hosted matrix evidence
+  remains a later push/PR gate.
+- Harness: after refreshing the canonical LF package receipt and durable-memory
+  hashes, exact real-pilot conformance passed 1/1 and the contracts, events,
+  adapters, and memory core suite passed 102 tests with 15 skipped.

--- a/docs/qa/2026-08-23-fake-ip-dns-flclash.md
+++ b/docs/qa/2026-08-23-fake-ip-dns-flclash.md
@@ -1,0 +1,102 @@
+# Issue #59 Fake-IP DNS and FlClash acceptance
+
+## QA Session
+
+- Title: Cross-Node Fake-IP contracts and real FlClash recovery
+- Date: 2026-08-23
+- Version or commit: `1.13.0`; base `03ccb8bf2e1172a7591b893d79f2af699c2532c3`
+- Owner: Codex with user-controlled FlClash state changes
+- Related ticket: GitHub Issue #59; parent #56; dependencies #57 and #58
+- QA type: regression / MCP tool change
+
+## Scope
+
+In scope:
+
+- Node 20, 22, and 25 focused Fake-IP contract tests.
+- Real Windows FlClash Rule + TUN + Fake-IP behavior before and after the two
+  Bilibili media-domain filters.
+- A public `force_asr` MCP path using the already-ready CPU model.
+
+Out of scope:
+
+- GPU readiness, model installation, proxy-node selection, public DNS bypass,
+  release, and publication.
+
+## Preconditions
+
+- [x] Work is isolated on `codex/issue-59-fake-ip-qa` from the recorded base.
+- [x] Package version is `1.13.0`.
+- [x] Credentials are loadable from the approved global configuration; no value
+  was printed or copied into this record.
+- [x] The test BVID is public and already used by repository fixtures.
+- [x] Local MCP stdio, Windows, FlClash Rule mode, TUN, and Fake-IP DNS are active.
+- [x] `doctor --json` reports the existing `small` model ready on CPU.
+
+## Automated Evidence
+
+| Runtime | Focused files | Result |
+|---------|---------------|--------|
+| Node 20.20.2 | pinned HTTPS, ASR candidate aggregation, MCP error structure | 92/92 pass |
+| Node 22.23.2 | pinned HTTPS, ASR candidate aggregation, MCP error structure | 92/92 pass |
+| Node 25.9.0 | pinned HTTPS, ASR candidate aggregation, MCP error structure | 92/92 pass |
+
+- [x] The new matrix configuration regression failed 2/2 before the package
+  script and workflow job existed, then passed 2/2.
+- [x] `npm run test:fake-ip` passes 92/92 on the local default Node runtime.
+- [x] Final `npm run build` and complete `npm test`: 44 files / 1,076 tests
+  pass.
+- [x] Exact real-pilot conformance passed 1/1; Harness contracts, events,
+  adapters, and memory passed 102 tests with 15 skipped.
+- [ ] Hosted Node matrix; requires a later authorized push/PR.
+
+## Real FlClash Evidence
+
+Environment:
+
+- Windows with FlClash Rule mode, TUN enabled, DNS enhanced mode `fake-ip`.
+- No proxy node, private profile content, Cookie, signed media URL, or complete
+  DNS answer is recorded.
+
+Without the two media-domain filters:
+
+- [x] Active profile temporarily omits `+.bilivideo.com` and
+  `+.bilivideo.cn` while Rule mode and TUN remain enabled.
+- [x] The same `force_asr` request returns `ASR_FAKE_IP_DNS` in 2,223 ms,
+  before model work, with category `network`, `retryable: false`, and
+  `user_action_required: true`.
+
+With the two media-domain filters:
+
+- [x] The active generated configuration contains exactly
+  `+.bilivideo.com` and `+.bilivideo.cn` from the user-approved override script.
+- [x] The sampled Bilibili media hostname resolves outside the standard
+  Fake-IP range; individual DNS answers are intentionally omitted.
+- [x] The same public `force_asr` request completes with `data_source: asr`
+  and a non-empty 1,744-character transcript; transcript text is omitted.
+- [x] Rule mode and TUN remained enabled.
+- [x] The original override script was restored, the configuration was
+  reloaded, both filters returned, and DNS again resolved outside the standard
+  Fake-IP range.
+
+One harness-only first attempt used the MCP SDK's default 60-second client
+timeout and was cancelled cleanly. Repeating with the product's 30-minute
+ceiling completed successfully; no product timeout was changed.
+
+## Security And Privacy
+
+- [x] No Cookie, credential value, proxy node, private profile, signed media
+  URL, complete DNS answer, or transcript text is retained.
+- [x] The live result records only status, source, and bounded aggregate size.
+- [x] Existing pinned HTTPS, Host/SNI, redirect, and candidate fallback behavior
+  is unchanged.
+
+## Result
+
+- Overall result: `pass`
+- Blocking issue: none.
+- Non-blocking caveat: hosted Node matrix evidence requires later push/PR
+  authority.
+- Follow-up ticket: none.
+- Codemap update status: complete.
+- Research note: `docs/research/2026-08-23-fake-ip-node-matrix.md`

--- a/docs/research/2026-08-23-fake-ip-node-matrix.md
+++ b/docs/research/2026-08-23-fake-ip-node-matrix.md
@@ -1,0 +1,73 @@
+# Fake-IP Node compatibility matrix
+
+## Research Topic
+
+- Topic: GitHub Actions matrix for the Issue #59 focused Fake-IP suite
+- Date: 2026-08-23
+- Owner: Codex
+- Related task: GitHub Issue #59
+- Refresh before: changing the Verify workflow or its pinned setup-node action
+
+## Question
+
+How should the repository run one focused Vitest command on Node 20, 22, and
+25 without duplicating the test definition or weakening the existing Required
+gate?
+
+## Context
+
+Issue #59 requires durable cross-Node evidence for DNS lookup, pinned HTTPS,
+audio-candidate aggregation, and the public MCP Fake-IP error structure.
+
+## Sources
+
+| Source | Type | Date checked | Notes |
+|--------|------|--------------|-------|
+| [GitHub workflow syntax — strategy matrix](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategymatrix) | official docs | 2026-08-23 | Matrix values are exposed through the `matrix` context and create one job per value. |
+| [actions/setup-node usage](https://github.com/actions/setup-node/blob/main/README.md) | official source | 2026-08-23 | `node-version` accepts a matrix value; the repository already pins setup-node v7 to an immutable SHA. |
+
+## Findings
+
+- One `strategy.matrix.node-version` list creates independent Node 20, 22, and
+  25 jobs while keeping one focused command.
+- `fail-fast: false` preserves evidence from the other Node versions if one
+  version fails.
+- The existing immutable checkout and setup-node pins can be reused; no new
+  action or dependency is required.
+- The aggregate `Required` job must depend on the matrix job so a failed or
+  cancelled Node version cannot be hidden by the main product job.
+
+## Applicability To This Project
+
+Applies:
+
+- Add one `test:fake-ip` package script as the single focused command.
+- Add one three-version job to `.github/workflows/verify.yml`.
+- Include that job result in `Required`.
+
+Does not apply:
+
+- This matrix does not run live Bilibili, Cookie, ASR model, or FlClash tests in
+  GitHub-hosted runners.
+
+## Decision Impact
+
+Use the existing workflow actions and npm cache, and run the deterministic
+Fake-IP contract suite on Node 20, 22, and 25. Keep real FlClash evidence in a
+separate redacted QA record.
+
+## Risks And Unknowns
+
+- Major-only Node selectors intentionally follow the newest available patch in
+  each tested major; exact local patch versions are recorded in QA evidence.
+- Hosted matrix evidence is available only after the branch is pushed and a PR
+  or master workflow run starts.
+
+## Staleness Notes
+
+Refresh this note when the supported Node floor, Verify workflow, or setup-node
+pin changes.
+
+## Follow-Up
+
+- [ ] Confirm the hosted Node matrix before release.

--- a/harness/fixtures/pilot-artifacts/migration.json
+++ b/harness/fixtures/pilot-artifacts/migration.json
@@ -89,27 +89,27 @@
     }
   ],
   "durable_memory": {
-    "docs/agent-memory/active-work.md": "c6bf8ad518f3488d3440db12d27550466143fdd49a85a5e35c67297d7d60305a",
-    "docs/agent-memory/codemap.md": "e08ec7f0539e6c2fd96b6f8434d76552d863b346e434a7d1e6c6a1c61c188ff7",
+    "docs/agent-memory/active-work.md": "469bf4c917953eee9a7e19ad395d9a84c82bbbe7577ab6314efaeb64fb3aa248",
+    "docs/agent-memory/codemap.md": "5d73f156c64b917289a744175c30456530f9d1adcc310195c38533215db22364",
     "docs/agent-memory/decisions.md": "302b443c014aa57294dfe2eaed16c18677c89a7fdb653919041304a46afa672e",
     "docs/agent-memory/executions/2026-08-14-github-36-codex-direct-report.md": "439b169470c2ab1ec3af3625b8ca3e247d6ccd4f01bc39ff967deff673853570",
     "docs/agent-memory/harness-eval.md": "f531cc2d0e69ccc8d41c882c9aefdae03d5583789bc19c51dd45a4188fe9a370",
     "docs/agent-memory/harness-security.md": "b907339f85c0ba13c2a8642b475aa682ae1b313cb51cebec9977aca798df3430",
     "docs/agent-memory/lessons-learned.md": "6a0e45bc73159237fb3200a3725d12d54dd0d83aa5c8eebcec5ffb9bd2efb7d7",
     "docs/agent-memory/project-facts.md": "ce49559de2e1ed1ecb322ecd2f0d3ff62887c9ca1f7d885ab2b47ab9ff6b7e3c",
-    "docs/agent-memory/verification-log.md": "74dc17820d472a671ea5b2ecfed86df0844eb74c8bea807fe0c20e95ecad876c"
+    "docs/agent-memory/verification-log.md": "0ee3f44f45803360428f40fc2ccb1f2fb45e4570511c71ada9746582a42c99c6"
   },
   "package": {
-    "output_digest": "bd1706df97cabcab513ef17abeef73b8e6fbf38022c9c70fd0b54f56257f1b6f",
+    "output_digest": "349327664349100ff08e9f837f700b6bfa1f7c9532f39c2cd5d57838d16967e8",
     "pack_output": [
       {
         "id": "@xzxzzx/bilibili-mcp@1.13.0",
         "name": "@xzxzzx/bilibili-mcp",
         "version": "1.13.0",
-        "size": 1136235,
-        "unpackedSize": 1927169,
-        "shasum": "f8af318ac78fdd264347075f25f04c82d5e37e68",
-        "integrity": "sha512-uOi4xmIrT/Lz3PBmk7NZI7lLXI229OpPoKcVxJk88HTng+xl71U2j5NDMO4q5jO56GmHT27w3J7CVz7Al3LmiQ==",
+        "size": 1136287,
+        "unpackedSize": 1927300,
+        "shasum": "e4ae76277f5b2bfc769dd160373a2293d0b84a7b",
+        "integrity": "sha512-gmux7ccocFj4mROokWTQLWwmwbp8BoJEB2CeD3CKVhFj0Ebf2dRpw+w6uUp1vR8itqK8WdmrOZzkF5eXBbojHg==",
         "filename": "xzxzzx-bilibili-mcp-1.13.0.tgz",
         "files": [
           {
@@ -1074,7 +1074,7 @@
           },
           {
             "path": "package.json",
-            "size": 2349,
+            "size": 2480,
             "mode": 420
           }
         ],

--- a/harness/fixtures/three-adapter-pilot-evidence.json
+++ b/harness/fixtures/three-adapter-pilot-evidence.json
@@ -8,7 +8,7 @@
       "product-verification": "pass"
     },
     "file": "migration.json",
-    "sha256": "129eacdf2e591038b24d9040d84ed2187ded22a1528f30325740a402fd4da813"
+    "sha256": "d7814d9d05a138fbb76847e7ffffc62d46f9d0f9ccaf380b1ced30111c8cc9b1"
   },
   "pilots": [
     {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "node --input-type=commonjs -e \"const{rmSync}=require('fs');const{resolve,dirname,basename}=require('path');const d=resolve('dist');if(dirname(d)!==process.cwd()||basename(d)!=='dist'){console.error('Safety check failed: '+d);process.exit(1);}rmSync(d,{recursive:true,force:true});\" && tsc",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
+    "test:fake-ip": "vitest run tests/pinned-https.test.ts tests/asr-transcription.test.ts tests/server-error-next-steps.test.ts",
     "prepublishOnly": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/tests/fake-ip-node-matrix.test.ts
+++ b/tests/fake-ip-node-matrix.test.ts
@@ -22,5 +22,8 @@ describe("Fake-IP Node compatibility gate", () => {
     expect(verifyWorkflow).toContain("npm run test:fake-ip");
     expect(verifyWorkflow).toMatch(/required:[\s\S]*needs:[\s\S]*- fake_ip_node/);
     expect(verifyWorkflow).toContain("FAKE_IP_NODE_RESULT:");
+    expect(verifyWorkflow).toContain(
+      'test "$FAKE_IP_NODE_RESULT" = success',
+    );
   });
 });

--- a/tests/fake-ip-node-matrix.test.ts
+++ b/tests/fake-ip-node-matrix.test.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const packageJson = JSON.parse(
+  fs.readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { scripts?: Record<string, string> };
+const verifyWorkflow = fs.readFileSync(
+  new URL("../.github/workflows/verify.yml", import.meta.url),
+  "utf8",
+);
+
+describe("Fake-IP Node compatibility gate", () => {
+  it("defines the focused DNS, download aggregation, and MCP error suite", () => {
+    expect(packageJson.scripts?.["test:fake-ip"]).toBe(
+      "vitest run tests/pinned-https.test.ts tests/asr-transcription.test.ts tests/server-error-next-steps.test.ts",
+    );
+  });
+
+  it("runs the focused suite on Node 20, 22, and 25 before Required passes", () => {
+    expect(verifyWorkflow).toContain("fake_ip_node:");
+    expect(verifyWorkflow).toContain("node-version: [20, 22, 25]");
+    expect(verifyWorkflow).toContain("npm run test:fake-ip");
+    expect(verifyWorkflow).toMatch(/required:[\s\S]*needs:[\s\S]*- fake_ip_node/);
+    expect(verifyWorkflow).toContain("FAKE_IP_NODE_RESULT:");
+  });
+});


### PR DESCRIPTION
## Summary

- add a focused Fake-IP regression script covering pinned HTTPS, ASR candidate aggregation, and public MCP error structure
- run that suite on GitHub-hosted Node 20, 22, and 25 and require the matrix in the aggregate `Required` job
- record redacted real FlClash Rule + TUN + Fake-IP failure/recovery evidence

## Verification

- Node 20.20.2: 92/92 focused tests passed
- Node 22.23.2: 92/92 focused tests passed
- Node 25.9.0: 92/92 focused tests passed
- `npm run build`: passed
- `npm test`: 44 files / 1,076 tests passed
- Harness conformance: 1/1 passed
- Harness core: 102 passed, 15 skipped
- gitleaks staged-diff scan: zero findings

## Merge condition

Do not merge until the GitHub-hosted Node 20/22/25 matrix and aggregate `Required` check pass.

Closes #59