### PR TITLE
feat(cli): explain ASR model tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ Bilibili 会把部分视频的 AI 识别字幕标为 `ai-zh`、`ai-en`、`ai-ja`
 
 | 模型 | 大小 | 说明 |
 |---|---|---|
-| tiny | ~78 MB | 最小占用 |
-| base | ~148 MB | 折中选择 |
-| small | ~486 MB | 推荐，Enter 默认选中 |
+| tiny | ~78 MB | 速度优先：适合快速提取和长视频初筛；准确率相对较低 |
+| base | ~148 MB | 均衡：兼顾速度、质量和资源占用 |
+| small | ~486 MB | 质量优先：CPU 耗时和内存占用更高；推荐，Enter 默认选中 |
 
 Runtime 固定为 `faster-whisper==1.2.1`，模型存放在用户目录 `~/.bilibili-mcp/asr/`，通过 CPU INT8 加载验证后才算就绪，不需要系统 FFmpeg；同一目录仅保留一个活跃模型。`doctor --json` 的 `asr.status` 和 `asr.model` 报告就绪状态与已选模型（纯信息字段，不影响凭证退出状态）。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -176,9 +176,9 @@ Some videos ship without any subtitle. Once you install a local ASR model, `get_
 
 | Model | Size | Notes |
 |---|---|---|
-| tiny | ~78 MB | smallest footprint |
-| base | ~148 MB | middle ground |
-| small | ~486 MB | recommended, selected on Enter |
+| tiny | ~78 MB | Speed-first: suited to quick extraction and initial review of long videos; relatively lower accuracy |
+| base | ~148 MB | Balanced: balances speed, quality, and resource use |
+| small | ~486 MB | Quality-first: higher CPU time and memory use; recommended, selected on Enter |
 
 The runtime is pinned to `faster-whisper==1.2.1`. Models live under `~/.bilibili-mcp/asr/`, are verified by a CPU INT8 load before being marked ready, and do not require system FFmpeg; only one active model is kept per directory. `doctor --json` reports readiness and the selected model via `asr.status` and `asr.model` (informational fields that never affect credential exit codes).
 

--- a/docs/client-setup.en.md
+++ b/docs/client-setup.en.md
@@ -1354,9 +1354,9 @@ bilibili-mcp check
 After credentials are configured, `setup` asks whether to install an optional local ASR model (defaults to No `[y/N]`).
 
 - After choosing Yes, three model choices are displayed:
-  - `1. tiny` (~78.2 MB) — smallest footprint
-  - `2. base` (~148 MB)
-  - `3. small` (~486 MB) — [recommended], selected on Enter
+  - `1. tiny` (~78.2 MB) — Speed-first: suited to quick extraction and initial review of long videos, with relatively lower accuracy
+  - `2. base` (~148 MB) — Balanced: balances speed, quality, and resource use
+  - `3. small` (~486 MB) — Quality-first: higher CPU time and memory use; [recommended], selected on Enter
 - Enter `1/2/3` or `tiny/base/small` to choose; invalid input re-prompts without starting installation.
 - Runtime is fixed at `faster-whisper==1.2.1` plus runtime library overhead.
 - Requires Python 3.9+ on the machine. Set the `BILIBILI_ASR_PYTHON` environment variable to override the Python executable.

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -1347,9 +1347,9 @@ bilibili-mcp check
 完成凭证配置后，`setup` 会询问是否安装可选的本地 ASR 模型（默认为否 `[y/N]`）。
 
 - 选择 Yes 后，会显示三个可选模型：
-  - `1. tiny`（约 78.2 MB）— 最小体积
-  - `2. base`（约 148 MB）
-  - `3. small`（约 486 MB）— [推荐]，Enter 默认选择
+  - `1. tiny`（约 78.2 MB）— 速度优先：适合快速提取和长视频初筛，准确率相对较低
+  - `2. base`（约 148 MB）— 均衡：兼顾速度、质量和资源占用
+  - `3. small`（约 486 MB）— 质量优先：CPU 耗时和内存占用更高；[推荐]，Enter 默认选择
 - 输入数字 `1/2/3` 或名称 `tiny/base/small` 选择；无效输入会重新提示，不会启动安装。
 - runtime 固定为 `faster-whisper==1.2.1`，加上运行时库的总磁盘开销。
 - 需要本机装有 Python 3.9+。可通过设置 `BILIBILI_ASR_PYTHON` 环境变量指定 Python 可执行文件。

--- a/harness/fixtures/pilot-artifacts/migration.json
+++ b/harness/fixtures/pilot-artifacts/migration.json
@@ -100,16 +100,16 @@
     "docs/agent-memory/verification-log.md": "0ee3f44f45803360428f40fc2ccb1f2fb45e4570511c71ada9746582a42c99c6"
   },
   "package": {
-    "output_digest": "349327664349100ff08e9f837f700b6bfa1f7c9532f39c2cd5d57838d16967e8",
+    "output_digest": "b794903d0c96ada487f050e75730b121afbe00df07b0f98c8e1b39cdc72ecb4e",
     "pack_output": [
       {
         "id": "@xzxzzx/bilibili-mcp@1.13.0",
         "name": "@xzxzzx/bilibili-mcp",
         "version": "1.13.0",
-        "size": 1136287,
-        "unpackedSize": 1927300,
-        "shasum": "e4ae76277f5b2bfc769dd160373a2293d0b84a7b",
-        "integrity": "sha512-gmux7ccocFj4mROokWTQLWwmwbp8BoJEB2CeD3CKVhFj0Ebf2dRpw+w6uUp1vR8itqK8WdmrOZzkF5eXBbojHg==",
+        "size": 1136900,
+        "unpackedSize": 1928398,
+        "shasum": "fc3758a3062c45d0426ef02965103278e9643bca",
+        "integrity": "sha512-f1lQcatpVgD6l9uh2xMUi41uOVo+r3P6mNMUPFkmAGpEeTjkgqq2/pgIGttepz+Mp20YboYos0es8zKCt2NZ5A==",
         "filename": "xzxzzx-bilibili-mcp-1.13.0.tgz",
         "files": [
           {
@@ -119,12 +119,12 @@
           },
           {
             "path": "README_EN.md",
-            "size": 19655,
+            "size": 19822,
             "mode": 420
           },
           {
             "path": "README.md",
-            "size": 18094,
+            "size": 18239,
             "mode": 420
           },
           {
@@ -564,12 +564,12 @@
           },
           {
             "path": "dist/cli.js",
-            "size": 16111,
+            "size": 16406,
             "mode": 420
           },
           {
             "path": "dist/cli.js.map",
-            "size": 13784,
+            "size": 13924,
             "mode": 420
           },
           {
@@ -1054,12 +1054,12 @@
           },
           {
             "path": "docs/client-setup.en.md",
-            "size": 44494,
+            "size": 44684,
             "mode": 420
           },
           {
             "path": "docs/client-setup.md",
-            "size": 42616,
+            "size": 42777,
             "mode": 420
           },
           {

--- a/harness/fixtures/three-adapter-pilot-evidence.json
+++ b/harness/fixtures/three-adapter-pilot-evidence.json
@@ -8,7 +8,7 @@
       "product-verification": "pass"
     },
     "file": "migration.json",
-    "sha256": "d7814d9d05a138fbb76847e7ffffc62d46f9d0f9ccaf380b1ced30111c8cc9b1"
+    "sha256": "f71a5ae1cfe87182cfc6b95a31df33bad084c64fc094b0fb5574db47cc841620"
   },
   "pilots": [
     {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,12 @@ import {
 } from "./asr/state.js";
 import { runAsrInstallation } from "./asr/installer.js";
 
+const ASR_MODEL_TIER_DESCRIPTIONS: Record<AsrModelKey, string> = {
+  tiny: "速度优先：适合快速提取和长视频初筛，准确率相对较低",
+  base: "均衡：兼顾速度、质量和资源占用",
+  small: "质量优先：CPU 耗时和内存占用更高",
+};
+
 // Version info
 import fs from "fs";
 const packageJson = JSON.parse(
@@ -381,7 +387,9 @@ export async function setupCredentials(
   for (let i = 0; i < ASR_MODEL_SPECS.length; i++) {
     const spec = ASR_MODEL_SPECS[i];
     const marker = spec.key === "small" ? " [推荐]" : "";
-    console.log(`  ${i + 1}. ${spec.key}（约 ${spec.approximateMB} MB）${marker}`);
+    console.log(
+      `  ${i + 1}. ${spec.key}（约 ${spec.approximateMB} MB）${marker} — ${ASR_MODEL_TIER_DESCRIPTIONS[spec.key]}`,
+    );
   }
 
   let modelKey: AsrModelKey | null = null;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1101,7 +1101,7 @@ describe("setupCredentials model selection", () => {
     logSpy.mockRestore();
   });
 
-  it("model selector text is printed after Yes", async () => {
+  it("model selector explains every Model Tier after Yes", async () => {
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
     vi.spyOn(credentialManager, "getCredentials").mockReturnValue(null);
     const configure = vi.fn(async () => {});
@@ -1118,6 +1118,11 @@ describe("setupCredentials model selection", () => {
     expect(allOutput).toMatch(/2\.\s*base/);
     expect(allOutput).toMatch(/3\.\s*small/);
     expect(allOutput).toMatch(/请选择模型/);
+    expect(allOutput).toContain(
+      "速度优先：适合快速提取和长视频初筛，准确率相对较低",
+    );
+    expect(allOutput).toContain("均衡：兼顾速度、质量和资源占用");
+    expect(allOutput).toContain("质量优先：CPU 耗时和内存占用更高");
     expect(allOutput).toContain("推荐");
 
     logSpy.mockRestore();


### PR DESCRIPTION
## Summary
- explain the speed, quality, and resource tradeoffs for tiny, base, and small during ASR setup
- keep small as the recommended interactive default and preserve existing allowlist/non-interactive behavior
- synchronize the Chinese and English README and setup documentation

## Verification
- `npx vitest run tests/cli.test.ts` — 70/70 passed
- `npm run build` — passed
- `npm test` — 44 files, 1076/1076 passed
- `npm pack --dry-run --json --ignore-scripts` — passed, 193 entries

Closes #64