### PR TITLE
feat(asr): persist verified CPU execution profile (#65)

### DIFF
--- a/docs/agent-memory/active-work.md
+++ b/docs/agent-memory/active-work.md
@@ -2,16 +2,20 @@
 
 ## Current Product Ticket
 
-GitHub Issue #59 completes the approved #56 Fake-IP DNS acceptance after #57
-and #58 merged and closed. Work is isolated on
-`codex/issue-59-fake-ip-qa` from merged PR #62 base
-`03ccb8bf2e1172a7591b893d79f2af699c2532c3` and is directly executed by Codex
-without Paseo. The bounded scope is a Node 20/22/25 focused CI gate plus
-redacted real FlClash Rule + TUN + Fake-IP evidence. Local focused, build,
-complete-suite, package, production-audit, and real pre/post-filter acceptance
-all pass. The user-controlled override was restored and reloaded after QA;
-push, PR, Issue close, release, and publication remain separate authority
-gates.
+GitHub Issue #65 is the current approved child ticket under #55. Work is
+isolated on `codex/issue-65-cpu-execution-profile` from merged PR #68 base
+`547b2bb170121bb7701d523e28f3a1f06b1224a8` and is directly executed by Codex
+without Paseo. The bounded implementation upgrades ASR state to v2, persists
+only a verified `cpu/int8` Execution Profile, derives legacy v1 as model-ready
+with device migration pending, requires a generated short-WAV inference and
+generator consumption before ready, reports controlled readiness fields from
+`doctor`, and drives the existing runner from the validated Profile. CUDA
+readiness, GPU probing/fallback, and first-ASR automatic migration remain #66
+and #67. Focused tests, build, the 44-file / 1,104-test suite, package dry run,
+production audit, and three independent review axes pass; a real model CPU
+smoke remains intentionally unrun because it would touch user-managed ASR
+state. Commit, push, PR, Issue close, release, and publication remain separate
+authority gates.
 
 ## Harness v2
 

--- a/docs/agent-memory/codemap.md
+++ b/docs/agent-memory/codemap.md
@@ -14,8 +14,9 @@ This file is a navigation index for `@xzxzzx/bilibili-mcp`. It is not a design s
 - `src/cli.ts`: package CLI entry point. Exports a testable `createCli()`
   factory, uses the Commander root action for no-argument bounded stdio
   startup, and exposes `setup` (credentials plus optional ASR with three-model
-  selector), `doctor` (credential and ASR status plus `asr.model` key),
-  `config`, `check`, `check-update`, and `version`.
+  selector), `doctor` (credential status plus model, controlled execution
+  Profile, Device Readiness, migration status, and optional sanitized failure
+  category), `config`, `check`, `check-update`, and `version`.
 - `src/config.ts`: runtime configuration with strict positive-safe-integer
   validation for rate limits, timeouts, and cache sizing, plus canonical
   supported-language selection that preserves `ai-zh` and rejects unknown values.
@@ -42,19 +43,25 @@ This file is a navigation index for `@xzxzzx/bilibili-mcp`. It is not a design s
 
 ## ASR Runtime (Phases 1-3)
 
-- `src/asr/state.ts`: three-model allowlist (`tiny`/`base`/`small` with pinned revisions and approximate sizes), model-spec resolution and validation, derived user paths (`~/.bilibili-mcp/asr/`), versioned state read/validation (accepts any allowlisted repository/revision), and atomic state write (parameterized by model key, defaults to `small`).
+- `src/asr/state.ts`: three-model allowlist (`tiny`/`base`/`small` with pinned
+  revisions and approximate sizes), controlled Execution Profile/failure
+  enums, derived user paths (`~/.bilibili-mcp/asr/`), strict v1/v2 state
+  validation, v1 migration-pending projection, and atomic v2 `cpu/int8` ready
+  write (parameterized by model key, defaults to `small`).
 - `src/asr/installer.ts`: injectable Python 3.9+ discovery (with
   `BILIBILI_ASR_PYTHON` override), allowlisted child environment, subprocess
   deadlines/output caps, user-scoped venv creation, pinned pip install,
-  staged/budgeted/no-symlink snapshot download, CPU INT8 model-load
-  verification, atomic activation, and failure cleanup. One active model reuses
-  the Phase 1 directory.
+  staged/budgeted/no-symlink snapshot download, generated short-WAV CPU INT8
+  inference with full generator consumption, temporary-audio cleanup, same-model
+  v1 promotion without reinstall, atomic Profile activation, and failure cleanup.
+  One active model reuses the Phase 1 directory.
 - `src/asr/transcription.ts`: explicit ready-state-only ASR orchestration. It
   requires trusted duration, owns one aggregate audio deadline/byte budget,
   unique temporary directories, one-active/no-queue concurrency, bounded
   Windows Job/POSIX `RLIMIT` managed-Python execution, strict NDJSON,
-  cancellation/tree kill, guarded cleanup, and all-candidate Fake-IP failure
-  aggregation without preventing later-candidate success. MCP requests never
+  cancellation/tree kill, controlled Profile-driven Python argv, legacy v1 CPU
+  fallback, guarded cleanup, and all-candidate Fake-IP failure aggregation
+  without preventing later-candidate success. MCP requests never
   install or switch models.
 
 ## MCP Tool Surface
@@ -122,16 +129,24 @@ When adding or changing a public MCP tool, inspect both `tool-schemas.ts` and `t
 
 - `tests/mcp-server-smoke.test.ts`: built `index.js`/`cli.js` stdio coverage, Agent-facing doctor/setup/version CLI probes, MCP handler smoke coverage, and a public JSON-clean `initialize` → `tools/list` → representative `tools/call` wire test.
 - `tests/cli.test.ts`: deterministic CLI tests for help output,
-  `buildDoctorStatus` JSON contract (including ASR object), credential-source
-  priority, isolated blank-replacement protection, and no-leak checks.
+  `buildDoctorStatus` JSON contract (including ASR Profile/readiness/migration
+  fields and sanitized failure category), credential-source priority, isolated
+  blank-replacement protection, and no-leak checks.
 - `tests/config.test.ts`: canonical-language behavior and table-driven strict
   validation for every user-facing numeric environment variable.
 - `tests/index-env-order.test.ts`: mocked dotenv regression proving the entrypoint
   loads `.env` before runtime config is imported and validated.
-- `tests/asr-installer.test.ts`: deterministic installer/state tests. State read/validation/write, Python discovery (override/path/version), venv/pip/download/verify subprocess gating, and full orchestration success/failure. No tests invoke real Python, pip, network, or model download.
+- `tests/asr-installer.test.ts`: deterministic installer/state tests. Strict
+  v1/v2 state validation, atomic writes, managed-path safety, Python discovery,
+  venv/pip/download gates, generated-WAV inference/cleanup, same-model v1
+  promotion, and full orchestration success/failure. No tests invoke real
+  Python, pip, network, or model download.
 - `tests/asr-installer-process.test.ts`: mocked default subprocess deadlines,
   output ceilings, argv, stdio, and platform process-group settings.
-- `tests/asr-transcription.test.ts`: deterministic ready-state, download, redirect, size/MIME, Fake-IP candidate aggregation, child argv/environment, strict output, timeout/kill, cleanup, and concurrency tests with no real network, Python, audio, Cookie, or model.
+- `tests/asr-transcription.test.ts`: deterministic v1/v2 ready-state and
+  Profile-driven runner coverage plus download, redirect, size/MIME, Fake-IP
+  aggregation, child argv/environment, strict output, timeout/kill, cleanup,
+  and concurrency tests with no real network, Python, audio, Cookie, or model.
 - `tests/bilibili-playback.test.ts`: deterministic playurl auth/parameter, malformed-versus-empty DASH, duration, CDN allowlist, and candidate-order tests.
 - `tests/bounded-stdio-transport.test.ts`: inbound/outbound framing ceilings,
   UTF-8 byte accounting, fixed-buffer chunking, and fail-closed overflow.

--- a/docs/agent-memory/decisions.md
+++ b/docs/agent-memory/decisions.md
@@ -859,3 +859,34 @@
   domain-wildcard `fake-ip-filter`, rule-mode `real-ip`, and domain-specific DNS
   policy. Issue #57 fixes the public category as `network`, non-retryable, and
   user-action-required.
+
+## 2026-08-24 — CPU ASR Execution Profile
+
+- Decision: State v2 may become ready only as the currently verified and
+  executable `cpu/int8` Profile. Keep `cuda/float16` in the controlled Profile
+  resolver, but do not accept it as disk-ready until #66 supplies real GPU
+  readiness and execution.
+- Reason: `doctor`, setup idempotency, and transcription must describe the same
+  executable fact; accepting CUDA early would report ready while the current
+  ASR path correctly refuses it.
+- Evidence: state, doctor, setup, and transcription regressions plus independent
+  Standards, Spec, and risk review.
+
+- Decision: CPU readiness requires loading the selected local model, transcribing
+  a program-generated fixed one-second WAV, fully consuming the segment
+  generator, and successfully deleting the temporary WAV before the atomic v2
+  state rename.
+- Reason: model construction alone does not prove the inference path works, and
+  cleanup failure must not publish a false ready Profile.
+- Evidence: deterministic probe-script, generator-consumption, cleanup-failure,
+  v1-promotion, and atomic-rename tests.
+
+- Decision: Legacy v1 preserves its model-ready fact as
+  `migration_pending/pending` and may continue through the controlled CPU path.
+  Setup can promote the same model with one probe and no reinstall or download.
+  The atomic boundary is the state/Profile promotion; existing different-model
+  Phase 2 switching remains unchanged.
+- Reason: #65 must not force existing users to redownload a valid model, while
+  #67 owns first-ASR device migration and #66 owns GPU probing/fallback.
+- Evidence: exact v1 state preservation on probe failure, one-probe promotion,
+  and #65/#55 issue boundary review.

--- a/docs/agent-memory/executions/2026-08-24-github-65-codex-direct-report.md
+++ b/docs/agent-memory/executions/2026-08-24-github-65-codex-direct-report.md
@@ -1,0 +1,89 @@
+# Execution Report: GitHub Issue #65
+
+## Contract
+
+- Task/source: GitHub Issue #65; parent #55; no blocker.
+- Mode: `codex-direct`, following the user's explicit no-Paseo direction.
+- Canonical worktree/base: `C:\Users\ZX\.codex\worktrees\issue-65\bilibili-mcp`
+  at `547b2bb170121bb7701d523e28f3a1f06b1224a8`.
+- Terminal state: locally accepted and uncommitted; every remote effect remains
+  a separate authority gate.
+
+## Summary
+
+CPU setup now persists an actual ASR Execution Profile only after the selected
+local model completes a generated short-WAV inference and the result generator
+and temporary file are fully consumed/cleaned. State v2, legacy v1 projection,
+doctor reporting, and the Python runner share one controlled Profile contract.
+
+CUDA execution, GPU readiness/fallback, first-ASR automatic migration,
+concurrency changes, transcript shape, MCP schemas, dependencies, and network
+security boundaries did not change.
+
+## Files Changed
+
+- Runtime: `src/asr/state.ts`, `src/asr/installer.ts`,
+  `src/asr/transcription.ts`, and `src/cli.ts`.
+- Tests: `tests/asr-installer.test.ts`, `tests/asr-transcription.test.ts`, and
+  `tests/cli.test.ts`.
+- Evidence: active work, project facts, decisions, codemap, verification log,
+  this report, QA record, and mechanically refreshed Harness receipts.
+
+## Verification
+
+- Focused Vitest: 4 files / 282 tests passed.
+- Complete Vitest: 44 files / 1,104 tests passed.
+- `npm run build`: passed.
+- `npm pack --dry-run --json --ignore-scripts`: 193 files; package exclusions
+  preserved.
+- `npm audit --omit=dev --json`: zero production vulnerabilities.
+- Full audit: two unchanged high development-chain findings (`nanoid`,
+  `postcss`); no dependency change or auto-fix.
+- Gitleaks 8.30.1: zero findings in the tracked diff and both untracked evidence
+  files.
+- Harness core first identified one canonical-LF `LICENSE` receipt mismatch;
+  the package/durable-memory/outer receipt chain was regenerated and the exact
+  real-pilot conformance rerun passed 1/1.
+- `git diff --check`: passed with Windows line-ending warnings only.
+- Standards, Spec, and risk review: no remaining finding after same-scope
+  repairs.
+
+## Review Repairs
+
+- Rejected contradictory CUDA-ready/failure states, then kept CUDA disk state
+  non-ready until #66 so doctor/setup/transcription report the same fact.
+- Restored real coverage in missing-artifact, symlink, and wrong-path-type tests
+  after the v2 schema change.
+- Made temporary-WAV deletion failure block ready publication.
+
+## Residual Risk
+
+- A real `faster-whisper` CPU smoke was not run because using the existing
+  user-managed model would mutate or depend on state outside the isolated
+  worktree. Deterministic subprocess tests cover the contract, but a small
+  Python/PyAV compatibility risk remains for merge/release QA.
+
+## Capabilities Used
+
+- User-invoked manual Skill: Matt `implement` for #65.
+- Model-invoked Skills: Matt `tdd`, `code-review`, `codebase-design`, Vitest,
+  and `bilibili-mcp-memory`.
+- `secret-scanning` was not exposed in this runtime; installed gitleaks 8.30.1
+  is the bounded fallback.
+- Reviewers: independent Standards, Spec, and project risk axes; no reviewer
+  edited files.
+
+## Harness Artifacts
+
+- Task ticket: live GitHub Issue #65; no duplicate local ticket.
+- Research note: not required; no external research changed implementation.
+- QA checklist: `docs/qa/2026-08-24-asr-cpu-execution-profile.md`.
+- Codemap and durable memory: updated for v2 state, CPU probe, Profile runner,
+  doctor fields, decisions, active work, and verification.
+- Harness security: reviewed; no credential, new authority, or external effect.
+- Harness eval: unchanged; #65 does not redesign an adapter or workflow.
+
+## Git And Remote State
+
+No commit, push, PR, merge, Issue close, tag, release, or npm publication was
+performed.

--- a/docs/agent-memory/project-facts.md
+++ b/docs/agent-memory/project-facts.md
@@ -772,3 +772,25 @@
 - Impact: Issue #40 and the related locally recorded Issue #41 defects are now
   available from npm and the Official MCP Registry. After follow-up user
   authorization, Registry `1.12.0` is `active` and `isLatest=true`.
+
+## 2026-08-24
+
+- Fact: The isolated Issue #65 candidate upgrades managed ASR state to v2 and
+  persists a ready Profile only after the selected local model completes a
+  generated short-WAV inference on `cpu/int8` and the temporary WAV is removed.
+- Evidence: `src/asr/state.ts`, `src/asr/installer.ts`, deterministic state and
+  installer regressions, 282 focused tests, and 44 files / 1,104 full tests.
+- Impact: New CPU setup records actual execution facts instead of intent. A
+  same-model v1 install can be promoted with one probe and no reinstall or model
+  download; failure preserves the exact previous v1 state.
+
+- Fact: `doctor --json` now derives model, device, compute type, Device
+  Readiness, migration status, and optional sanitized failure category from the
+  controlled state. The Python runner receives its Profile through validated
+  argv, while the public transcript and MCP schemas remain unchanged.
+- Evidence: `src/cli.ts`, `src/asr/transcription.ts`, CLI/transcription tests,
+  build, package dry run, production audit, and three-axis review.
+- Impact: v1 reports migration pending without claiming a device; v2 currently
+  accepts only verified `cpu/int8` as ready. `cuda/float16` remains a controlled
+  future Profile but cannot become disk-ready until #66 implements GPU
+  readiness; #67 still owns first-ASR automatic migration.

--- a/docs/agent-memory/verification-log.md
+++ b/docs/agent-memory/verification-log.md
@@ -2618,3 +2618,39 @@ Six release blockers fixed; one regression proof per root cause (new tests
 - Harness: after refreshing the canonical LF package receipt and durable-memory
   hashes, exact real-pilot conformance passed 1/1 and the contracts, events,
   adapters, and memory core suite passed 102 tests with 15 skipped.
+
+## 2026-08-24 — Issue #65 CPU Execution Profile
+
+- TDD evidence: tests first failed for v2 Profile persistence, v1 migration
+  projection, real minimal-inference generator consumption, cleanup, Profile
+  argv, doctor fields, contradictory CUDA/failure state, current CUDA readiness,
+  and cleanup-error handling; each passed after its bounded implementation.
+- Final behavior: state v2 writes only verified `cpu/int8` ready/completed;
+  strict enums and exact keys fail closed. V1 remains model-ready with device
+  migration pending, same-model setup performs one CPU probe without reinstall,
+  and failed probe or atomic rename preserves the previous state bytes.
+- Probe and runtime: setup generates a private one-second WAV, loads the selected
+  model, transcribes it, consumes the segment generator, and requires successful
+  cleanup before publishing ready. The existing runner receives only a validated
+  Profile via argv; legacy v1 stays on controlled CPU until #67.
+- Doctor and public boundary: JSON/human output reports controlled model,
+  device, compute type, readiness, migration, and sanitized failure category.
+  Transcript result shape, MCP schema, credentials, resource ceilings, and
+  pinned-HTTPS audio behavior are unchanged.
+- Verification: 4 focused files / 282 tests passed; build passed; the complete
+  Vitest suite passed 44 files / 1,104 tests; the package dry run contained 193
+  files; production audit found zero vulnerabilities. Full audit retained the
+  two unchanged high development-chain findings in `nanoid` and `postcss`.
+  Gitleaks 8.30.1 found zero secrets in the tracked diff and both untracked
+  evidence files.
+- Harness: the core run exposed one stale canonical-LF `LICENSE` size in the
+  mechanically generated package receipt while all other cases passed or
+  skipped for their existing environment gates. After normalizing every
+  packaged text file and refreshing the receipt chain, the exact real-pilot
+  conformance test passed 1/1.
+- Review and residual: Standards, Spec, and risk reviews passed after repairing
+  false-positive managed-path tests, contradictory early CUDA readiness, and
+  cleanup-error publication. No real model CPU smoke ran because it would touch
+  user-managed ASR state; that small Python/PyAV compatibility risk remains a
+  merge/release follow-up. No commit, push, PR, Issue close, release, or publish
+  occurred.

--- a/docs/qa/2026-08-24-asr-cpu-execution-profile.md
+++ b/docs/qa/2026-08-24-asr-cpu-execution-profile.md
@@ -1,0 +1,41 @@
+# Issue #65 CPU Execution Profile QA
+
+Date: 2026-08-24
+Worktree: `C:\Users\ZX\.codex\worktrees\issue-65\bilibili-mcp`
+Branch: `codex/issue-65-cpu-execution-profile`
+Base: `547b2bb170121bb7701d523e28f3a1f06b1224a8`
+
+## Accepted
+
+- State v2 writes only `cpu/int8`, `ready`, and `completed` after a real
+  model-transcribe call and full segment-generator consumption.
+- The generated one-second WAV is owner-only and removed before ready; deletion
+  failure rejects setup.
+- Legacy v1 keeps the existing model-ready fact but reports device migration
+  pending. Same-model setup probes once and does not reinstall or redownload.
+- Invalid keys, Profile pairs, readiness/migration values, failure categories,
+  unexpected fields, symlinks, and wrong managed-path types fail closed.
+- `doctor --json` exposes only controlled model/Profile/readiness fields and no
+  stderr, command, environment, or local-path data.
+- The runner receives only the validated Profile through argv. Transcript and
+  MCP success schemas are unchanged.
+
+## Evidence
+
+- Focused: 4 files / 282 tests passed.
+- Complete Vitest: 44 files / 1,104 tests passed.
+- TypeScript build: passed.
+- Package dry run: 193 files; tests, Harness, and agent memory excluded.
+- Production dependency audit: zero vulnerabilities.
+- Gitleaks 8.30.1: zero findings in the final diff and new evidence files.
+- Harness canonical package/memory receipt conformance: passed after LF
+  normalization of the generated package receipt.
+- Standards, Spec, and risk review: no remaining findings.
+
+## Deferred Boundary
+
+- No user-managed ASR state or model was changed for a real CPU smoke. A
+  sanitized real-model smoke remains a merge/release gate when an isolated
+  disposable model/runtime is available.
+- CUDA readiness/probe/fallback remains #66; first-ASR automatic migration and
+  concurrency behavior remains #67.

--- a/harness/fixtures/pilot-artifacts/migration.json
+++ b/harness/fixtures/pilot-artifacts/migration.json
@@ -89,27 +89,27 @@
     }
   ],
   "durable_memory": {
-    "docs/agent-memory/active-work.md": "469bf4c917953eee9a7e19ad395d9a84c82bbbe7577ab6314efaeb64fb3aa248",
-    "docs/agent-memory/codemap.md": "5d73f156c64b917289a744175c30456530f9d1adcc310195c38533215db22364",
-    "docs/agent-memory/decisions.md": "302b443c014aa57294dfe2eaed16c18677c89a7fdb653919041304a46afa672e",
+    "docs/agent-memory/active-work.md": "1dc181bd1ec4f26cb753735727c0ed7a54f039a11b0f92d44dfd7b8ad89a6c5e",
+    "docs/agent-memory/codemap.md": "83fe0f84010fbe2eaf8c355f8606a3aa0a44a470aa2ba139834e3860d0ab0606",
+    "docs/agent-memory/decisions.md": "d0926eb78c992620f311a551d7989e820dbc91bb38cc04c8a1d4c5f01a066b63",
     "docs/agent-memory/executions/2026-08-14-github-36-codex-direct-report.md": "439b169470c2ab1ec3af3625b8ca3e247d6ccd4f01bc39ff967deff673853570",
     "docs/agent-memory/harness-eval.md": "f531cc2d0e69ccc8d41c882c9aefdae03d5583789bc19c51dd45a4188fe9a370",
     "docs/agent-memory/harness-security.md": "b907339f85c0ba13c2a8642b475aa682ae1b313cb51cebec9977aca798df3430",
     "docs/agent-memory/lessons-learned.md": "6a0e45bc73159237fb3200a3725d12d54dd0d83aa5c8eebcec5ffb9bd2efb7d7",
-    "docs/agent-memory/project-facts.md": "ce49559de2e1ed1ecb322ecd2f0d3ff62887c9ca1f7d885ab2b47ab9ff6b7e3c",
-    "docs/agent-memory/verification-log.md": "0ee3f44f45803360428f40fc2ccb1f2fb45e4570511c71ada9746582a42c99c6"
+    "docs/agent-memory/project-facts.md": "aa00251eb112f23d480d8a446fe2332e45a1db9204e7b29445ca2dd9650ff172",
+    "docs/agent-memory/verification-log.md": "b292d99ce75548dd35fef181a8fc49fd9e8c810149997ffece1d75f102e159f3"
   },
   "package": {
-    "output_digest": "b794903d0c96ada487f050e75730b121afbe00df07b0f98c8e1b39cdc72ecb4e",
+    "output_digest": "b45d5a5bb574f7fe03bcf0e11d145d3bc4e71587142aef3929025ee319fbbb93",
     "pack_output": [
       {
         "id": "@xzxzzx/bilibili-mcp@1.13.0",
         "name": "@xzxzzx/bilibili-mcp",
         "version": "1.13.0",
-        "size": 1136900,
-        "unpackedSize": 1928398,
-        "shasum": "fc3758a3062c45d0426ef02965103278e9643bca",
-        "integrity": "sha512-f1lQcatpVgD6l9uh2xMUi41uOVo+r3P6mNMUPFkmAGpEeTjkgqq2/pgIGttepz+Mp20YboYos0es8zKCt2NZ5A==",
+        "size": 1140510,
+        "unpackedSize": 1945939,
+        "shasum": "50940bcd50233b1a6886114de2ef6f87409df179",
+        "integrity": "sha512-/cY+uX7NhxcQdfgxPin9ZFSgqCgyPfPQy9KTgOil7hQsnqmI4rmHdaA2kFElgd3d/T1k0mEcyHrVLtyyyFH4cA==",
         "filename": "xzxzzx-bilibili-mcp-1.13.0.tgz",
         "files": [
           {
@@ -164,52 +164,52 @@
           },
           {
             "path": "dist/asr/installer.js",
-            "size": 18289,
+            "size": 20329,
             "mode": 420
           },
           {
             "path": "dist/asr/installer.js.map",
-            "size": 16699,
+            "size": 18820,
             "mode": 420
           },
           {
             "path": "dist/asr/state.d.ts",
-            "size": 2237,
+            "size": 3269,
             "mode": 420
           },
           {
             "path": "dist/asr/state.d.ts.map",
-            "size": 1625,
+            "size": 2204,
             "mode": 420
           },
           {
             "path": "dist/asr/state.js",
-            "size": 8573,
+            "size": 11355,
             "mode": 420
           },
           {
             "path": "dist/asr/state.js.map",
-            "size": 7546,
+            "size": 9983,
             "mode": 420
           },
           {
             "path": "dist/asr/transcription.d.ts",
-            "size": 2662,
+            "size": 2769,
             "mode": 420
           },
           {
             "path": "dist/asr/transcription.d.ts.map",
-            "size": 2496,
+            "size": 2569,
             "mode": 420
           },
           {
             "path": "dist/asr/transcription.js",
-            "size": 25438,
+            "size": 26721,
             "mode": 420
           },
           {
             "path": "dist/asr/transcription.js.map",
-            "size": 20338,
+            "size": 21149,
             "mode": 420
           },
           {
@@ -554,22 +554,22 @@
           },
           {
             "path": "dist/cli.d.ts",
-            "size": 1654,
+            "size": 2026,
             "mode": 420
           },
           {
             "path": "dist/cli.d.ts.map",
-            "size": 1426,
+            "size": 1714,
             "mode": 420
           },
           {
             "path": "dist/cli.js",
-            "size": 16406,
+            "size": 18408,
             "mode": 420
           },
           {
             "path": "dist/cli.js.map",
-            "size": 13924,
+            "size": 15538,
             "mode": 420
           },
           {

--- a/harness/fixtures/three-adapter-pilot-evidence.json
+++ b/harness/fixtures/three-adapter-pilot-evidence.json
@@ -8,7 +8,7 @@
       "product-verification": "pass"
     },
     "file": "migration.json",
-    "sha256": "f71a5ae1cfe87182cfc6b95a31df33bad084c64fc094b0fb5574db47cc841620"
+    "sha256": "354f954060e46e2f7c3c2d6e6d9fd5cbab9f078ff05d8c806b3fa017c53adc52"
   },
   "pilots": [
     {

--- a/src/asr/installer.ts
+++ b/src/asr/installer.ts
@@ -1,6 +1,7 @@
 import { spawn } from "child_process";
 import { randomUUID } from "crypto";
 import fs from "fs";
+import os from "os";
 import path from "path";
 import {
   ASR_PINNED_RUNTIME,
@@ -407,17 +408,44 @@ export async function verifyModel(
   modelPath: string,
   spawnFn: typeof execFile = execFile,
 ): Promise<void> {
+  const probePath = path.join(os.tmpdir(), `.bilibili-mcp-asr-probe-${randomUUID()}.wav`);
+  const sampleRate = 16_000;
+  const sampleCount = sampleRate;
+  const wav = Buffer.alloc(44 + sampleCount * 2);
+  wav.write("RIFF", 0, "ascii");
+  wav.writeUInt32LE(wav.length - 8, 4);
+  wav.write("WAVEfmt ", 8, "ascii");
+  wav.writeUInt32LE(16, 16);
+  wav.writeUInt16LE(1, 20);
+  wav.writeUInt16LE(1, 22);
+  wav.writeUInt32LE(sampleRate, 24);
+  wav.writeUInt32LE(sampleRate * 2, 28);
+  wav.writeUInt16LE(2, 32);
+  wav.writeUInt16LE(16, 34);
+  wav.write("data", 36, "ascii");
+  wav.writeUInt32LE(sampleCount * 2, 40);
   const script = [
     "import sys",
     "from faster_whisper import WhisperModel",
     `model = WhisperModel(sys.argv[1], device="${DEVICE}", compute_type="${COMPUTE_TYPE}")`,
+    "segments, _ = model.transcribe(sys.argv[2], beam_size=1)",
+    "for _ in segments:",
+    "    pass",
     "print('VERIFIED')",
   ].join("\n");
 
-  const result = await spawnFn(
-    venvPython.executable,
-    toPythonArgs(venvPython, "-c", script, modelPath),
-      );
+  let result: { code: number | null; stdout: string; stderr: string };
+  let probeCreated = false;
+  try {
+    fs.writeFileSync(probePath, wav, { flag: "wx", mode: 0o600 });
+    probeCreated = true;
+    result = await spawnFn(
+      venvPython.executable,
+      toPythonArgs(venvPython, "-c", script, modelPath, probePath),
+    );
+  } finally {
+    if (probeCreated) fs.unlinkSync(probePath);
+  }
   if (result.code !== 0) {
     throw new Error(
       `Model verification failed: ${result.stderr.slice(0, 500)}`,
@@ -521,13 +549,35 @@ export async function runAsrInstallation(
     return { success: false, error: message, asrPaths };
   }
 
-  // Idempotency: if already ready with same model, skip
+  // A legacy v1 state already owns a valid managed model and runtime. Promote
+  // it in place only after the new end-to-end CPU readiness probe succeeds.
   const existingState = readAsrState(asrPaths.stateFile);
-  if (
+  const sameModel =
     existingState.kind === "ready" &&
     existingState.model === modelSpec.repository &&
-    existingState.revision === modelSpec.revision
-  ) {
+    existingState.revision === modelSpec.revision;
+  if (sameModel && existingState.migrationStatus === "pending") {
+    const venvPython: PythonCommand = {
+      executable: path.join(
+        asrPaths.venv,
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      prefixArgs: [],
+    };
+    try {
+      logStage("正在验证模型最小推理（CPU INT8）...");
+      await verifyModel(venvPython, asrPaths.model, spawnFn);
+      writeAsrState(asrPaths.stateFile, modelSpec.key);
+      return { success: true, pythonPath: venvPython.executable, asrPaths };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { success: false, error: message, asrPaths };
+    }
+  }
+
+  // Idempotency: a same-model v2 CPU profile has already passed this probe.
+  if (sameModel) {
     return { success: true, pythonPath: "already installed", asrPaths };
   }
 

--- a/src/asr/state.ts
+++ b/src/asr/state.ts
@@ -4,7 +4,27 @@ import os from "os";
 import { randomUUID } from "crypto";
 
 export const ASR_PINNED_RUNTIME = "faster-whisper==1.2.1";
-export const ASR_STATE_VERSION = 1;
+export const ASR_STATE_VERSION = 2;
+const ASR_LEGACY_STATE_VERSION = 1;
+
+export const ASR_EXECUTION_PROFILES = [
+  { device: "cpu", computeType: "int8" },
+  { device: "cuda", computeType: "float16" },
+] as const;
+
+export type AsrExecutionProfile = (typeof ASR_EXECUTION_PROFILES)[number];
+export const ASR_CPU_EXECUTION_PROFILE = ASR_EXECUTION_PROFILES[0];
+export type AsrDeviceReadiness = "not_ready" | "migration_pending" | "ready";
+export type AsrMigrationStatus = "pending" | "completed";
+
+export const ASR_FAILURE_CATEGORIES = [
+  "no_nvidia_gpu",
+  "cuda_runtime_missing",
+  "runtime_version_mismatch",
+  "model_probe_failed",
+] as const;
+
+export type AsrFailureCategory = (typeof ASR_FAILURE_CATEGORIES)[number];
 
 export const ASR_MODEL_SPECS = [
   {
@@ -70,6 +90,10 @@ export interface AsrState {
   model?: string;
   revision?: string;
   modelKey?: AsrModelKey;
+  executionProfile?: AsrExecutionProfile;
+  deviceReadiness?: AsrDeviceReadiness;
+  migrationStatus?: AsrMigrationStatus;
+  failureCategory?: AsrFailureCategory;
 }
 
 export function modelKeyForRepo(repository: string, revision: string): AsrModelKey | null {
@@ -125,6 +149,29 @@ function isRealPath(
   }
 }
 
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  return actual.length === wanted.length && actual.every((key, index) => key === wanted[index]);
+}
+
+export function resolveExecutionProfile(
+  device: unknown,
+  computeType: unknown,
+): AsrExecutionProfile | undefined {
+  return ASR_EXECUTION_PROFILES.find(
+    (profile) => profile.device === device && profile.computeType === computeType,
+  );
+}
+
+function isFailureCategory(value: unknown): value is AsrFailureCategory {
+  return typeof value === "string" &&
+    (ASR_FAILURE_CATEGORIES as readonly string[]).includes(value);
+}
+
 export function readAsrState(
   stateFile: string,
   readFileSync: typeof fs.readFileSync = fs.readFileSync,
@@ -162,9 +209,11 @@ export function readAsrState(
     return { kind: "incomplete" };
   }
 
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { kind: "incomplete" };
+  }
+
   if (
-    typeof parsed !== "object" ||
-    parsed === null ||
     parsed.kind !== "ready" ||
     typeof parsed.version !== "number" ||
     typeof parsed.runtime !== "string" ||
@@ -174,16 +223,60 @@ export function readAsrState(
     return { kind: "incomplete" };
   }
 
-  if (parsed.version !== ASR_STATE_VERSION) {
-    return { kind: "incomplete" };
-  }
-
   if (
     parsed.runtime !== ASR_PINNED_RUNTIME ||
     typeof parsed.model !== "string" ||
     typeof parsed.revision !== "string" ||
     !isAllowlistedModel(parsed.model, parsed.revision)
   ) {
+    return { kind: "incomplete" };
+  }
+
+  const legacy = parsed.version === ASR_LEGACY_STATE_VERSION;
+  let executionProfile: AsrExecutionProfile | undefined;
+  let deviceReadiness: AsrDeviceReadiness;
+  let migrationStatus: AsrMigrationStatus;
+  let failureCategory: AsrFailureCategory | undefined;
+
+  if (legacy) {
+    if (!hasExactKeys(parsed, ["kind", "version", "runtime", "model", "revision"])) {
+      return { kind: "incomplete" };
+    }
+    deviceReadiness = "migration_pending";
+    migrationStatus = "pending";
+  } else if (parsed.version === ASR_STATE_VERSION) {
+    const expectedKeys = [
+      "kind",
+      "version",
+      "runtime",
+      "model",
+      "revision",
+      "device",
+      "compute_type",
+      "device_readiness",
+      "migration_status",
+      ...(Object.prototype.hasOwnProperty.call(parsed, "failure_category")
+        ? ["failure_category"]
+        : []),
+    ];
+    if (!hasExactKeys(parsed, expectedKeys)) {
+      return { kind: "incomplete" };
+    }
+    executionProfile = resolveExecutionProfile(parsed.device, parsed.compute_type);
+    if (
+      executionProfile === undefined ||
+      executionProfile.device !== "cpu" ||
+      parsed.device_readiness !== "ready" ||
+      parsed.migration_status !== "completed" ||
+      (Object.prototype.hasOwnProperty.call(parsed, "failure_category") &&
+        !isFailureCategory(parsed.failure_category))
+    ) {
+      return { kind: "incomplete" };
+    }
+    deviceReadiness = "ready";
+    migrationStatus = "completed";
+    failureCategory = parsed.failure_category as AsrFailureCategory | undefined;
+  } else {
     return { kind: "incomplete" };
   }
 
@@ -226,6 +319,10 @@ export function readAsrState(
     model: parsed.model as string,
     revision: parsed.revision as string,
     modelKey: derivedKey ?? undefined,
+    executionProfile,
+    deviceReadiness,
+    migrationStatus,
+    failureCategory,
   };
 }
 
@@ -241,12 +338,16 @@ export function writeAsrState(
   chmodSync: typeof fs.chmodSync = fs.chmodSync,
 ): void {
   const spec = resolveModelSpec(modelKey);
-  const state: AsrState = {
+  const state = {
     kind: "ready",
     version: ASR_STATE_VERSION,
     runtime: ASR_PINNED_RUNTIME,
     model: spec.repository,
     revision: spec.revision,
+    device: "cpu",
+    compute_type: "int8",
+    device_readiness: "ready",
+    migration_status: "completed",
   };
 
   const dir = path.dirname(stateFile);

--- a/src/asr/transcription.ts
+++ b/src/asr/transcription.ts
@@ -25,9 +25,12 @@ import { sanitizeRemoteText } from "../utils/bounded-text.js";
 import { AsrError } from "../utils/errors.js";
 import { buildAsrChildEnv } from "./installer.js";
 import {
+  ASR_CPU_EXECUTION_PROFILE,
   deriveAsrPaths,
   readAsrState,
+  resolveExecutionProfile,
   type AsrPaths,
+  type AsrExecutionProfile,
   type AsrState,
 } from "./state.js";
 
@@ -100,7 +103,7 @@ const PYTHON_SCRIPT = [
   "        cap = 64 if hard < 0 else min(64, hard)",
   "        resource.setrlimit(resource.RLIMIT_NPROC, (cap, cap))",
   "from faster_whisper import WhisperModel",
-  "model = WhisperModel(sys.argv[1], device='cpu', compute_type='int8')",
+  "model = WhisperModel(sys.argv[1], device=sys.argv[3], compute_type=sys.argv[4])",
   "segments, info = model.transcribe(sys.argv[2], beam_size=5)",
   "language = info.language if isinstance(info.language, str) else None",
   "print(json.dumps({'type': 'meta', 'language': language}, ensure_ascii=True), flush=True)",
@@ -149,6 +152,7 @@ export interface AsrTranscriptionDependencies {
     pythonExecutable: string,
     modelPath: string,
     audioPath: string,
+    executionProfile: AsrExecutionProfile,
     signal?: AbortSignal,
   ) => Promise<AsrTranscriptionResult>;
 }
@@ -577,11 +581,19 @@ export async function runManagedAsrRuntime(
   modelPath: string,
   audioPath: string,
   options: {
+    executionProfile: AsrExecutionProfile;
     spawnFn?: typeof spawn;
     timeoutMs?: number;
     signal?: AbortSignal;
-  } = {},
+  },
 ): Promise<AsrTranscriptionResult> {
+  const executionProfile = resolveExecutionProfile(
+    options.executionProfile.device,
+    options.executionProfile.computeType,
+  );
+  if (executionProfile === undefined) {
+    throw new AsrError("ASR_NOT_READY", "The ASR execution profile is not allowlisted.");
+  }
   return new Promise((resolve, reject) => {
     const signal = getOperationSignal(options.signal);
     try {
@@ -593,7 +605,15 @@ export async function runManagedAsrRuntime(
     const spawnFn = options.spawnFn ?? spawn;
     const child = spawnFn(
       pythonExecutable,
-      ["-I", "-c", PYTHON_SCRIPT, modelPath, audioPath],
+      [
+        "-I",
+        "-c",
+        PYTHON_SCRIPT,
+        modelPath,
+        audioPath,
+        executionProfile.device,
+        executionProfile.computeType,
+      ],
       {
         env: buildAsrRuntimeEnv(process.env),
         shell: false,
@@ -791,12 +811,13 @@ export async function transcribeVideoPart(
         pythonExecutable: string,
         modelPath: string,
         audioPath: string,
+        executionProfile: AsrExecutionProfile,
         operationSignal?: AbortSignal,
       ) => await runManagedAsrRuntime(
         pythonExecutable,
         modelPath,
         audioPath,
-        { signal: operationSignal },
+        { executionProfile, signal: operationSignal },
       )
     );
   let tempDir: string | undefined;
@@ -810,6 +831,24 @@ export async function transcribeVideoPart(
       throw new AsrError(
         "ASR_NOT_READY",
         "Local ASR is not ready. Run `npx -y @xzxzzx/bilibili-mcp@latest setup`, then inspect `doctor --json`.",
+      );
+    }
+    const executionProfile = state.executionProfile !== undefined &&
+      state.deviceReadiness === "ready" &&
+      state.migrationStatus === "completed"
+      ? resolveExecutionProfile(
+          state.executionProfile.device,
+          state.executionProfile.computeType,
+        )
+      : state.executionProfile === undefined &&
+          state.deviceReadiness === "migration_pending" &&
+          state.migrationStatus === "pending"
+        ? ASR_CPU_EXECUTION_PROFILE
+        : undefined;
+    if (executionProfile === undefined || executionProfile.device !== "cpu") {
+      throw new AsrError(
+        "ASR_NOT_READY",
+        "Local ASR has no verified CPU execution profile. Run setup, then inspect doctor --json.",
       );
     }
 
@@ -831,6 +870,7 @@ export async function transcribeVideoPart(
       managedPythonExecutable(paths.venv),
       paths.model,
       audioPath,
+      executionProfile,
       signal,
     );
   } finally {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,9 +12,15 @@ import { buildPackageUpdateInfo } from "./utils/update-check.js";
 import { BoundedStdioServerTransport } from "./server/bounded-stdio-transport.js";
 
 import {
+  ASR_FAILURE_CATEGORIES,
   readAsrState,
   deriveAsrPaths,
+  resolveExecutionProfile,
   type AsrStateKind,
+  type AsrDeviceReadiness,
+  type AsrExecutionProfile,
+  type AsrFailureCategory,
+  type AsrMigrationStatus,
   ASR_MODEL_SPECS,
   resolveModelSpec,
   type AsrModelKey,
@@ -191,6 +197,11 @@ export interface DoctorStatus {
   asr: {
     status: AsrStateKind;
     model: AsrModelKey | null;
+    device: AsrExecutionProfile["device"] | null;
+    compute_type: AsrExecutionProfile["computeType"] | null;
+    device_readiness: AsrDeviceReadiness;
+    migration_status: AsrMigrationStatus | null;
+    failure_category: AsrFailureCategory | null;
   };
   status: "locally_ready" | "needs_credentials";
   next_steps: string[];
@@ -208,6 +219,25 @@ export function buildDoctorStatus(
 
   const asrState = readAsrStateFn(asrPaths.stateFile);
   const asrModelKey: AsrModelKey | null = asrState.modelKey ?? null;
+  const executionProfile = asrState.kind === "ready" && asrState.executionProfile !== undefined
+    ? resolveExecutionProfile(
+        asrState.executionProfile.device,
+        asrState.executionProfile.computeType,
+      )
+    : undefined;
+  const profileReady = executionProfile !== undefined &&
+    asrState.deviceReadiness === "ready" &&
+    asrState.migrationStatus === "completed";
+  const migrationPending = asrState.kind === "ready" &&
+    executionProfile === undefined &&
+    (asrState.version === 1 ||
+      (asrState.deviceReadiness === "migration_pending" &&
+        asrState.migrationStatus === "pending"));
+  const failureCategory = profileReady &&
+    typeof asrState.failureCategory === "string" &&
+    (ASR_FAILURE_CATEGORIES as readonly string[]).includes(asrState.failureCategory)
+    ? asrState.failureCategory
+    : null;
 
   return {
     package_name: "@xzxzzx/bilibili-mcp",
@@ -225,6 +255,19 @@ export function buildDoctorStatus(
     asr: {
       status: asrState.kind,
       model: asrModelKey,
+      device: profileReady ? executionProfile.device : null,
+      compute_type: profileReady ? executionProfile.computeType : null,
+      device_readiness: profileReady
+        ? "ready"
+        : migrationPending
+          ? "migration_pending"
+          : "not_ready",
+      migration_status: profileReady
+        ? "completed"
+        : migrationPending
+          ? "pending"
+          : null,
+      failure_category: failureCategory,
     },
     status: isReady ? "locally_ready" : "needs_credentials",
     next_steps: isReady
@@ -256,6 +299,16 @@ export function doctorCommand(
       console.log(`ASR: ${status.asr.status}`);
       if (status.asr.model) {
         console.log(`ASR model: ${status.asr.model}`);
+      }
+      console.log(`ASR device readiness: ${status.asr.device_readiness}`);
+      if (status.asr.device && status.asr.compute_type) {
+        console.log(`ASR execution profile: ${status.asr.device}/${status.asr.compute_type}`);
+      }
+      if (status.asr.migration_status) {
+        console.log(`ASR migration status: ${status.asr.migration_status}`);
+      }
+      if (status.asr.failure_category) {
+        console.log(`ASR failure category: ${status.asr.failure_category}`);
       }
       console.log(`Status: ${status.status}`);
       if (status.next_steps.length > 0) {

--- a/tests/asr-installer.test.ts
+++ b/tests/asr-installer.test.ts
@@ -24,6 +24,7 @@ import {
   isAllowlistedModel,
   modelKeyForRepo,
   readAsrState,
+  resolveExecutionProfile,
   resolveModelSpec,
   writeAsrState,
   type AsrModelKey,
@@ -51,6 +52,12 @@ describe("deriveAsrPaths", () => {
 });
 
 describe("readAsrState", () => {
+  const validLstatSync = () => vi.fn(() => ({
+    isSymbolicLink: () => false,
+    isDirectory: () => true,
+    isFile: () => true,
+  }));
+
   it("returns not_installed when state file and all artifacts are absent", () => {
     const existsSync = vi.fn(() => false);
     const state = readAsrState("/tmp/asr/state.json", fs.readFileSync, existsSync);
@@ -119,7 +126,17 @@ describe("readAsrState", () => {
   it("returns ready when all fields match AND artifacts exist", () => {
     const existsSync = vi.fn(() => true); // everything exists
     const readFileSync = vi.fn(() =>
-      JSON.stringify({ kind: "ready", version: ASR_STATE_VERSION, runtime: ASR_PINNED_RUNTIME, model: ASR_PINNED_MODEL, revision: ASR_PINNED_REVISION }),
+      JSON.stringify({
+        kind: "ready",
+        version: ASR_STATE_VERSION,
+        runtime: ASR_PINNED_RUNTIME,
+        model: ASR_PINNED_MODEL,
+        revision: ASR_PINNED_REVISION,
+        device: "cpu",
+        compute_type: "int8",
+        device_readiness: "ready",
+        migration_status: "completed",
+      }),
     );
     const lstatSync = vi.fn(() => ({
       isSymbolicLink: () => false,
@@ -141,50 +158,55 @@ describe("readAsrState", () => {
     );
     const existsSync = vi.fn((p: string) => p !== venvPython);
     const readFileSync = vi.fn(() =>
-      JSON.stringify({ kind: "ready", version: ASR_STATE_VERSION, runtime: ASR_PINNED_RUNTIME, model: ASR_PINNED_MODEL, revision: ASR_PINNED_REVISION }),
+      JSON.stringify({ kind: "ready", version: ASR_STATE_VERSION, runtime: ASR_PINNED_RUNTIME, model: ASR_PINNED_MODEL, revision: ASR_PINNED_REVISION, device: "cpu", compute_type: "int8", device_readiness: "ready", migration_status: "completed" }),
     );
-    const state = readAsrState(stateFile, readFileSync, existsSync);
+    const state = readAsrState(stateFile, readFileSync, existsSync, validLstatSync());
     expect(state.kind).toBe("incomplete");
+    expect(existsSync).toHaveBeenCalledWith(venvPython);
   });
 
   it("returns incomplete when model.bin is missing", () => {
     const modelBin = path.join(path.dirname("/tmp/asr/state.json"), "models", "model.bin");
     const existsSync = vi.fn((p: string) => p !== modelBin);
     const readFileSync = vi.fn(() =>
-      JSON.stringify({ kind: "ready", version: ASR_STATE_VERSION, runtime: ASR_PINNED_RUNTIME, model: ASR_PINNED_MODEL, revision: ASR_PINNED_REVISION }),
+      JSON.stringify({ kind: "ready", version: ASR_STATE_VERSION, runtime: ASR_PINNED_RUNTIME, model: ASR_PINNED_MODEL, revision: ASR_PINNED_REVISION, device: "cpu", compute_type: "int8", device_readiness: "ready", migration_status: "completed" }),
     );
-    const state = readAsrState("/tmp/asr/state.json", readFileSync, existsSync);
+    const state = readAsrState("/tmp/asr/state.json", readFileSync, existsSync, validLstatSync());
     expect(state.kind).toBe("incomplete");
+    expect(existsSync).toHaveBeenCalledWith(modelBin);
   });
 
   it("returns incomplete when config.json is missing", () => {
     const configJson = path.join(path.dirname("/tmp/asr/state.json"), "models", "config.json");
     const existsSync = vi.fn((p: string) => p !== configJson);
     const readFileSync = vi.fn(() =>
-      JSON.stringify({ kind: "ready", version: ASR_STATE_VERSION, runtime: ASR_PINNED_RUNTIME, model: ASR_PINNED_MODEL, revision: ASR_PINNED_REVISION }),
+      JSON.stringify({ kind: "ready", version: ASR_STATE_VERSION, runtime: ASR_PINNED_RUNTIME, model: ASR_PINNED_MODEL, revision: ASR_PINNED_REVISION, device: "cpu", compute_type: "int8", device_readiness: "ready", migration_status: "completed" }),
     );
-    const state = readAsrState("/tmp/asr/state.json", readFileSync, existsSync);
+    const state = readAsrState("/tmp/asr/state.json", readFileSync, existsSync, validLstatSync());
     expect(state.kind).toBe("incomplete");
+    expect(existsSync).toHaveBeenCalledWith(configJson);
   });
 
   it("returns incomplete when tokenizer.json is missing", () => {
     const tok = path.join(path.dirname("/tmp/asr/state.json"), "models", "tokenizer.json");
     const existsSync = vi.fn((p: string) => p !== tok);
     const readFileSync = vi.fn(() =>
-      JSON.stringify({ kind: "ready", version: ASR_STATE_VERSION, runtime: ASR_PINNED_RUNTIME, model: ASR_PINNED_MODEL, revision: ASR_PINNED_REVISION }),
+      JSON.stringify({ kind: "ready", version: ASR_STATE_VERSION, runtime: ASR_PINNED_RUNTIME, model: ASR_PINNED_MODEL, revision: ASR_PINNED_REVISION, device: "cpu", compute_type: "int8", device_readiness: "ready", migration_status: "completed" }),
     );
-    const state = readAsrState("/tmp/asr/state.json", readFileSync, existsSync);
+    const state = readAsrState("/tmp/asr/state.json", readFileSync, existsSync, validLstatSync());
     expect(state.kind).toBe("incomplete");
+    expect(existsSync).toHaveBeenCalledWith(tok);
   });
 
   it("returns incomplete when vocabulary.txt is missing", () => {
     const vocab = path.join(path.dirname("/tmp/asr/state.json"), "models", "vocabulary.txt");
     const existsSync = vi.fn((p: string) => p !== vocab);
     const readFileSync = vi.fn(() =>
-      JSON.stringify({ kind: "ready", version: ASR_STATE_VERSION, runtime: ASR_PINNED_RUNTIME, model: ASR_PINNED_MODEL, revision: ASR_PINNED_REVISION }),
+      JSON.stringify({ kind: "ready", version: ASR_STATE_VERSION, runtime: ASR_PINNED_RUNTIME, model: ASR_PINNED_MODEL, revision: ASR_PINNED_REVISION, device: "cpu", compute_type: "int8", device_readiness: "ready", migration_status: "completed" }),
     );
-    const state = readAsrState("/tmp/asr/state.json", readFileSync, existsSync);
+    const state = readAsrState("/tmp/asr/state.json", readFileSync, existsSync, validLstatSync());
     expect(state.kind).toBe("incomplete");
+    expect(existsSync).toHaveBeenCalledWith(vocab);
   });
 });
 
@@ -235,6 +257,31 @@ describe("writeAsrState", () => {
     expect(rename).not.toHaveBeenCalled();
     expect(unlink).toHaveBeenCalledWith(expect.stringMatching(/\.state-[0-9a-f-]{36}\.tmp$/));
   });
+
+  it("preserves the previous valid state bytes when atomic rename fails", () => {
+    const previous = JSON.stringify({
+      kind: "ready",
+      version: 1,
+      runtime: ASR_PINNED_RUNTIME,
+      model: ASR_PINNED_MODEL,
+      revision: ASR_PINNED_REVISION,
+    });
+    fs.writeFileSync(stateFile, previous);
+    const randomId = () => "rename-failure";
+
+    expect(() => writeAsrState(
+      stateFile,
+      "small",
+      fs.writeFileSync,
+      (() => { throw new Error("interrupted"); }) as typeof fs.renameSync,
+      fs.unlinkSync,
+      fs.mkdirSync,
+      randomId,
+    )).toThrow("atomically");
+
+    expect(fs.readFileSync(stateFile, "utf8")).toBe(previous);
+    expect(fs.existsSync(path.join(tmpDir, ".state-rename-failure.tmp"))).toBe(false);
+  });
 });
 
 describe("readAsrState symlink safety", () => {
@@ -244,6 +291,10 @@ describe("readAsrState symlink safety", () => {
     runtime: ASR_PINNED_RUNTIME,
     model: ASR_PINNED_MODEL,
     revision: ASR_PINNED_REVISION,
+    device: "cpu",
+    compute_type: "int8",
+    device_readiness: "ready",
+    migration_status: "completed",
   });
 
   const managedPaths = (): Array<[string, "dir" | "file"]> => {
@@ -288,6 +339,7 @@ describe("readAsrState symlink safety", () => {
         lstatSync,
       );
       expect(state.kind).toBe("incomplete");
+      expect(lstatSync).toHaveBeenCalledWith(managed);
     },
   );
 
@@ -349,6 +401,10 @@ describe("readAsrState path type verification", () => {
     runtime: ASR_PINNED_RUNTIME,
     model: ASR_PINNED_MODEL,
     revision: ASR_PINNED_REVISION,
+    device: "cpu",
+    compute_type: "int8",
+    device_readiness: "ready",
+    migration_status: "completed",
   });
   const stateFile = "/tmp/asr/state.json";
   const root = path.dirname(stateFile);
@@ -382,6 +438,7 @@ describe("readAsrState path type verification", () => {
     });
     const state = readAsrState(stateFile, readFileSync, existsSync, lstatSync);
     expect(state.kind).toBe("incomplete");
+    expect(lstatSync).toHaveBeenCalledWith(slot);
   });
 
   it.each(dirSlots)("a file in a directory slot never returns ready: %s", (slot) => {
@@ -399,6 +456,7 @@ describe("readAsrState path type verification", () => {
     });
     const state = readAsrState(stateFile, readFileSync, existsSync, lstatSync);
     expect(state.kind).toBe("incomplete");
+    expect(lstatSync).toHaveBeenCalledWith(slot);
   });
 
   it("never reads a state file that is a directory", () => {
@@ -726,6 +784,10 @@ describe("readAsrState real-fs symlink rejection", () => {
           runtime: ASR_PINNED_RUNTIME,
           model: ASR_PINNED_MODEL,
           revision: ASR_PINNED_REVISION,
+          device: "cpu",
+          compute_type: "int8",
+          device_readiness: "ready",
+          migration_status: "completed",
         }),
       );
       expect(readAsrState(stateFile).kind).toBe("ready");
@@ -932,6 +994,59 @@ describe("downloadModel", () => {
 });
 
 describe("verifyModel", () => {
+  it("runs a minimal inference against a generated WAV and cleans it", async () => {
+    let probePath = "";
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      const script = args[2];
+      probePath = args[4];
+      expect(script).toContain("model.transcribe");
+      expect(script).toContain("for _ in segments");
+      expect(fs.readFileSync(probePath).subarray(0, 4).toString("ascii")).toBe("RIFF");
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+
+    await verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", spawnFn);
+
+    expect(probePath).not.toBe("");
+    expect(fs.existsSync(probePath)).toBe(false);
+  });
+
+  it("cleans the generated WAV when inference fails", async () => {
+    let probePath = "";
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      probePath = args[4];
+      expect(fs.existsSync(probePath)).toBe(true);
+      return Promise.resolve({ code: 1, stdout: "", stderr: "probe failed" });
+    });
+
+    await expect(
+      verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", spawnFn),
+    ).rejects.toThrow("Model verification failed");
+    expect(fs.existsSync(probePath)).toBe(false);
+  });
+
+  it("does not verify ready when the generated WAV cannot be removed", async () => {
+    let probePath = "";
+    const realUnlinkSync = fs.unlinkSync;
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      probePath = args[4];
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+    const unlinkSpy = vi.spyOn(fs, "unlinkSync").mockImplementation((candidate) => {
+      if (candidate === probePath) throw new Error("cleanup denied");
+      return realUnlinkSync(candidate);
+    });
+
+    try {
+      await expect(
+        verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", spawnFn),
+      ).rejects.toThrow("cleanup denied");
+    } finally {
+      unlinkSpy.mockRestore();
+      if (probePath) realUnlinkSync(probePath);
+    }
+  });
+
   it("passes model path via argv", async () => {
     const spawnFn = vi.fn(() => Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" }));
     await verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", spawnFn);
@@ -1485,7 +1600,7 @@ describe("readAsrState Phase 2 compatibility", () => {
     const readFileSync = vi.fn(() =>
       JSON.stringify({
         kind: "ready",
-        version: ASR_STATE_VERSION,
+        version: 1,
         runtime: ASR_PINNED_RUNTIME,
         model: "Systran/faster-whisper-tiny",
         revision: "d90ca5fe260221311c53c58e660288d3deb8d356",
@@ -1506,7 +1621,7 @@ describe("readAsrState Phase 2 compatibility", () => {
     const readFileSync = vi.fn(() =>
       JSON.stringify({
         kind: "ready",
-        version: ASR_STATE_VERSION,
+        version: 1,
         runtime: ASR_PINNED_RUNTIME,
         model: "Systran/faster-whisper-base",
         revision: "ebe41f70d5b6dfa9166e2c581c45c9c0cfc57b66",
@@ -1526,7 +1641,7 @@ describe("readAsrState Phase 2 compatibility", () => {
     const readFileSync = vi.fn(() =>
       JSON.stringify({
         kind: "ready",
-        version: ASR_STATE_VERSION,
+        version: 1,
         runtime: ASR_PINNED_RUNTIME,
         model: ASR_PINNED_MODEL,
         revision: ASR_PINNED_REVISION,
@@ -1546,7 +1661,7 @@ describe("readAsrState Phase 2 compatibility", () => {
     const readFileSync = vi.fn(() =>
       JSON.stringify({
         kind: "ready",
-        version: ASR_STATE_VERSION,
+        version: 1,
         runtime: ASR_PINNED_RUNTIME,
         model: "evil/model",
         revision: "deadbeef",
@@ -1554,6 +1669,96 @@ describe("readAsrState Phase 2 compatibility", () => {
     );
     const state = readAsrState("/tmp/asr/state.json", readFileSync, existsSync);
     expect(state.kind).toBe("incomplete");
+  });
+});
+
+describe("readAsrState Execution Profile schema", () => {
+  const existsSync = vi.fn(() => true);
+  const lstatSync = vi.fn(() => ({
+    isSymbolicLink: () => false,
+    isDirectory: () => true,
+    isFile: () => true,
+  }));
+  const base = {
+    kind: "ready",
+    version: 2,
+    runtime: ASR_PINNED_RUNTIME,
+    model: ASR_PINNED_MODEL,
+    revision: ASR_PINNED_REVISION,
+    device: "cpu",
+    compute_type: "int8",
+    device_readiness: "ready",
+    migration_status: "completed",
+  };
+  const read = (value: Record<string, unknown>) => readAsrState(
+    "/tmp/asr/state.json",
+    vi.fn(() => JSON.stringify(value)),
+    existsSync,
+    lstatSync,
+  );
+
+  it("reads v1 as model-ready with device migration pending", () => {
+    const state = read({
+      kind: "ready",
+      version: 1,
+      runtime: ASR_PINNED_RUNTIME,
+      model: ASR_PINNED_MODEL,
+      revision: ASR_PINNED_REVISION,
+    });
+
+    expect(state.kind).toBe("ready");
+    expect(state.modelKey).toBe("small");
+    expect(state.executionProfile).toBeUndefined();
+    expect(state.deviceReadiness).toBe("migration_pending");
+    expect(state.migrationStatus).toBe("pending");
+  });
+
+  it("reads a verified v2 CPU profile", () => {
+    const state = read(base);
+
+    expect(state.kind).toBe("ready");
+    expect(state.executionProfile).toEqual({ device: "cpu", computeType: "int8" });
+    expect(state.deviceReadiness).toBe("ready");
+    expect(state.migrationStatus).toBe("completed");
+    expect(state.failureCategory).toBeUndefined();
+  });
+
+  it("recognizes the future CUDA profile but does not mark it ready before GPU support", () => {
+    expect(resolveExecutionProfile("cuda", "float16")).toEqual({
+      device: "cuda",
+      computeType: "float16",
+    });
+
+    const state = read({
+      ...base,
+      device: "cuda",
+      compute_type: "float16",
+    });
+
+    expect(state.kind).toBe("incomplete");
+  });
+
+  it("accepts a sanitized GPU failure category on the CPU fallback profile", () => {
+    const state = read({
+      ...base,
+      failure_category: "no_nvidia_gpu",
+    });
+
+    expect(state.executionProfile).toEqual({ device: "cpu", computeType: "int8" });
+    expect(state.failureCategory).toBe("no_nvidia_gpu");
+  });
+
+  it.each([
+    ["device", { device: "../../gpu" }],
+    ["compute type", { compute_type: "__import__('os')" }],
+    ["cross-paired profile", { device: "cpu", compute_type: "float16" }],
+    ["readiness", { device_readiness: "maybe" }],
+    ["migration status", { migration_status: "running" }],
+    ["failure category", { failure_category: "raw stderr: C:\\secret" }],
+    ["CUDA ready with a GPU failure category", { device: "cuda", compute_type: "float16", failure_category: "no_nvidia_gpu" }],
+    ["unexpected sensitive field", { stderr: "C:\\secret" }],
+  ])("fails closed for invalid %s", (_label, overrides) => {
+    expect(read({ ...base, ...overrides }).kind).toBe("incomplete");
   });
 });
 
@@ -1576,6 +1781,13 @@ describe("writeAsrState Phase 2", () => {
     const parsed = JSON.parse(fs.readFileSync(stateFile, "utf8"));
     expect(parsed.model).toBe("Systran/faster-whisper-tiny");
     expect(parsed.revision).toBe("d90ca5fe260221311c53c58e660288d3deb8d356");
+    expect(parsed).toMatchObject({
+      version: 2,
+      device: "cpu",
+      compute_type: "int8",
+      device_readiness: "ready",
+      migration_status: "completed",
+    });
   });
 
   it("writes base model state", () => {
@@ -1713,6 +1925,65 @@ describe("runAsrInstallation with modelKey", () => {
     expect(spawnFn).not.toHaveBeenCalled();
 
     try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ok */ }
+  });
+
+  it("promotes a same-model v1 state with one CPU probe and no reinstall", async () => {
+    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "bilibili-mcp-asr-v1-promote-"));
+    const stateFile = path.join(tmpBase, "state.json");
+    const binDir = path.join(tmpBase, "venv", os.platform() === "win32" ? "Scripts" : "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, os.platform() === "win32" ? "python.exe" : "python"), "fake");
+    fs.mkdirSync(path.join(tmpBase, "models"));
+    for (const file of ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]) {
+      fs.writeFileSync(path.join(tmpBase, "models", file), "placeholder");
+    }
+    fs.writeFileSync(stateFile, JSON.stringify({
+      kind: "ready",
+      version: 1,
+      runtime: ASR_PINNED_RUNTIME,
+      model: ASR_PINNED_MODEL,
+      revision: ASR_PINNED_REVISION,
+    }));
+    const spawnFn = vi.fn(() => Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" }));
+
+    const result = await runAsrInstallation({ spawnFn, asrBase: tmpBase, modelKey: "small" });
+
+    expect(result.success).toBe(true);
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    expect(spawnFn.mock.calls[0][1]).toContain(path.join(tmpBase, "models"));
+    const state = readAsrState(stateFile);
+    expect(state.executionProfile).toEqual({ device: "cpu", computeType: "int8" });
+    expect(state.migrationStatus).toBe("completed");
+    fs.rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("keeps a same-model v1 state unchanged when the CPU probe fails", async () => {
+    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "bilibili-mcp-asr-v1-fail-"));
+    const stateFile = path.join(tmpBase, "state.json");
+    const binDir = path.join(tmpBase, "venv", os.platform() === "win32" ? "Scripts" : "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, os.platform() === "win32" ? "python.exe" : "python"), "fake");
+    fs.mkdirSync(path.join(tmpBase, "models"));
+    for (const file of ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]) {
+      fs.writeFileSync(path.join(tmpBase, "models", file), "placeholder");
+    }
+    const previous = JSON.stringify({
+      kind: "ready",
+      version: 1,
+      runtime: ASR_PINNED_RUNTIME,
+      model: ASR_PINNED_MODEL,
+      revision: ASR_PINNED_REVISION,
+    });
+    fs.writeFileSync(stateFile, previous);
+    const spawnFn = vi.fn(() => Promise.resolve({ code: 1, stdout: "", stderr: "probe failed" }));
+
+    const result = await runAsrInstallation({ spawnFn, asrBase: tmpBase, modelKey: "small" });
+
+    expect(result.success).toBe(false);
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync(stateFile, "utf8")).toBe(previous);
+    expect(readAsrState(stateFile).migrationStatus).toBe("pending");
+    fs.rmSync(tmpBase, { recursive: true, force: true });
   });
 
   it("already-installed tiny is idempotent with explicit modelKey", async () => {
@@ -1924,7 +2195,7 @@ describe("readAsrState derived modelKey", () => {
     const readFileSync = vi.fn(() =>
       JSON.stringify({
         kind: "ready",
-        version: ASR_STATE_VERSION,
+        version: 1,
         runtime: ASR_PINNED_RUNTIME,
         model: ASR_PINNED_MODEL,
         revision: ASR_PINNED_REVISION,
@@ -1944,7 +2215,7 @@ describe("readAsrState derived modelKey", () => {
     const readFileSync = vi.fn(() =>
       JSON.stringify({
         kind: "ready",
-        version: ASR_STATE_VERSION,
+        version: 1,
         runtime: ASR_PINNED_RUNTIME,
         model: "Systran/faster-whisper-tiny",
         revision: "d90ca5fe260221311c53c58e660288d3deb8d356",

--- a/tests/asr-transcription.test.ts
+++ b/tests/asr-transcription.test.ts
@@ -21,6 +21,8 @@ import type { PlaybackAudioCandidate } from "../src/bilibili/playback.js";
 import { FakeIpDnsError } from "../src/security/pinned-https.js";
 import { AsrError } from "../src/utils/errors.js";
 
+const CPU_PROFILE = { device: "cpu", computeType: "int8" } as const;
+
 const tempDirs: string[] = [];
 const candidate: PlaybackAudioCandidate = {
   url: "https://upos-sz-mirrorcoso1.bilivideo.com/audio.m4s?token=signed",
@@ -37,7 +39,12 @@ function readyDependencies() {
       model: path.join("managed-root", "models"),
       stateFile: path.join("managed-root", "state.json"),
     }),
-    getState: () => ({ kind: "ready" as const }),
+    getState: () => ({
+      kind: "ready" as const,
+      executionProfile: CPU_PROFILE,
+      deviceReadiness: "ready" as const,
+      migrationStatus: "completed" as const,
+    }),
   };
 }
 
@@ -119,7 +126,7 @@ describe("ASR child isolation and lifecycle", () => {
       "managed-python",
       "managed-model",
       "temporary-audio",
-      { spawnFn: spawnFn as never },
+      { executionProfile: CPU_PROFILE, spawnFn: spawnFn as never },
     );
     child.stdout.write(fakeNdjson());
     child.emit("close", 0);
@@ -129,8 +136,9 @@ describe("ASR child isolation and lifecycle", () => {
     const [executable, argv, options] = spawnFn.mock.calls[0];
     expect(executable).toBe("managed-python");
     expect(argv[0]).toBe("-I");
-    expect(argv.at(-2)).toBe("managed-model");
-    expect(argv.at(-1)).toBe("temporary-audio");
+    expect(argv.slice(-4)).toEqual(["managed-model", "temporary-audio", "cpu", "int8"]);
+    expect(argv[2]).toContain("device=sys.argv[3]");
+    expect(argv[2]).toContain("compute_type=sys.argv[4]");
     expect(argv[2]).toContain("CreateJobObjectW");
     expect(argv[2]).toContain("AssignProcessToJobObject");
     expect(argv[2]).toContain("RLIMIT_AS");
@@ -156,6 +164,7 @@ describe("ASR child isolation and lifecycle", () => {
     child.kill = vi.fn(() => true);
     const spawnFn = vi.fn(() => child as never);
     const promise = runManagedAsrRuntime("python", "model", "audio", {
+      executionProfile: CPU_PROFILE,
       spawnFn: spawnFn as never,
       signal: controller.signal,
     });
@@ -194,6 +203,7 @@ describe("ASR child isolation and lifecycle", () => {
     const spawnFn = vi.fn(() => child as never);
 
     const promise = runManagedAsrRuntime("python", "model", "audio", {
+      executionProfile: CPU_PROFILE,
       spawnFn: spawnFn as never,
       timeoutMs: 5,
     });
@@ -216,6 +226,7 @@ describe("ASR child isolation and lifecycle", () => {
     });
     const spawnFn = vi.fn(() => child as never);
     const promise = runManagedAsrRuntime("python", "model", "audio", {
+      executionProfile: CPU_PROFILE,
       spawnFn: spawnFn as never,
       timeoutMs: 1_000,
     });
@@ -614,6 +625,91 @@ describe("ASR orchestration", () => {
     )).resolves.toMatchObject({ language: "en" });
     expect(removeTempDir).toHaveBeenCalledOnce();
     expect(runRuntime).toHaveBeenCalledOnce();
+    expect(runRuntime.mock.calls[0][3]).toEqual(CPU_PROFILE);
+  });
+
+  it("uses the controlled legacy CPU fallback for a v1 migration-pending state", async () => {
+    const runRuntime = vi.fn(async () => ({ language: "zh", segments: [] }));
+
+    await transcribeVideoPart(
+      { bvid: "BV1T6PQzQErF", cid: 12345, durationSeconds: 60 },
+      {
+        ...readyDependencies(),
+        getState: () => ({
+          kind: "ready",
+          version: 1,
+          deviceReadiness: "migration_pending",
+          migrationStatus: "pending",
+        }),
+        getPlayback: async () => ({ candidates: [candidate], durationSeconds: 60 }),
+        createTempDir: async () => path.join(os.tmpdir(), `${ASR_TEMP_PREFIX}legacy`),
+        removeTempDir: vi.fn(async () => undefined),
+        downloadAudio: vi.fn(async () => undefined),
+        runRuntime,
+      },
+    );
+
+    expect(runRuntime.mock.calls[0][3]).toEqual(CPU_PROFILE);
+  });
+
+  it("rejects an unallowlisted injected profile before playback or subprocess work", async () => {
+    const getPlayback = vi.fn();
+    const runRuntime = vi.fn();
+
+    await expect(transcribeVideoPart(
+      { bvid: "BV1T6PQzQErF", cid: 12345, durationSeconds: 60 },
+      {
+        ...readyDependencies(),
+        getState: () => ({
+          kind: "ready",
+          executionProfile: { device: "cpu", computeType: "float16" },
+          deviceReadiness: "ready",
+          migrationStatus: "completed",
+        } as never),
+        getPlayback,
+        runRuntime,
+      },
+    )).rejects.toMatchObject({ code: "ASR_NOT_READY" });
+    expect(getPlayback).not.toHaveBeenCalled();
+    expect(runRuntime).not.toHaveBeenCalled();
+  });
+
+  it("rejects a CPU profile that has not reached ready/completed", async () => {
+    const getPlayback = vi.fn();
+
+    await expect(transcribeVideoPart(
+      { bvid: "BV1T6PQzQErF", cid: 12345, durationSeconds: 60 },
+      {
+        ...readyDependencies(),
+        getState: () => ({
+          kind: "ready",
+          executionProfile: CPU_PROFILE,
+          deviceReadiness: "migration_pending",
+          migrationStatus: "pending",
+        }),
+        getPlayback,
+      },
+    )).rejects.toMatchObject({ code: "ASR_NOT_READY" });
+    expect(getPlayback).not.toHaveBeenCalled();
+  });
+
+  it("does not execute a CUDA profile before the CUDA readiness ticket", async () => {
+    const getPlayback = vi.fn();
+
+    await expect(transcribeVideoPart(
+      { bvid: "BV1T6PQzQErF", cid: 12345, durationSeconds: 60 },
+      {
+        ...readyDependencies(),
+        getState: () => ({
+          kind: "ready",
+          executionProfile: { device: "cuda", computeType: "float16" },
+          deviceReadiness: "ready",
+          migrationStatus: "completed",
+        }),
+        getPlayback,
+      },
+    )).rejects.toMatchObject({ code: "ASR_NOT_READY" });
+    expect(getPlayback).not.toHaveBeenCalled();
   });
 
   it("cleans the request directory after download or runtime failure", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -956,6 +956,117 @@ describe("buildDoctorStatus Phase 2 model field", () => {
   });
 });
 
+describe("buildDoctorStatus ASR Execution Profile", () => {
+  beforeEach(() => {
+    clearCredentialEnv();
+    credentialManager.clearCredentials();
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    credentialManager.clearCredentials();
+  });
+
+  it("reports the verified v2 CPU profile", () => {
+    const status = buildDoctorStatus(vi.fn(() => ({
+      kind: "ready" as const,
+      version: 2,
+      runtime: ASR_PINNED_RUNTIME,
+      model: ASR_PINNED_MODEL,
+      revision: ASR_PINNED_REVISION,
+      modelKey: "small" as const,
+      executionProfile: { device: "cpu" as const, computeType: "int8" as const },
+      deviceReadiness: "ready" as const,
+      migrationStatus: "completed" as const,
+    })));
+
+    expect(status.asr).toEqual({
+      status: "ready",
+      model: "small",
+      device: "cpu",
+      compute_type: "int8",
+      device_readiness: "ready",
+      migration_status: "completed",
+      failure_category: null,
+    });
+  });
+
+  it("reports only an allowlisted sanitized failure category", () => {
+    const status = buildDoctorStatus(vi.fn(() => ({
+      kind: "ready" as const,
+      version: 2,
+      modelKey: "small" as const,
+      executionProfile: { device: "cpu" as const, computeType: "int8" as const },
+      deviceReadiness: "ready" as const,
+      migrationStatus: "completed" as const,
+      failureCategory: "no_nvidia_gpu" as const,
+    })));
+
+    expect(status.asr.failure_category).toBe("no_nvidia_gpu");
+  });
+
+  it("reports v1 as migration pending without claiming a verified device", () => {
+    const status = buildDoctorStatus(vi.fn(() => ({
+      kind: "ready" as const,
+      version: 1,
+      runtime: ASR_PINNED_RUNTIME,
+      model: ASR_PINNED_MODEL,
+      revision: ASR_PINNED_REVISION,
+      modelKey: "small" as const,
+      deviceReadiness: "migration_pending" as const,
+      migrationStatus: "pending" as const,
+    })));
+
+    expect(status.asr).toMatchObject({
+      status: "ready",
+      model: "small",
+      device: null,
+      compute_type: null,
+      device_readiness: "migration_pending",
+      migration_status: "pending",
+      failure_category: null,
+    });
+  });
+
+  it.each(["not_installed", "incomplete"] as const)(
+    "reports %s without an execution profile",
+    (kind) => {
+      const status = buildDoctorStatus(vi.fn(() => ({ kind })));
+      expect(status.asr).toMatchObject({
+        device: null,
+        compute_type: null,
+        device_readiness: "not_ready",
+        migration_status: null,
+        failure_category: null,
+      });
+    },
+  );
+
+  it("never serializes injected stderr, paths, commands, or failure text", () => {
+    const status = buildDoctorStatus(vi.fn(() => ({
+      kind: "ready",
+      version: 2,
+      modelKey: "small",
+      executionProfile: { device: "../../cuda", computeType: "raw-command" },
+      deviceReadiness: "ready",
+      migrationStatus: "completed",
+      failureCategory: "raw stderr at C:\\private\\driver.dll",
+      stderr: "SECRET_STDERR",
+      command: "python --secret",
+      env: "TOKEN=secret",
+    } as never)));
+    const json = JSON.stringify(status);
+
+    expect(status.asr.device).toBeNull();
+    expect(status.asr.failure_category).toBeNull();
+    expect(json).not.toContain("SECRET_STDERR");
+    expect(json).not.toContain("private");
+    expect(json).not.toContain("--secret");
+    expect(json).not.toContain("TOKEN");
+  });
+});
+
 // ---------- Phase 2: setup model selection flow ----------
 
 describe("setupCredentials model selection", () => {


### PR DESCRIPTION
## Summary

- persist a verified `cpu/int8` ASR Execution Profile only after minimal model inference succeeds
- project legacy v1 state as model-ready with device migration pending
- expose sanitized readiness fields through `doctor` and drive transcription from the validated profile
- preserve transcript/MCP schemas, credential handling, network boundaries, and #66/#67 GPU migration scope

## Verification

- `npm run build`
- focused Vitest: 4 files / 282 tests
- full Vitest: 44 files / 1,104 tests
- `npm pack --dry-run --json --ignore-scripts`
- production audit: 0 vulnerabilities
- staged Gitleaks scan: 0 findings
- exact Harness real-pilot conformance: 1/1
- Standards, Spec, and risk reviews: no remaining findings

## Residual validation

A real `faster-whisper` CPU smoke remains a merge/release QA check because it would use user-managed model state outside the isolated worktree.

Closes #65