### PR TITLE
feat(asr): add verified CUDA readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Bilibili MCP 是一个本地 MCP server，让 AI Agent 读取 Bilibili 内容。
    npx -y @xzxzzx/bilibili-mcp@latest check
    npx -y @xzxzzx/bilibili-mcp@latest doctor --json
    doctor --json 只检查本机配置状态，不能代替后面的实时登录验证。
-   setup 会询问是否安装可选的本地 ASR 模型，选否即可。自动化环境可用 setup --non-interactive（凭据来自已有的环境变量或全局配置，绝不提示、也绝不从 stdin/argv 读取凭据值）；加 --asr-model <tiny|base|small> 可同时安装指定模型。
+   setup 会询问是否安装可选的本地 ASR 模型，选否即可。自动化环境可用 setup --non-interactive（凭据来自已有的环境变量或全局配置，绝不提示、也绝不从 stdin/argv 读取凭据值）；加 --asr-model <tiny|base|small> 可同时安装指定模型，--asr-device <auto|cpu|cuda> 选择设备偏好（默认 auto）。
 5. 让我重启或重连客户端。你无法代替我完成这一步时，请明确让我操作。
 6. 重连后调用 MCP 工具 check_bilibili_credentials。
    只有 configured: true 且 logged_in: true 才报告成功。
@@ -170,9 +170,11 @@ Bilibili 会把部分视频的 AI 识别字幕标为 `ai-zh`、`ai-en`、`ai-ja`
 |---|---|---|
 | tiny | ~78 MB | 速度优先：适合快速提取和长视频初筛；准确率相对较低 |
 | base | ~148 MB | 均衡：兼顾速度、质量和资源占用 |
-| small | ~486 MB | 质量优先：CPU 耗时和内存占用更高；推荐，Enter 默认选中 |
+| small | ~486 MB | 质量优先：耗时和内存占用更高；推荐，Enter 默认选中 |
 
-Runtime 固定为 `faster-whisper==1.2.1`，模型存放在用户目录 `~/.bilibili-mcp/asr/`，通过 CPU INT8 加载验证后才算就绪，不需要系统 FFmpeg；同一目录仅保留一个活跃模型。`doctor --json` 的 `asr.status` 和 `asr.model` 报告就绪状态与已选模型（纯信息字段，不影响凭证退出状态）。
+Runtime 固定为 `faster-whisper==1.2.1` 与 `ctranslate2==4.8.0`，模型存放在用户目录 `~/.bilibili-mcp/asr/`，不需要系统 FFmpeg；同一目录仅保留一个活跃模型。选择模型后还需选择设备偏好：`auto`（默认）先用程序生成的固定短 WAV 完整验证 `cuda/float16`，失败时说明脱敏原因并验证、保存 `cpu/int8`；`cpu` 跳过 GPU；`cuda` 验证失败则报错且不回退。`doctor --json` 会报告实际生效的 `device`、`compute_type`、readiness 与脱敏失败类别。
+
+项目不会安装或修改 NVIDIA 驱动、CUDA、cuBLAS、cuDNN、系统 `PATH`、`LD_LIBRARY_PATH` 或全局 Python。GPU 验证失败后，你可以继续使用已经验证的 CPU，也可以自行修复 GPU 环境后重新运行 `setup`；每次重新运行都会再次验证设备。
 
 **边界：**本地转录始终被约束在安全范围内——显式选择、资源受限、Cookie 隔离：
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -57,7 +57,7 @@ Please help me install the Bilibili MCP server: @xzxzzx/bilibili-mcp.
    npx -y @xzxzzx/bilibili-mcp@latest check
    npx -y @xzxzzx/bilibili-mcp@latest doctor --json
    doctor --json checks local configuration only; it does not replace the live login verification below.
-   setup will ask about installing the optional local ASR model; choosing no is fine. Automated environments can run setup --non-interactive (credentials come from existing environment variables or the global config file; no prompts, and credential values are never read from stdin/argv); add --asr-model <tiny|base|small> to also install a given model.
+   setup will ask about installing the optional local ASR model; choosing no is fine. Automated environments can run setup --non-interactive (credentials come from existing environment variables or the global config file; no prompts, and credential values are never read from stdin/argv); add --asr-model <tiny|base|small> to install a model and --asr-device <auto|cpu|cuda> to choose the device preference (default: auto).
 5. Ask me to restart or reconnect the client. When you can't do it for me,
    tell me explicitly to do it myself.
 6. After reconnect, call the MCP tool check_bilibili_credentials.
@@ -178,9 +178,11 @@ Some videos ship without any subtitle. Once you install a local ASR model, `get_
 |---|---|---|
 | tiny | ~78 MB | Speed-first: suited to quick extraction and initial review of long videos; relatively lower accuracy |
 | base | ~148 MB | Balanced: balances speed, quality, and resource use |
-| small | ~486 MB | Quality-first: higher CPU time and memory use; recommended, selected on Enter |
+| small | ~486 MB | Quality-first: higher runtime and memory use; recommended, selected on Enter |
 
-The runtime is pinned to `faster-whisper==1.2.1`. Models live under `~/.bilibili-mcp/asr/`, are verified by a CPU INT8 load before being marked ready, and do not require system FFmpeg; only one active model is kept per directory. `doctor --json` reports readiness and the selected model via `asr.status` and `asr.model` (informational fields that never affect credential exit codes).
+The runtime is pinned to `faster-whisper==1.2.1` and `ctranslate2==4.8.0`. Models live under `~/.bilibili-mcp/asr/`, do not require system FFmpeg, and only one active model is kept per directory. After choosing a model, choose a device preference: `auto` (default) performs a complete `cuda/float16` check with a generated fixed short WAV, explains a sanitized failure and verifies/saves `cpu/int8` when CUDA is not ready; `cpu` skips GPU probing; `cuda` fails without CPU fallback. `doctor --json` reports the effective device, compute type, readiness, and sanitized failure category.
+
+The project never installs or modifies NVIDIA drivers, CUDA, cuBLAS, cuDNN, the system `PATH`, `LD_LIBRARY_PATH`, or global Python. After a GPU failure, you decide whether to keep the verified CPU profile or repair the GPU environment and rerun `setup`; every setup rerun rechecks device readiness.
 
 **Boundaries:** local transcription stays within safe bounds — opt-in, resource-capped, Cookie-isolated:
 

--- a/docs/agent-memory/active-work.md
+++ b/docs/agent-memory/active-work.md
@@ -14,13 +14,18 @@ never falls back; a readiness failure before activation preserves the prior
 installation. Captured activation errors roll back, and incomplete rollback
 leaves the ready state inactive so the runner fails closed. Focused tests,
 build, the 44-file / 1,145-test suite, isolated exact-pin CPU setup and
-runner smoke, and independent review pass. A fresh Windows run with externally
+runner smoke, and the initial independent review pass. A fresh Windows run with externally
 supplied CUDA 12 libraries also completed exact-pair setup as `cuda/float16`
 and produced a non-empty actual runner transcript, satisfying the final #66
-hardware gate without changing persistent host configuration. The candidate is
-locally accepted; the user has separately authorized its focused commit and
-push on this branch. First-ASR automatic migration remains #67. PR, merge,
-Issue close, release, and publication remain separate authority gates.
+hardware gate without changing persistent host configuration. PR #70 then
+found that standard POSIX venv creation can leave `venv/bin/python` as a
+symlink rejected by the managed-path gate. The same-scope repair creates venvs
+with copied executables; 184 focused tests, the 44-file / 1,145-test suite,
+build, and a real Ubuntu 24.04 non-symlink interpreter smoke pass. The first
+Hosted run also exposed only the expected stale canonical-LF package/memory
+receipt, which was refreshed without changing package boundaries. PR #70 is
+the current integration gate. First-ASR automatic migration remains #67;
+merge, Issue close, release, and publication remain separate authority gates.
 
 ## Harness v2
 

--- a/docs/agent-memory/active-work.md
+++ b/docs/agent-memory/active-work.md
@@ -2,20 +2,25 @@
 
 ## Current Product Ticket
 
-GitHub Issue #65 is the current approved child ticket under #55. Work is
-isolated on `codex/issue-65-cpu-execution-profile` from merged PR #68 base
-`547b2bb170121bb7701d523e28f3a1f06b1224a8` and is directly executed by Codex
-without Paseo. The bounded implementation upgrades ASR state to v2, persists
-only a verified `cpu/int8` Execution Profile, derives legacy v1 as model-ready
-with device migration pending, requires a generated short-WAV inference and
-generator consumption before ready, reports controlled readiness fields from
-`doctor`, and drives the existing runner from the validated Profile. CUDA
-readiness, GPU probing/fallback, and first-ASR automatic migration remain #66
-and #67. Focused tests, build, the 44-file / 1,104-test suite, package dry run,
-production audit, and three independent review axes pass; a real model CPU
-smoke remains intentionally unrun because it would touch user-managed ASR
-state. Commit, push, PR, Issue close, release, and publication remain separate
-authority gates.
+GitHub Issue #66 is the current approved child ticket under #55. Work is
+isolated on `codex/issue-66-cuda-readiness` from base
+`6199142cb35a5d3b12f70ee1c41a65e60d3ca696` and is directly executed by Codex
+without Paseo. The implementation adds `auto | cpu | cuda` setup preferences,
+pins `faster-whisper==1.2.1` with `ctranslate2==4.8.0`, verifies the selected
+Profile through generated-WAV inference, and publishes staged runtime/model
+artifacts before the matching ready state. Auto saves CUDA only after real success and otherwise
+explains a sanitized category before verified CPU fallback; explicit CUDA
+never falls back; a readiness failure before activation preserves the prior
+installation. Captured activation errors roll back, and incomplete rollback
+leaves the ready state inactive so the runner fails closed. Focused tests,
+build, the 44-file / 1,145-test suite, isolated exact-pin CPU setup and
+runner smoke, and independent review pass. A fresh Windows run with externally
+supplied CUDA 12 libraries also completed exact-pair setup as `cuda/float16`
+and produced a non-empty actual runner transcript, satisfying the final #66
+hardware gate without changing persistent host configuration. The candidate is
+locally accepted; the user has separately authorized its focused commit and
+push on this branch. First-ASR automatic migration remains #67. PR, merge,
+Issue close, release, and publication remain separate authority gates.
 
 ## Harness v2
 

--- a/docs/agent-memory/codemap.md
+++ b/docs/agent-memory/codemap.md
@@ -46,21 +46,25 @@ This file is a navigation index for `@xzxzzx/bilibili-mcp`. It is not a design s
 - `src/asr/state.ts`: three-model allowlist (`tiny`/`base`/`small` with pinned
   revisions and approximate sizes), controlled Execution Profile/failure
   enums, derived user paths (`~/.bilibili-mcp/asr/`), strict v1/v2 state
-  validation, v1 migration-pending projection, and atomic v2 `cpu/int8` ready
-  write (parameterized by model key, defaults to `small`).
+  validation, v1 migration-pending projection, and atomic v2 verified
+  `cpu/int8` or `cuda/float16` ready writes (parameterized by model key,
+  defaults to `small`).
 - `src/asr/installer.ts`: injectable Python 3.9+ discovery (with
   `BILIBILI_ASR_PYTHON` override), allowlisted child environment, subprocess
-  deadlines/output caps, user-scoped venv creation, pinned pip install,
-  staged/budgeted/no-symlink snapshot download, generated short-WAV CPU INT8
-  inference with full generator consumption, temporary-audio cleanup, same-model
-  v1 promotion without reinstall, atomic Profile activation, and failure cleanup.
-  One active model reuses the Phase 1 directory.
+  deadlines/output caps, user-scoped venv creation, exact faster-whisper and
+  CTranslate2 pins, staged/budgeted/no-symlink snapshot download, `auto | cpu |
+  cuda` readiness with generated short-WAV inference and full generator
+  consumption, sanitized GPU failure categories, temporary-audio cleanup,
+  same-model v1 promotion, staged runtime/model publication with captured-error
+  rollback, and fail-closed state invalidation when rollback is incomplete. One
+  active model reuses the Phase 1 directory; a failed probe keeps the prior
+  verified installation.
 - `src/asr/transcription.ts`: explicit ready-state-only ASR orchestration. It
   requires trusted duration, owns one aggregate audio deadline/byte budget,
   unique temporary directories, one-active/no-queue concurrency, bounded
   Windows Job/POSIX `RLIMIT` managed-Python execution, strict NDJSON,
-  cancellation/tree kill, controlled Profile-driven Python argv, legacy v1 CPU
-  fallback, guarded cleanup, and all-candidate Fake-IP failure aggregation
+  cancellation/tree kill, validated `cpu/int8` or `cuda/float16` Profile-driven
+  Python argv, legacy v1 CPU fallback, guarded cleanup, and all-candidate Fake-IP failure aggregation
   without preventing later-candidate success. MCP requests never
   install or switch models.
 

--- a/docs/agent-memory/decisions.md
+++ b/docs/agent-memory/decisions.md
@@ -890,3 +890,36 @@
   #67 owns first-ASR device migration and #66 owns GPU probing/fallback.
 - Evidence: exact v1 state preservation on probe failure, one-probe promotion,
   and #65/#55 issue boundary review.
+
+## 2026-08-24 — CUDA ASR Device Readiness
+
+- Decision: Setup accepts only `auto`, `cpu`, or `cuda`, defaulting to `auto`.
+  Auto may save `cuda/float16` only after the selected local model completes a
+  generated-WAV inference; a failed GPU probe is reduced to a fixed category
+  before an independent CPU probe. Explicit CUDA never falls back.
+- Reason: hardware detection or model construction alone does not prove an
+  executable Profile, while silent fallback would violate explicit user intent.
+- Evidence: Issue #66, deterministic device/readiness regressions, and the
+  isolated Windows setup smoke.
+
+- Decision: Pin `ctranslate2==4.8.0` beside `faster-whisper==1.2.1` and stage the
+  runtime/model replacement before publication. During activation, move the
+  prior ready state out of the active slot before swapping artifacts; restore
+  it only after both artifact rollbacks succeed, otherwise leave state inactive
+  so subsequent runners fail closed. A supplied
+  `BILIBILI_ASR_PYTHON` or explicit override bootstraps staging; otherwise a
+  ready installation may reuse its managed Python.
+- Reason: a floating transitive GPU runtime is not reproducible, and mutating a
+  working runtime before readiness could destroy the only verified fallback.
+- Evidence: upstream/version research, historical Windows CTranslate2 4.8.0
+  inference evidence, rollback-failure/fail-closed regressions, and
+  Python-override TDD.
+
+- Decision: Keep NVIDIA drivers, CUDA, cuBLAS, cuDNN, loader paths, and global
+  Python outside project management. Report only controlled categories and let
+  the user decide whether to repair the environment, select CPU, or continue
+  without ASR.
+- Reason: system GPU mutation is host-specific and exceeds the package's
+  authority and rollback boundary.
+- Evidence: bilingual client guidance, sanitized CLI/doctor tests, and
+  `docs/research/2026-08-24-asr-cuda-readiness.md`.

--- a/docs/agent-memory/executions/2026-08-24-github-66-codex-direct-report.md
+++ b/docs/agent-memory/executions/2026-08-24-github-66-codex-direct-report.md
@@ -6,9 +6,9 @@
 - Mode: `codex-direct`, following the user's explicit no-Paseo direction.
 - Canonical worktree/base: `C:\Users\ZX\.codex\worktrees\issue-66\bilibili-mcp`
   at `6199142cb35a5d3b12f70ee1c41a65e60d3ca696`.
-- Terminal state: locally accepted and uncommitted. The fresh Windows GPU
-  setup-to-transcript gate is satisfied; remote effects remain a separate
-  authority gate.
+- Terminal state: branch pushed and PR #70 open. The fresh Windows GPU
+  setup-to-transcript gate is satisfied; the same-scope POSIX venv review
+  repair is locally verified and awaiting the Hosted integration gate.
 
 ## Summary
 
@@ -44,6 +44,9 @@ not change.
 - `npm audit --omit=dev --json`: zero production vulnerabilities.
 - `git diff --check`: passed; Gitleaks 8.30.1 found zero secrets in the tracked
   diff, three untracked evidence files, and rebuilt `dist`.
+- Post-review verification: `tests/asr-installer.test.ts` passed 184/184, the
+  complete 44-file / 1,145-test suite and build passed again, and Ubuntu 24.04
+  created `venv/bin/python` as a real non-symlink file with `--copies`.
 - Isolated exact-pin CPU setup and actual runner smoke: passed.
 - Isolated explicit-CUDA failure: `cuda_runtime_missing`; previous state and
   runtime preserved, no CPU fallback, zero staging residue.
@@ -68,6 +71,11 @@ not change.
 - Made probe cleanup failure non-fallbackable and moved the prior state out of
   the active slot during artifact activation, so incomplete rollback cannot
   expose a stale ready Profile.
+- Created managed venvs with copied executables so the standard POSIX
+  interpreter layout satisfies the existing fail-closed no-symlink gate.
+- Refreshed the canonical-LF package and durable-memory receipt chain after the
+  first Hosted run exposed expected #66 artifact drift; no packaged path was
+  added or removed.
 
 ## Residual Risk
 
@@ -102,5 +110,5 @@ not change.
 
 ## Git And Remote State
 
-No commit, push, PR, merge, Issue close, tag, release, or npm publication was
-performed.
+The focused implementation commit was pushed and PR #70 was opened. No merge,
+Issue close, tag, release, or npm publication was performed at report time.

--- a/docs/agent-memory/executions/2026-08-24-github-66-codex-direct-report.md
+++ b/docs/agent-memory/executions/2026-08-24-github-66-codex-direct-report.md
@@ -1,0 +1,106 @@
+# Execution Report: GitHub Issue #66
+
+## Contract
+
+- Task/source: GitHub Issue #66; parent #55; depends on merged #65 behavior.
+- Mode: `codex-direct`, following the user's explicit no-Paseo direction.
+- Canonical worktree/base: `C:\Users\ZX\.codex\worktrees\issue-66\bilibili-mcp`
+  at `6199142cb35a5d3b12f70ee1c41a65e60d3ca696`.
+- Terminal state: locally accepted and uncommitted. The fresh Windows GPU
+  setup-to-transcript gate is satisfied; remote effects remain a separate
+  authority gate.
+
+## Summary
+
+Setup now owns a three-value device preference and publishes only an actual
+verified Execution Profile. The exact managed runtime is built in staging and
+the selected local model must complete generated-WAV inference before staged
+runtime/model publication and the matching ready-state write. Captured
+activation errors roll back; incomplete rollback leaves state inactive. Auto
+can fall back to verified CPU with a
+sanitized explanation; explicit CUDA cannot.
+
+First-ASR automatic migration and its concurrency behavior remain #67. Public
+transcript/MCP schemas, playback security, limits, and credential behavior did
+not change.
+
+## Files Changed
+
+- Runtime: `src/asr/state.ts`, `src/asr/installer.ts`,
+  `src/asr/transcription.ts`, and `src/cli.ts`.
+- Tests: `tests/asr-installer.test.ts`, `tests/asr-transcription.test.ts`, and
+  `tests/cli.test.ts`.
+- User docs: bilingual README and client setup guidance.
+- Evidence: research, QA, active work, project facts, decisions, codemap,
+  verification log, handoff log, and this report.
+
+## Verification
+
+- Focused Vitest: 3 files / 321 tests passed.
+- Complete Vitest: 44 files / 1,145 tests passed.
+- `npm run build`: passed.
+- `npm pack --dry-run --json --ignore-scripts`: 193 files with all package
+  exclusions and `dist` entry points preserved.
+- `npm audit --omit=dev --json`: zero production vulnerabilities.
+- `git diff --check`: passed; Gitleaks 8.30.1 found zero secrets in the tracked
+  diff, three untracked evidence files, and rebuilt `dist`.
+- Isolated exact-pin CPU setup and actual runner smoke: passed.
+- Isolated explicit-CUDA failure: `cuda_runtime_missing`; previous state and
+  runtime preserved, no CPU fallback, zero staging residue.
+- Fresh Windows exact-pin GPU setup on RTX 5060 Laptop GPU / driver 592.19:
+  published `cuda/float16`; the actual managed runner produced one non-empty
+  segment / 46 characters from synthetic speech, with zero staging, backup, or
+  probe-WAV residue.
+- Standards and Spec reviewers: no remaining finding after same-scope repairs.
+- Codex Security did not complete because local auth refresh failed; no scan
+  pass or finding conclusion is claimed from that tool.
+
+## Review Repairs
+
+- Made runtime and model replacement one transaction so any failed probe keeps
+  the old verified installation intact.
+- Kept post-publication backup deletion best-effort so cleanup cannot report a
+  false setup failure after activation.
+- Distinguished CPU probe failures and preserved both sanitized categories when
+  auto GPU and CPU probes fail.
+- Honored explicit/environment Python overrides for ready same-model and
+  model-switch rebuilds while retaining managed-Python reuse without override.
+- Made probe cleanup failure non-fallbackable and moved the prior state out of
+  the active slot during artifact activation, so incomplete rollback cannot
+  expose a stale ready Profile.
+
+## Residual Risk
+
+- The host does not expose CUDA inference libraries by default. The successful
+  acceptance used official NVIDIA wheels in a disposable external environment
+  and process-local `PATH`; end users still own that prerequisite.
+- No real Linux GPU machine was exercised, so Linux support is not claimed as
+  machine-verified.
+- Best-effort deletion can leave a bounded backup directory when the OS denies
+  cleanup; the active verified runtime remains correct, but repeated external
+  denial could consume disk until the user removes stale backups.
+- Concurrent setup processes remain unsupported; this implementation does not
+  claim cross-process atomicity across runtime, model, and state.
+
+## Capabilities Used
+
+- User-invoked manual Skill: Matt `implement` for #66.
+- Model-invoked Skills: Matt `tdd`, `code-review`, `codebase-design`, Vitest,
+  `secret-scanning`, and `bilibili-mcp-memory`.
+- Reviewers: independent Standards/Spec axes and the project risk-review role;
+  no reviewer edited files.
+
+## Harness Artifacts
+
+- Task ticket: live GitHub Issue #66; no duplicate local ticket.
+- Research note: `docs/research/2026-08-24-asr-cuda-readiness.md`.
+- QA checklist: `docs/qa/2026-08-24-asr-cuda-readiness.md`.
+- Codemap and durable memory: updated for device preference, exact pins,
+  staged/fail-closed activation, failure categories, and the external GPU gate.
+- Harness security: reviewed; no credential or new authority boundary.
+- Harness eval: unchanged; #66 does not redesign the Harness or adapter flow.
+
+## Git And Remote State
+
+No commit, push, PR, merge, Issue close, tag, release, or npm publication was
+performed.

--- a/docs/agent-memory/handoff-log.md
+++ b/docs/agent-memory/handoff-log.md
@@ -529,3 +529,25 @@
   unverified (`BV1ybuQ62EfK` exposes no target subtitle; no real ASR/model run
   authorized); no commit/push/PR/Issue/release; corrupt-body/ASR live
   verification remains a named follow-up for Codex.
+
+## 2026-08-24 Issue #66 CUDA Device Readiness
+
+- Owner: Codex executed directly after the user invoked Matt `implement`; Paseo
+  was intentionally not used under the user's standing direction.
+- Objective: add `auto | cpu | cuda` setup semantics, exact GPU runtime pinning,
+  real model inference readiness, sanitized failure guidance, CPU fallback for
+  auto only, and transactional preservation of a previous verified install.
+- Result: implementation, bilingual docs, research, QA, durable memory, and
+  deterministic tests completed. Final review added fail-closed state handling
+  for incomplete rollback and stopped auto fallback after probe cleanup failure.
+  Independent reviewers closed every code and scope finding; focused tests,
+  full suite, build, and isolated CPU setup/runner smoke pass.
+- Hardware acceptance: after the expected `cuda_runtime_missing` result without
+  external libraries, a disposable NVIDIA CUDA 12 environment supplied only a
+  process-local `PATH`; exact-pair setup published `cuda/float16` and the actual
+  runner returned a non-empty transcript. Persistent host configuration and the
+  user installation remained unchanged.
+- Boundary: Linux GPU remains unverified and #67 still owns first-ASR automatic
+  migration. No commit, push, PR, merge, Issue close, tag, release, or
+  publication occurred. Report:
+  `docs/agent-memory/executions/2026-08-24-github-66-codex-direct-report.md`.

--- a/docs/agent-memory/lessons-learned.md
+++ b/docs/agent-memory/lessons-learned.md
@@ -577,3 +577,24 @@
 - Future behavior: for CLI tests that must terminate existing prompt loops,
   make mocks choose a terminating branch (for example "n" to skip ASR) and run
   each red test in isolation.
+
+## 2026-08-24 — ASR runtime replacement
+
+- Lesson: A readiness probe cannot protect a working installation if setup
+  mutates that installation before probing. Build runtime and model candidates
+  in sibling staging directories and probe there. Before activation, move the
+  old ready state out of the active slot; restore it only if every artifact
+  rollback succeeds, otherwise keep state inactive so the runner fails closed.
+- Evidence: Issue #66 review reproduced explicit-CUDA and model-switch failures
+  that otherwise left the previous Profile pointing at changed runtime bytes.
+- Future behavior: any ASR dependency, model, or device migration must preserve
+  the exact prior verified state/runtime/model until the replacement probe has
+  succeeded.
+
+- Lesson: Probe cleanup failure is not a normal device-readiness failure. Auto
+  fallback must stop rather than publish CPU ready while a generated WAV from
+  the failed GPU attempt remains undeleted.
+- Evidence: Issue #66 risk review reproduced a successful CPU fallback with an
+  orphaned GPU probe before the cleanup failure became non-fallbackable.
+- Future behavior: every readiness attempt must complete its own cleanup before
+  another device probe or ready-state publication is allowed.

--- a/docs/agent-memory/project-facts.md
+++ b/docs/agent-memory/project-facts.md
@@ -794,3 +794,26 @@
   accepts only verified `cpu/int8` as ready. `cuda/float16` remains a controlled
   future Profile but cannot become disk-ready until #66 implements GPU
   readiness; #67 still owns first-ASR automatic migration.
+
+- Fact: The isolated Issue #66 candidate accepts setup device preference
+  `auto | cpu | cuda`, installs the exact `faster-whisper==1.2.1` and
+  `ctranslate2==4.8.0` pair, and can persist either verified `cpu/int8` or
+  verified `cuda/float16`.
+- Evidence: device/state/installer/CLI regressions, 321 focused tests, 44 files /
+  1,145 full tests, build, isolated exact-pin setup, and independent review.
+- Impact: `auto` probes CUDA first and falls back only to independently verified
+  CPU; explicit CUDA failure preserves the old state, model, and runtime. Only
+  fixed sanitized failure categories reach doctor/setup guidance. Cleanup
+  failure cannot trigger fallback, and incomplete activation rollback leaves
+  state inactive rather than exposing an unverified ready combination.
+
+- Fact: Without externally exposed CUDA inference libraries, the fresh Windows
+  exact-pair probe returns `cuda_runtime_missing`; with CUDA 12 cuBLAS, cuDNN 9,
+  and CUDA Runtime supplied from a disposable external environment through
+  process-local `PATH`, the same RTX machine publishes `cuda/float16` and the
+  actual managed runner produces a non-empty transcript.
+- Evidence: `docs/research/2026-08-24-asr-cuda-readiness.md` and
+  `docs/qa/2026-08-24-asr-cuda-readiness.md`.
+- Impact: Issue #66's Windows GPU gate is satisfied without making the project
+  install or persist system CUDA components. Linux GPU remains unverified, and
+  first-ASR automatic migration remains #67.

--- a/docs/agent-memory/verification-log.md
+++ b/docs/agent-memory/verification-log.md
@@ -2690,3 +2690,13 @@ Six release blockers fixed; one regression proof per root cause (new tests
   commit, push, PR, merge, Issue close, tag, release, or publication occurred.
   Concurrent setup processes are not a supported #66 path; the implementation
   does not claim a cross-process multi-resource atomic transaction.
+- PR #70 follow-up: Hosted Product and both Harness core jobs deterministically
+  exposed a stale canonical-LF package receipt while Product tests/build,
+  Fake-IP Node 20/22/25, and the non-core Harness shards passed. The complete
+  193-path receipt and six changed durable-memory hashes were refreshed without
+  changing package membership. Codex review also found that POSIX `venv`
+  commonly symlinks `bin/python`, conflicting with the fail-closed managed-path
+  check; adding `--copies` preserved that security boundary. The focused file
+  passed 184/184, the full suite passed 44 files / 1,145 tests, build passed,
+  and a real Ubuntu 24.04 smoke confirmed `venv/bin/python` is a regular,
+  non-symlink file.

--- a/docs/agent-memory/verification-log.md
+++ b/docs/agent-memory/verification-log.md
@@ -2654,3 +2654,39 @@ Six release blockers fixed; one regression proof per root cause (new tests
   user-managed ASR state; that small Python/PyAV compatibility risk remains a
   merge/release follow-up. No commit, push, PR, Issue close, release, or publish
   occurred.
+
+## 2026-08-24 — Issue #66 CUDA Device Readiness
+
+- TDD evidence: device choice, exact pins, real probe profiles, sanitized
+  categories, fallback, no-fallback, rollback, staging cleanup, runner argv,
+  doctor output, and CLI guidance were introduced through failing regressions.
+  The final ready-install Python-override defect failed 2/2, then passed
+  181/181 after the bounded bootstrap repair.
+- Verification: 3 focused files / 321 tests, 44 files / 1,145 full tests, and
+  TypeScript build passed. Package dry run retained 193 files and all exclusion
+  and `dist` entry-point boundaries; production audit reported zero
+  vulnerabilities; diff check passed; Gitleaks found zero findings in the
+  tracked diff, three evidence files, and rebuilt `dist`.
+- Real isolated smoke: the exact pins completed CPU readiness and an actual
+  generated-WAV runner transcript from the newly activated managed venv. An
+  explicit CUDA retry returned only `cuda_runtime_missing`, preserved state
+  and a runtime marker, did not probe CPU, left zero staging residue, and the
+  disposable smoke root was removed after path verification.
+- Final Windows GPU acceptance: official NVIDIA CUDA 12 Windows wheels were
+  installed only into a disposable external environment and exposed through
+  process-local `PATH`. Exact `faster-whisper==1.2.1` plus
+  `ctranslate2==4.8.0` setup published `cuda/float16`; the actual managed runner
+  returned one non-empty 46-character English segment. State, package versions,
+  zero staging/backup/probe-WAV residue, and the unchanged user v1 installation
+  were checked directly.
+- Review: Standards, Spec, and risk axes found no remaining code/scope issue
+  after repairs for staged runtime/model activation, fail-closed incomplete
+  rollback, non-fallbackable probe cleanup failure, CPU/double-failure
+  diagnostics, best-effort post-publication cleanup, and ready-state Python
+  override handling.
+- Boundary: the Windows GPU gate now passes; Linux GPU remains unverified and
+  first-ASR automatic migration remains #67. Codex Security did not complete
+  because stored CLI auth could not be refreshed; no pass is claimed. No
+  commit, push, PR, merge, Issue close, tag, release, or publication occurred.
+  Concurrent setup processes are not a supported #66 path; the implementation
+  does not claim a cross-process multi-resource atomic transaction.

--- a/docs/client-setup.en.md
+++ b/docs/client-setup.en.md
@@ -72,7 +72,8 @@ Please help me install the Bilibili MCP server: @xzxzzx/bilibili-mcp.
    local ASR model. This is a local-only operation — do not answer for me or
    handle model files; let me follow the prompt, type y to continue or press
    Enter to skip [y/N]. After choosing to install, three model options are
-   shown; I select on my own or press Enter for the recommended small.
+   shown; I select on my own or press Enter for the recommended small, then
+   choose auto, cpu, or cuda (default: auto).
    After installation, I may explicitly set fallback_to_asr=true on
    get_video_transcript when I need no-subtitle fallback. Default calls never
    run ASR, and MCP calls never download or switch models.
@@ -80,7 +81,9 @@ Please help me install the Bilibili MCP server: @xzxzzx/bilibili-mcp.
    uses already-loadable credentials from environment variables or the global
    config file, never reading credential values from stdin/argv and never prompting. Without
    --asr-model it confirms loadability and exits successfully (exit 0); adding
-   --asr-model <tiny|base|small> installs that model (requires --non-interactive).
+   --asr-model <tiny|base|small> installs that model, and
+   --asr-device <auto|cpu|cuda> selects the device preference (default: auto;
+   both options require --non-interactive).
 
 6. After configuration, restart or reconnect this MCP server so it reloads
    the credentials.
@@ -1356,15 +1359,18 @@ After credentials are configured, `setup` asks whether to install an optional lo
 - After choosing Yes, three model choices are displayed:
   - `1. tiny` (~78.2 MB) — Speed-first: suited to quick extraction and initial review of long videos, with relatively lower accuracy
   - `2. base` (~148 MB) — Balanced: balances speed, quality, and resource use
-  - `3. small` (~486 MB) — Quality-first: higher CPU time and memory use; [recommended], selected on Enter
+  - `3. small` (~486 MB) — Quality-first: higher runtime and memory use; [recommended], selected on Enter
 - Enter `1/2/3` or `tiny/base/small` to choose; invalid input re-prompts without starting installation.
-- Runtime is fixed at `faster-whisper==1.2.1` plus runtime library overhead.
+- Then choose `auto/cpu/cuda`; Enter defaults to `auto`. `auto` fully checks the GPU first and explains a sanitized failure before verifying CPU fallback; `cpu` skips the GPU; explicit `cuda` fails without fallback.
+- Non-interactive form: `setup --non-interactive --asr-model <tiny|base|small> --asr-device <auto|cpu|cuda>`. Omitting `--asr-device` also defaults to `auto`.
+- Runtime is fixed at `faster-whisper==1.2.1` and `ctranslate2==4.8.0`, plus runtime library overhead.
 - Requires Python 3.9+ on the machine. Set the `BILIBILI_ASR_PYTHON` environment variable to override the Python executable.
 - Installation lives in the user-managed `~/.bilibili-mcp/asr/` directory; it does not mutate the system Python.
-- One active model per directory; switching models clears the old ready state.
-- After installation, the model is verified through a CPU INT8 load; system FFmpeg is not required (PyAV bundles the relevant FFmpeg libraries).
-- A failed installation leaves no ready marker; partial downloads are preserved and `setup` can resume from them.
-- The `doctor --json` `asr.status` and `asr.model` fields are informational only; they do not affect credential exit codes.
+- One active model per directory; a failed model switch or explicit CUDA check does not replace the previously verified model and Profile.
+- Readiness uses the chosen local model and a generated fixed short WAV to load the model, run minimal transcription, and fully consume the result; the WAV is then removed and no Bilibili request is made. System FFmpeg is not required (PyAV bundles the relevant libraries).
+- The project does not install or modify NVIDIA drivers, CUDA, cuBLAS, cuDNN, the system `PATH`, `LD_LIBRARY_PATH`, or global Python. After a GPU failure, keep the verified CPU profile or repair the environment and rerun `setup`; every rerun checks readiness again.
+- A failed new install leaves no ready state; an existing ready configuration remains unchanged on failure.
+- The `doctor --json` `asr.status`, `asr.model`, `device`, `compute_type`, `device_readiness`, and `failure_category` fields are informational only; they do not affect credential exit codes.
 - MCP calls never download or switch models; they use only the current model reported ready by `doctor --json`.
 - `get_video_transcript` runs ASR only with explicit `fallback_to_asr: true` after subtitles are definitively unavailable. Native subtitles and Cookie/API/network failures never trigger it.
 - ASR processes one resolved Part, capped at two hours and 128 MiB of temporary audio, with one active job and no queue.

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -69,13 +69,13 @@ bilibili-mcp --help
    完成凭证配置后，setup 会询问是否安装可选的本地 ASR 模型。
    这是纯本地操作——不要替我选择，也不要代收模型文件；让我自己按提示
    输入 y 继续，或直接回车跳过 [y/N]。选择安装后会显示三个模型选项，
-   自行选择或按 Enter 选择推荐的 small。
+   自行选择或按 Enter 选择推荐的 small；随后选择 auto、cpu 或 cuda（默认 auto）。
    安装完成后，可在明确需要无字幕回退时调用 get_video_transcript 并设置
    fallback_to_asr=true；默认调用不会运行 ASR，也不会在 MCP 内下载或切换模型。
    自动化/无终端场景：bilibili-mcp setup --non-interactive 使用已有的环境变量或
    全局配置文件凭据，绝不从 stdin/argv 读取凭据值、绝不提示；无 --asr-model 时仅确认凭据可加载
-   即成功退出（exit 0），加 --asr-model <tiny|base|small> 可安装指定模型
-   （必须与 --non-interactive 同用）。
+   即成功退出（exit 0），加 --asr-model <tiny|base|small> 可安装指定模型，
+   --asr-device <auto|cpu|cuda> 可选择设备偏好（默认 auto；两者必须与 --non-interactive 同用）。
 
 6. 配置完成后，重启或重连这个 MCP server，使其重新加载凭证。
 
@@ -1349,15 +1349,18 @@ bilibili-mcp check
 - 选择 Yes 后，会显示三个可选模型：
   - `1. tiny`（约 78.2 MB）— 速度优先：适合快速提取和长视频初筛，准确率相对较低
   - `2. base`（约 148 MB）— 均衡：兼顾速度、质量和资源占用
-  - `3. small`（约 486 MB）— 质量优先：CPU 耗时和内存占用更高；[推荐]，Enter 默认选择
+  - `3. small`（约 486 MB）— 质量优先：耗时和内存占用更高；[推荐]，Enter 默认选择
 - 输入数字 `1/2/3` 或名称 `tiny/base/small` 选择；无效输入会重新提示，不会启动安装。
-- runtime 固定为 `faster-whisper==1.2.1`，加上运行时库的总磁盘开销。
+- 随后选择 `auto/cpu/cuda`，Enter 默认 `auto`。`auto` 优先完整验证 GPU，失败时说明脱敏原因并验证 CPU 回退；`cpu` 跳过 GPU；显式 `cuda` 失败不回退。
+- 非交互形式为 `setup --non-interactive --asr-model <tiny|base|small> --asr-device <auto|cpu|cuda>`；省略 `--asr-device` 时同样默认 `auto`。
+- runtime 固定为 `faster-whisper==1.2.1` 与 `ctranslate2==4.8.0`，加上运行时库的总磁盘开销。
 - 需要本机装有 Python 3.9+。可通过设置 `BILIBILI_ASR_PYTHON` 环境变量指定 Python 可执行文件。
 - 安装内容存放在用户管理的 `~/.bilibili-mcp/asr/` 中；不修改系统 Python。
-- 同一目录只保留一个活跃模型，切换模型时清空旧的就绪状态。
-- 安装完成后通过 CPU INT8 加载模型进行验证；不需要系统 FFmpeg（PyAV 已捆绑 FFmpeg 库）。
-- 安装失败不会留下就绪标记；已下载的部分文件保留，重新运行 `setup` 可从断点续传。
-- `doctor --json` 的 `asr.status` 和 `asr.model` 字段为纯信息字段，不影响凭证退出状态。
+- 同一目录只保留一个活跃模型；切换模型或显式 CUDA 验证失败时，原来已验证的模型与 Profile 不会被替换。
+- readiness 使用所选本地模型和程序生成的固定短 WAV，真实加载模型、执行最小转写并完整消费结果；临时 WAV 随后清理，不访问 Bilibili。系统 FFmpeg 不需要另装（PyAV 已捆绑相关库）。
+- 项目不会安装或修改 NVIDIA 驱动、CUDA、cuBLAS、cuDNN、系统 `PATH`、`LD_LIBRARY_PATH` 或全局 Python。GPU 失败时可继续使用已验证 CPU，或自行修复环境后重新运行 `setup`；每次重跑都会重新验证。
+- 新安装失败不会留下 ready 状态；已有 ready 配置在失败时保持不变。
+- `doctor --json` 的 `asr.status`、`asr.model`、`device`、`compute_type`、`device_readiness` 与 `failure_category` 字段为纯信息字段，不影响凭证退出状态。
 - MCP 调用不会下载或切换模型；仅使用 `doctor --json` 显示 ready 的当前模型。
 - `get_video_transcript` 只有显式设置 `fallback_to_asr: true` 且确认无可用字幕时才运行 ASR；原生字幕、Cookie/API/网络错误都不会触发。
 - ASR 只处理一个已解析 Part，单 Part 最长 2 小时、临时音频最多 128 MiB，同时只允许一个转录任务且不排队。

--- a/docs/qa/2026-08-24-asr-cuda-readiness.md
+++ b/docs/qa/2026-08-24-asr-cuda-readiness.md
@@ -1,0 +1,80 @@
+# Issue #66 CUDA Readiness QA
+
+Date: 2026-08-24
+Worktree: `C:\Users\ZX\.codex\worktrees\issue-66\bilibili-mcp`
+Branch: `codex/issue-66-cuda-readiness`
+Base: `6199142cb35a5d3b12f70ee1c41a65e60d3ca696`
+
+## Accepted Code Contract
+
+- Interactive and non-interactive setup accept only `auto`, `cpu`, or `cuda`;
+  Enter defaults to `auto`.
+- `cpu` probes only `cpu/int8`. `auto` saves `cuda/float16` only after a real
+  model inference; otherwise it explains a sanitized GPU category and saves
+  CPU only after the CPU probe succeeds.
+- Explicit `cuda` never silently falls back. A failed probe preserves the
+  previous verified state, model, and managed runtime.
+- Every setup rerun builds the exact `faster-whisper==1.2.1` and
+  `ctranslate2==4.8.0` pair in staging, probes the selected local model with a
+  generated WAV, consumes the generator, then publishes artifacts and their
+  matching ready state. Captured activation errors roll back; incomplete
+  rollback leaves state inactive so the runner fails closed. An explicit
+  Python override remains authoritative.
+- Public diagnostics expose only `no_nvidia_gpu`, `cuda_runtime_missing`,
+  `runtime_version_mismatch`, or `model_probe_failed`; no raw stderr, command,
+  environment, or local library path is returned.
+- The project does not install or modify NVIDIA drivers, CUDA, cuBLAS, cuDNN,
+  `PATH`, `LD_LIBRARY_PATH`, or global Python. Transcript and MCP success shapes,
+  concurrency, resource limits, temporary-media cleanup, and pinned HTTPS are
+  unchanged.
+
+## Evidence
+
+- TDD: the final Python-override repair failed 2/2 before implementation and
+  passed 181/181 afterward; earlier device, transaction, and diagnostics
+  regressions followed the same red-to-green route.
+- Focused Vitest: 3 files / 321 tests passed.
+- Complete Vitest: 44 files / 1,145 tests passed.
+- TypeScript build: passed.
+- Package dry run: 193 files; tests, Harness, research, QA, agent memory,
+  credential files, and local runtime data excluded; entries still target
+  `dist`.
+- Production dependency audit: zero vulnerabilities.
+- `git diff --check`: passed with Windows line-ending warnings only.
+- Gitleaks 8.30.1: zero findings in the tracked diff, all three untracked
+  evidence files, and rebuilt `dist`.
+- Isolated Windows CPU smoke: exact pins installed, setup published `cpu/int8`,
+  and the actual managed runner completed a generated-WAV transcript.
+- Isolated explicit-CUDA failure without external libraries returned
+  `cuda_runtime_missing`, preserved the prior state and runtime marker,
+  performed no CPU fallback, and left no staging residue.
+- Fresh Windows GPU acceptance on an RTX 5060 Laptop GPU / driver 592.19: with
+  CUDA 12 libraries supplied from a disposable external environment through
+  process-local `PATH`, exact
+  `faster-whisper==1.2.1` + `ctranslate2==4.8.0` setup published
+  `cuda/float16`; the actual managed runner produced one non-empty 46-character
+  segment from a locally synthesized speech WAV.
+- GPU acceptance left zero staging/backup/probe-WAV residue and did not modify
+  the user's existing v1 ASR state, global Python, persistent `PATH`, or
+  `CUDA_PATH`.
+- Standards and Spec review: no remaining code or scope finding after repairs;
+  final independent hardware-evidence review accepted the Windows GPU gate.
+- Final risk repairs deterministically cover state-publication plus rollback
+  failure, probe-WAV cleanup failure under `auto`, and first-backup-rename
+  failure without deleting the prior runtime.
+
+## Residual Boundaries
+
+- The Issue #66 fresh Windows GPU gate is satisfied. No real Linux GPU machine
+  was exercised, so Linux GPU execution remains documented but not
+  machine-verified.
+- Users must still install or expose compatible NVIDIA libraries themselves;
+  the project does not persist the temporary acceptance environment or mutate
+  host loader configuration.
+- Concurrent setup processes are outside the supported #66 path. The code does
+  not claim a cross-process atomic transaction; it guarantees staged readiness,
+  captured-error rollback, and fail-closed state when rollback is incomplete.
+- The Codex Security CLI cloud scan did not complete because its stored login
+  could not be refreshed. Gitleaks and the bounded reviewer checks remain the
+  completed security evidence; this is not represented as a Codex Security
+  pass.

--- a/docs/research/2026-08-24-asr-cuda-readiness.md
+++ b/docs/research/2026-08-24-asr-cuda-readiness.md
@@ -1,0 +1,142 @@
+# Research Topic
+
+- Topic: CUDA readiness and the pinned CTranslate2 runtime for Issue #66
+- Date: 2026-08-24
+- Owner: Codex
+- Related task: GitHub Issue #66 under #55
+- Refresh before: changing either Python runtime pin or claiming a new GPU-supported release
+
+## Question
+
+Which exact CTranslate2 version should accompany `faster-whisper==1.2.1`,
+what does a real readiness check need to execute, and what CUDA support can the
+project truthfully claim today?
+
+## Context
+
+Why this matters for `@xzxzzx/bilibili-mcp`:
+
+- `faster-whisper==1.2.1` allows a moving CTranslate2 range, so two installs of
+  the same package version can otherwise receive different GPU runtimes.
+- Detecting an NVIDIA device or constructing a model object does not prove that
+  the selected model can complete CUDA inference.
+
+What decision or implementation this may affect:
+
+- The exact managed Python dependency pins, the `auto | cpu | cuda` setup
+  contract, sanitized failure categories, and release claims.
+
+## Sources
+
+| Source | Type | Date checked | Notes |
+|--------|------|--------------|-------|
+| [faster-whisper v1.2.1 requirements](https://raw.githubusercontent.com/SYSTRAN/faster-whisper/v1.2.1/requirements.txt) | official source | 2026-08-24 | Allows `ctranslate2>=4.0,<5`; it does not provide an exact pin. |
+| [faster-whisper GPU requirements and usage](https://github.com/SYSTRAN/faster-whisper#gpu) | official source | 2026-08-24 | Documents CUDA/FP16 and CPU/INT8 profiles, required NVIDIA libraries, and that transcription starts only when the segment generator is consumed. |
+| [CTranslate2 installation](https://opennmt.net/CTranslate2/installation.html) | official docs | 2026-08-24 | Windows/Linux wheels support GPU execution; system CUDA libraries remain an external prerequisite. |
+| [CTranslate2 hardware support](https://opennmt.net/CTranslate2/hardware_support.html) | official docs | 2026-08-24 | Prebuilt GPU support is NVIDIA-only and remains driver/CUDA dependent. |
+| [CTranslate2 v4.8.0](https://github.com/OpenNMT/CTranslate2/releases/tag/v4.8.0) and [PyPI 4.8.0](https://pypi.org/project/ctranslate2/4.8.0/) | official release and registry | 2026-08-24 | Confirms the immutable release and published Windows wheel. |
+| [NVIDIA cuDNN Windows installation](https://docs.nvidia.com/deeplearning/cudnn/installation/latest/windows.html) | official docs | 2026-08-24 | Documents Windows CUDA 12 cuDNN 9 wheels and the requirement to expose runtime DLL directories to the host process. |
+| Sanitized project GPU smoke | local acceptance evidence | 2026-07-27 | CTranslate2 4.8.0 loaded the selected model on a Windows RTX 5060 with `cuda/float16`, transcribed a 15-second WAV, fully consumed the generator, and produced non-empty segments; a later six-video run also completed. |
+| Isolated Issue #66 smoke | local acceptance evidence | 2026-08-24 | Exact runtime pins were exercised without modifying the user's managed ASR directory. |
+
+## Findings
+
+- The upstream `faster-whisper==1.2.1` dependency range is insufficient for a
+  reproducible GPU setup because it can float across CTranslate2 releases.
+- CTranslate2 4.8.0 is the only exact version for which this project has a
+  recorded real Windows CUDA model-load and inference result. That evidence
+  includes generator consumption, not only object construction or device
+  enumeration.
+- The 2026-07-27 command directly recorded CTranslate2 4.8.0, but did not print
+  the faster-whisper version in the same command. It therefore supports the
+  CTranslate2 pin but is not sufficient by itself to claim that the complete
+  current pair has passed a fresh release smoke.
+- The 2026-08-24 isolated environment installed exactly
+  `faster-whisper==1.2.1` and `ctranslate2==4.8.0`. On an RTX 5060 Laptop GPU
+  with driver 592.19, the real CUDA probe returned the sanitized
+  `cuda_runtime_missing` category. The subsequent CPU/INT8 probe and actual
+  transcript runner completed successfully.
+- An explicit CPU setup performed no GPU stage. An explicit CUDA retry failed
+  with the same sanitized category and left the previous state byte-for-byte
+  unchanged.
+- A post-review isolated staging smoke rebuilt the exact pinned runtime from a
+  legacy state, published `cpu/int8`, and completed an actual runner transcript
+  from the newly activated managed venv. A subsequent explicit CUDA attempt
+  preserved both the prior state and a runtime marker, left zero staging
+  directories, and returned only `cuda_runtime_missing`.
+- A final Windows GPU acceptance run supplied external CUDA 12 libraries only
+  through an isolated disposable Python environment and the current process
+  `PATH`: `nvidia-cublas-cu12==12.9.2.10`,
+  `nvidia-cudnn-cu12==9.24.0.43`, and
+  `nvidia-cuda-runtime-cu12==12.9.79`. With those prerequisites visible, a new
+  exact `faster-whisper==1.2.1` + `ctranslate2==4.8.0` staged setup published
+  `cuda/float16`. The actual managed runner transcribed a locally synthesized
+  speech WAV into one non-empty segment (46 characters, detected English).
+- The final GPU run left no staging, backup, or generated-probe WAV residue.
+  The existing user ASR state remained v1 with its prior CTranslate2 4.8.1
+  environment, and neither persistent `PATH` nor `CUDA_PATH` was changed.
+- Upstream pages are not fully consistent about the cuDNN generation for all
+  CTranslate2 versions. The project should not encode an automatic CUDA library
+  installer or a filesystem-specific recipe; the real inference probe remains
+  the readiness authority.
+
+## Applicability To This Project
+
+Applies:
+
+- Install both exact pins in the managed venv on every setup rerun.
+- Treat `cuda/float16` as ready only after the selected local model completes a
+  generated-WAV transcription and the segment generator is exhausted.
+- Preserve ambient `CUDA_PATH` and `LD_LIBRARY_PATH` for the child without
+  setting or modifying either variable; continue dropping `LD_PRELOAD`,
+  credentials, proxies, and unrelated environment values.
+- Return only the fixed categories `no_nvidia_gpu`, `cuda_runtime_missing`,
+  `runtime_version_mismatch`, and `model_probe_failed`.
+
+Does not apply:
+
+- The historical smoke does not authorize a current GPU-ready release claim.
+- The project does not install NVIDIA drivers, CUDA, cuBLAS, cuDNN, mutate
+  system loader paths, or manage global Python.
+
+## Decision Impact
+
+Recommended project action:
+
+- Pin `ctranslate2==4.8.0` beside `faster-whisper==1.2.1`.
+- Keep `auto` as the default, but save CUDA only after full inference; otherwise
+  explain the sanitized reason and save CPU only after its own inference passes.
+- Treat the fresh Windows exact-pair GPU setup and non-empty runner transcript
+  as satisfying the Issue #66 Windows GPU gate. Keep Linux GPU explicitly
+  unverified.
+
+Rules or files that may need updates:
+
+- `src/asr/state.ts`, `src/asr/installer.ts`, `src/asr/transcription.ts`,
+  `src/cli.ts`, ASR documentation, and the Issue #66 QA record.
+
+## Risks And Unknowns
+
+- The exact cuBLAS/cuDNN provenance of the 2026-07-27 successful machine was
+  not recorded.
+- GPU compatibility can change with drivers and system libraries even while
+  Python package versions stay fixed.
+- Windows is the only platform with historical real GPU evidence; no Linux GPU
+  machine has been exercised for this ticket.
+
+## Staleness Notes
+
+Refresh this research when:
+
+- either Python pin changes
+- CUDA/cuDNN upstream requirements change
+- a new Windows or Linux GPU smoke is used for a release claim
+
+## Follow-Up
+
+- [x] Expose compatible NVIDIA CUDA runtime libraries outside the project and
+  pass new setup, readiness, and an actual GPU transcript.
+- [x] Record the complete ASR pair, driver summary, sanitized result, and
+  platform without recording raw stderr or private data.
+- [ ] Obtain a separate real Linux GPU smoke before making a Linux GPU
+  verification claim.

--- a/harness/fixtures/pilot-artifacts/migration.json
+++ b/harness/fixtures/pilot-artifacts/migration.json
@@ -89,27 +89,27 @@
     }
   ],
   "durable_memory": {
-    "docs/agent-memory/active-work.md": "1dc181bd1ec4f26cb753735727c0ed7a54f039a11b0f92d44dfd7b8ad89a6c5e",
-    "docs/agent-memory/codemap.md": "83fe0f84010fbe2eaf8c355f8606a3aa0a44a470aa2ba139834e3860d0ab0606",
-    "docs/agent-memory/decisions.md": "d0926eb78c992620f311a551d7989e820dbc91bb38cc04c8a1d4c5f01a066b63",
+    "docs/agent-memory/active-work.md": "2182539d827902c05b441c471ea2cce19be3145dd8be6a51eb00103e70a80614",
+    "docs/agent-memory/codemap.md": "860f5d42d790ce042c0104e1bd547100b094c24976da72511b9017dbd828ab2f",
+    "docs/agent-memory/decisions.md": "093d5a0ee8e24f22120637aaedfbdd122d9e955cdd3001657aae5aea233382da",
     "docs/agent-memory/executions/2026-08-14-github-36-codex-direct-report.md": "439b169470c2ab1ec3af3625b8ca3e247d6ccd4f01bc39ff967deff673853570",
     "docs/agent-memory/harness-eval.md": "f531cc2d0e69ccc8d41c882c9aefdae03d5583789bc19c51dd45a4188fe9a370",
     "docs/agent-memory/harness-security.md": "b907339f85c0ba13c2a8642b475aa682ae1b313cb51cebec9977aca798df3430",
-    "docs/agent-memory/lessons-learned.md": "6a0e45bc73159237fb3200a3725d12d54dd0d83aa5c8eebcec5ffb9bd2efb7d7",
-    "docs/agent-memory/project-facts.md": "aa00251eb112f23d480d8a446fe2332e45a1db9204e7b29445ca2dd9650ff172",
-    "docs/agent-memory/verification-log.md": "b292d99ce75548dd35fef181a8fc49fd9e8c810149997ffece1d75f102e159f3"
+    "docs/agent-memory/lessons-learned.md": "43060f93ca33b6655bac4e2c84a4c8abd4f44271024e758af01aa00cc190f924",
+    "docs/agent-memory/project-facts.md": "a7d1d22e4a203307118e5f6990c5678eb34b5955d3fe1c544a10347619c2fcbe",
+    "docs/agent-memory/verification-log.md": "f1461a81ecbeb794294f30f5836125d9f88120d7ee41874e038dc46f06028fac"
   },
   "package": {
-    "output_digest": "b45d5a5bb574f7fe03bcf0e11d145d3bc4e71587142aef3929025ee319fbbb93",
+    "output_digest": "1ecd0c27076f5b43126d2ee4c65a08121e3396a2e9f038b4e896cc2be6e54378",
     "pack_output": [
       {
         "id": "@xzxzzx/bilibili-mcp@1.13.0",
         "name": "@xzxzzx/bilibili-mcp",
         "version": "1.13.0",
-        "size": 1140510,
-        "unpackedSize": 1945939,
-        "shasum": "50940bcd50233b1a6886114de2ef6f87409df179",
-        "integrity": "sha512-/cY+uX7NhxcQdfgxPin9ZFSgqCgyPfPQy9KTgOil7hQsnqmI4rmHdaA2kFElgd3d/T1k0mEcyHrVLtyyyFH4cA==",
+        "size": 1148617,
+        "unpackedSize": 1982016,
+        "shasum": "0c22aac8fefc1f634e14eb86279054b48c83e447",
+        "integrity": "sha512-UebiLKX90VV6URC4OEXUmU4o1CooBX/vBUkYxD5faerGX+LlNbXivAmzWZKgQnItGzam73IiT3KdcB66kMCjsQ==",
         "filename": "xzxzzx-bilibili-mcp-1.13.0.tgz",
         "files": [
           {
@@ -119,12 +119,12 @@
           },
           {
             "path": "README_EN.md",
-            "size": 19822,
+            "size": 20393,
             "mode": 420
           },
           {
             "path": "README.md",
-            "size": 18239,
+            "size": 18785,
             "mode": 420
           },
           {
@@ -154,42 +154,42 @@
           },
           {
             "path": "dist/asr/installer.d.ts",
-            "size": 2126,
+            "size": 2912,
             "mode": 420
           },
           {
             "path": "dist/asr/installer.d.ts.map",
-            "size": 2204,
+            "size": 2775,
             "mode": 420
           },
           {
             "path": "dist/asr/installer.js",
-            "size": 20329,
+            "size": 31500,
             "mode": 420
           },
           {
             "path": "dist/asr/installer.js.map",
-            "size": 18820,
+            "size": 26435,
             "mode": 420
           },
           {
             "path": "dist/asr/state.d.ts",
-            "size": 3269,
+            "size": 3869,
             "mode": 420
           },
           {
             "path": "dist/asr/state.d.ts.map",
-            "size": 2204,
+            "size": 2566,
             "mode": 420
           },
           {
             "path": "dist/asr/state.js",
-            "size": 11355,
+            "size": 12419,
             "mode": 420
           },
           {
             "path": "dist/asr/state.js.map",
-            "size": 9983,
+            "size": 10899,
             "mode": 420
           },
           {
@@ -204,12 +204,12 @@
           },
           {
             "path": "dist/asr/transcription.js",
-            "size": 26721,
+            "size": 26728,
             "mode": 420
           },
           {
             "path": "dist/asr/transcription.js.map",
-            "size": 21149,
+            "size": 21140,
             "mode": 420
           },
           {
@@ -554,22 +554,22 @@
           },
           {
             "path": "dist/cli.d.ts",
-            "size": 2026,
+            "size": 2474,
             "mode": 420
           },
           {
             "path": "dist/cli.d.ts.map",
-            "size": 1714,
+            "size": 1978,
             "mode": 420
           },
           {
             "path": "dist/cli.js",
-            "size": 18408,
+            "size": 23969,
             "mode": 420
           },
           {
             "path": "dist/cli.js.map",
-            "size": 15538,
+            "size": 19112,
             "mode": 420
           },
           {
@@ -1054,12 +1054,12 @@
           },
           {
             "path": "docs/client-setup.en.md",
-            "size": 44684,
+            "size": 45748,
             "mode": 420
           },
           {
             "path": "docs/client-setup.md",
-            "size": 42777,
+            "size": 43743,
             "mode": 420
           },
           {

--- a/harness/fixtures/three-adapter-pilot-evidence.json
+++ b/harness/fixtures/three-adapter-pilot-evidence.json
@@ -8,7 +8,7 @@
       "product-verification": "pass"
     },
     "file": "migration.json",
-    "sha256": "354f954060e46e2f7c3c2d6e6d9fd5cbab9f078ff05d8c806b3fa017c53adc52"
+    "sha256": "27fc071e7e4393496cb53825ecd870cda0e7735879a6f03f5e34570a947f1494"
   },
   "pilots": [
     {

--- a/src/asr/installer.ts
+++ b/src/asr/installer.ts
@@ -4,10 +4,19 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import {
+  ASR_CUDA_EXECUTION_PROFILE,
+  ASR_CPU_EXECUTION_PROFILE,
+  ASR_FAILURE_CATEGORIES,
+  ASR_PINNED_CTRANSLATE2,
   ASR_PINNED_RUNTIME,
   deriveAsrPaths,
   readAsrState,
+  resolveDevicePreference,
+  resolveExecutionProfile,
   resolveModelSpec,
+  type AsrExecutionProfile,
+  type AsrDevicePreference,
+  type AsrFailureCategory,
   type AsrModelKey,
   type AsrModelSpec,
   type AsrPaths,
@@ -16,8 +25,14 @@ import {
 
 export const PYTHON_MIN_MAJOR = 3;
 export const PYTHON_MIN_MINOR = 9;
-export const COMPUTE_TYPE = "int8";
-export const DEVICE = "cpu";
+export const COMPUTE_TYPE = ASR_CPU_EXECUTION_PROFILE.computeType;
+export const DEVICE = ASR_CPU_EXECUTION_PROFILE.device;
+const ASR_READINESS_EXIT_CODES: Record<AsrFailureCategory, number> = {
+  no_nvidia_gpu: 20,
+  cuda_runtime_missing: 21,
+  runtime_version_mismatch: 22,
+  model_probe_failed: 23,
+};
 const DIAG_MAX = 2000;
 const MAX_INSTALLER_OUTPUT_BYTES = 64 * 1024;
 const MAX_MODEL_FILES = 10_000;
@@ -27,6 +42,18 @@ const MODEL_BUDGET_OVERHEAD_BYTES = 64 * 1024 * 1024;
 export interface PythonCommand {
   executable: string;
   prefixArgs: string[];
+}
+
+export class AsrReadinessError extends Error {
+  constructor(
+    readonly category: AsrFailureCategory,
+    readonly device?: AsrExecutionProfile["device"],
+    readonly gpuFailureCategory?: AsrFailureCategory,
+    readonly allowFallback = true,
+  ) {
+    super(`ASR device readiness failed (${category})`);
+    this.name = "AsrReadinessError";
+  }
 }
 
 function toPythonArgs(cmd: PythonCommand, ...extra: string[]): string[] {
@@ -48,6 +75,8 @@ const ASR_CHILD_ENV_ALLOWLIST = new Set([
   "NO_COLOR",
   "SSL_CERT_FILE",
   "SSL_CERT_DIR",
+  "CUDA_PATH",
+  "LD_LIBRARY_PATH",
 ]);
 
 export function buildAsrChildEnv(
@@ -246,6 +275,14 @@ export async function discoverPython(
   );
 }
 
+function pythonCommandForVenv(venvPath: string): PythonCommand {
+  const binDir = path.join(venvPath, process.platform === "win32" ? "Scripts" : "bin");
+  return {
+    executable: path.join(binDir, process.platform === "win32" ? "python.exe" : "python"),
+    prefixArgs: [],
+  };
+}
+
 export async function createVenv(
   python: PythonCommand,
   venvPath: string,
@@ -259,10 +296,7 @@ export async function createVenv(
     throw new Error(`venv creation failed: ${result.stderr.slice(0, 500)}`);
   }
 
-  const binDir = path.join(venvPath, process.platform === "win32" ? "Scripts" : "bin");
-  const pythonExe = path.join(binDir, process.platform === "win32" ? "python.exe" : "python");
-
-  return { executable: pythonExe, prefixArgs: [] };
+  return pythonCommandForVenv(venvPath);
 }
 
 export async function installRuntime(
@@ -271,12 +305,18 @@ export async function installRuntime(
 ): Promise<void> {
   const result = await spawnFn(
     venvPython.executable,
-    toPythonArgs(venvPython, "-m", "pip", "install", "--quiet", ASR_PINNED_RUNTIME),
-      );
+    toPythonArgs(
+      venvPython,
+      "-m",
+      "pip",
+      "install",
+      "--quiet",
+      ASR_PINNED_RUNTIME,
+      ASR_PINNED_CTRANSLATE2,
+    ),
+  );
   if (result.code !== 0) {
-    throw new Error(
-      `pip install faster-whisper failed: ${result.stderr.slice(0, 500)}`,
-    );
+    throw new Error("pip install for the managed ASR runtime failed");
   }
 }
 
@@ -406,8 +446,16 @@ export async function downloadModel(
 export async function verifyModel(
   venvPython: PythonCommand,
   modelPath: string,
+  executionProfile: AsrExecutionProfile = ASR_CPU_EXECUTION_PROFILE,
   spawnFn: typeof execFile = execFile,
 ): Promise<void> {
+  const profile = resolveExecutionProfile(
+    executionProfile.device,
+    executionProfile.computeType,
+  );
+  if (profile === undefined) {
+    throw new AsrReadinessError("model_probe_failed");
+  }
   const probePath = path.join(os.tmpdir(), `.bilibili-mcp-asr-probe-${randomUUID()}.wav`);
   const sampleRate = 16_000;
   const sampleCount = sampleRate;
@@ -425,53 +473,176 @@ export async function verifyModel(
   wav.write("data", 36, "ascii");
   wav.writeUInt32LE(sampleCount * 2, 40);
   const script = [
-    "import sys",
-    "from faster_whisper import WhisperModel",
-    `model = WhisperModel(sys.argv[1], device="${DEVICE}", compute_type="${COMPUTE_TYPE}")`,
-    "segments, _ = model.transcribe(sys.argv[2], beam_size=1)",
-    "for _ in segments:",
-    "    pass",
-    "print('VERIFIED')",
+    "import ctypes, importlib.metadata, sys",
+    "def fail(category, code):",
+    "    print('FAILED:' + category, flush=True)",
+    "    raise SystemExit(code)",
+    "try:",
+    "    model_path, probe_path, pinned_ct2, device, compute_type = sys.argv[1:6]",
+    "    if importlib.metadata.version('ctranslate2') != pinned_ct2:",
+    "        fail('runtime_version_mismatch', 22)",
+    "    if device == 'cuda':",
+    "        try:",
+    "            cuda = ctypes.WinDLL('nvcuda.dll') if sys.platform == 'win32' else ctypes.CDLL('libcuda.so.1')",
+    "        except OSError:",
+    "            fail('cuda_runtime_missing', 21)",
+    "        status = int(cuda.cuInit(0))",
+    "        if status in (35, 803):",
+    "            fail('runtime_version_mismatch', 22)",
+    "        if status == 100:",
+    "            fail('no_nvidia_gpu', 20)",
+    "        if status != 0:",
+    "            fail('model_probe_failed', 23)",
+    "        count = ctypes.c_int()",
+    "        status = int(cuda.cuDeviceGetCount(ctypes.byref(count)))",
+    "        if status in (35, 803):",
+    "            fail('runtime_version_mismatch', 22)",
+    "        if status == 100 or (status == 0 and count.value == 0):",
+    "            fail('no_nvidia_gpu', 20)",
+    "        if status != 0:",
+    "            fail('model_probe_failed', 23)",
+    "    from faster_whisper import WhisperModel",
+    "    model = WhisperModel(model_path, device=device, compute_type=compute_type)",
+    "    segments, _ = model.transcribe(probe_path, beam_size=1)",
+    "    for _ in segments:",
+    "        pass",
+    "except Exception as error:",
+    "    message = str(error).lower()",
+    "    if device == 'cuda':",
+    "        if any(token in message for token in ('insufficient driver', 'driver mismatch', 'unsupported cuda version')):",
+    "            fail('runtime_version_mismatch', 22)",
+    "        if any(token in message for token in ('cublas', 'cudnn', 'nvcuda', 'libcuda', 'cuda runtime', 'cannot be loaded', 'library not found', 'dll not found')):",
+    "            fail('cuda_runtime_missing', 21)",
+    "    fail('model_probe_failed', 23)",
+    "print('VERIFIED', flush=True)",
   ].join("\n");
 
-  let result: { code: number | null; stdout: string; stderr: string };
+  let result: { code: number | null; stdout: string; stderr: string } | undefined;
   let probeCreated = false;
+  let cleanupFailed = false;
   try {
     fs.writeFileSync(probePath, wav, { flag: "wx", mode: 0o600 });
     probeCreated = true;
     result = await spawnFn(
       venvPython.executable,
-      toPythonArgs(venvPython, "-c", script, modelPath, probePath),
+      toPythonArgs(
+        venvPython,
+        "-c",
+        script,
+        modelPath,
+        probePath,
+        ASR_PINNED_CTRANSLATE2.split("==", 2)[1],
+        profile.device,
+        profile.computeType,
+      ),
     );
+  } catch {
+    // Map subprocess and local probe failures after cleanup so a cleanup
+    // failure can prevent auto fallback from publishing a ready Profile.
   } finally {
-    if (probeCreated) fs.unlinkSync(probePath);
+    if (probeCreated) {
+      try {
+        fs.unlinkSync(probePath);
+      } catch {
+        cleanupFailed = true;
+      }
+    }
   }
-  if (result.code !== 0) {
-    throw new Error(
-      `Model verification failed: ${result.stderr.slice(0, 500)}`,
+  if (cleanupFailed) {
+    throw new AsrReadinessError(
+      "model_probe_failed",
+      profile.device,
+      undefined,
+      false,
     );
+  }
+  if (result === undefined) {
+    throw new AsrReadinessError("model_probe_failed", profile.device);
   }
 
-  if (result.stdout.trim() !== "VERIFIED") {
-    throw new Error("Model verification did not confirm load");
+  if (result.code === 0 && result.stdout.trim() === "VERIFIED") {
+    return;
   }
+
+  const match = /^FAILED:([a-z_]+)$/.exec(result.stdout.trim());
+  const matchedCategory = match !== null &&
+      (ASR_FAILURE_CATEGORIES as readonly string[]).includes(match[1])
+    ? match[1] as AsrFailureCategory
+    : undefined;
+  const category = matchedCategory !== undefined &&
+      result.code === ASR_READINESS_EXIT_CODES[matchedCategory]
+    ? matchedCategory
+    : "model_probe_failed";
+  throw new AsrReadinessError(category, profile.device);
 }
 
 export interface InstallResult {
   success: boolean;
   error?: string;
   pythonPath?: string;
+  executionProfile?: AsrExecutionProfile;
+  failureCategory?: AsrFailureCategory;
+  failureDevice?: AsrExecutionProfile["device"];
+  gpuFailureCategory?: AsrFailureCategory;
   asrPaths: AsrPaths;
 }
 
-function prepareModelStaging(asrPaths: AsrPaths): string {
+async function verifyDeviceReadiness(
+  venvPython: PythonCommand,
+  modelPath: string,
+  preference: AsrDevicePreference,
+  spawnFn: typeof execFile,
+  logStage: (stage: string) => void,
+): Promise<{
+  executionProfile: AsrExecutionProfile;
+  failureCategory?: AsrFailureCategory;
+}> {
+  if (preference === "cpu") {
+    logStage("正在验证模型最小推理（CPU INT8）...");
+    await verifyModel(venvPython, modelPath, ASR_CPU_EXECUTION_PROFILE, spawnFn);
+    return { executionProfile: ASR_CPU_EXECUTION_PROFILE };
+  }
+
+  try {
+    logStage("正在验证 NVIDIA GPU 最小推理（CUDA Float16）...");
+    await verifyModel(venvPython, modelPath, ASR_CUDA_EXECUTION_PROFILE, spawnFn);
+    return { executionProfile: ASR_CUDA_EXECUTION_PROFILE };
+  } catch (error) {
+    const readinessError = error instanceof AsrReadinessError
+      ? error
+      : new AsrReadinessError("model_probe_failed", "cuda");
+    if (preference === "cuda" || !readinessError.allowFallback) {
+      throw readinessError;
+    }
+
+    logStage(`GPU 验证未通过（${readinessError.category}），正在验证 CPU INT8 回退...`);
+    try {
+      await verifyModel(venvPython, modelPath, ASR_CPU_EXECUTION_PROFILE, spawnFn);
+    } catch (cpuError) {
+      const cpuReadinessError = cpuError instanceof AsrReadinessError
+        ? cpuError
+        : new AsrReadinessError("model_probe_failed", "cpu");
+      throw new AsrReadinessError(
+        cpuReadinessError.category,
+        "cpu",
+        readinessError.category,
+      );
+    }
+    return {
+      executionProfile: ASR_CPU_EXECUTION_PROFILE,
+      failureCategory: readinessError.category,
+    };
+  }
+}
+
+function prepareModelStaging(asrPaths: AsrPaths, preserveExistingModel: boolean): string {
   const root = path.resolve(asrPaths.root);
   const model = path.resolve(asrPaths.model);
   if (path.dirname(model) !== root || path.basename(model) !== "models") {
     throw new Error("ASR model path is outside the managed root");
   }
   const staging = path.join(root, `.models-staging-${randomUUID()}`);
-  if (fs.existsSync(model)) {
+  if (fs.existsSync(model) && !preserveExistingModel) {
     const stat = fs.lstatSync(model);
     if (!stat.isDirectory() || stat.isSymbolicLink()) {
       throw new Error("Existing ASR model path is unsafe");
@@ -495,6 +666,29 @@ function cleanupModelStaging(asrPaths: AsrPaths, staging: string): void {
   fs.rmSync(target, { recursive: true, force: true });
 }
 
+function prepareRuntimeStaging(asrPaths: AsrPaths): string {
+  const root = path.resolve(asrPaths.root);
+  const venv = path.resolve(asrPaths.venv);
+  if (path.dirname(venv) !== root || path.basename(venv) !== "venv") {
+    throw new Error("ASR runtime path is outside the managed root");
+  }
+  const staging = path.join(root, `.venv-staging-${randomUUID()}`);
+  fs.mkdirSync(staging, { recursive: false, mode: 0o700 });
+  return staging;
+}
+
+function cleanupRuntimeStaging(asrPaths: AsrPaths, staging: string): void {
+  const root = path.resolve(asrPaths.root);
+  const target = path.resolve(staging);
+  if (
+    path.dirname(target) !== root ||
+    !path.basename(target).startsWith(".venv-staging-")
+  ) {
+    throw new Error("Refused unsafe ASR runtime staging cleanup");
+  }
+  fs.rmSync(target, { recursive: true, force: true });
+}
+
 export async function runAsrInstallation(
   options: {
     fsMkdirSync?: typeof fs.mkdirSync;
@@ -503,6 +697,7 @@ export async function runAsrInstallation(
     asrBase?: string;
     pythonOverride?: string;
     modelKey?: AsrModelKey;
+    devicePreference?: AsrDevicePreference;
     spawnFn?: typeof execFile;
     onStage?: (stage: string) => void;
   } = {},
@@ -513,7 +708,11 @@ export async function runAsrInstallation(
   const spawnFn = options.spawnFn ?? execFile;
   const logStage = options.onStage ?? (() => {});
   const asrPaths = deriveAsrPaths(options.asrBase);
+  let venvStaging: string | undefined;
+  let venvBackup: string | undefined;
   let modelStaging: string | undefined;
+  let modelBackup: string | undefined;
+  let stateBackup: string | undefined;
 
   // Fail before ANY mutation when an existing ASR root is a symlink or not
   // a real directory; an absent root is created owner-only later.
@@ -541,6 +740,14 @@ export async function runAsrInstallation(
 
   // Resolve model before any mutation
   const modelKey = options.modelKey ?? "small";
+  const devicePreference = resolveDevicePreference(options.devicePreference ?? "auto");
+  if (devicePreference === undefined) {
+    return {
+      success: false,
+      error: "Invalid ASR device preference. Expected auto, cpu, or cuda.",
+      asrPaths,
+    };
+  }
   let modelSpec: AsrModelSpec;
   try {
     modelSpec = resolveModelSpec(modelKey);
@@ -549,103 +756,194 @@ export async function runAsrInstallation(
     return { success: false, error: message, asrPaths };
   }
 
-  // A legacy v1 state already owns a valid managed model and runtime. Promote
-  // it in place only after the new end-to-end CPU readiness probe succeeds.
   const existingState = readAsrState(asrPaths.stateFile);
   const sameModel =
     existingState.kind === "ready" &&
     existingState.model === modelSpec.repository &&
     existingState.revision === modelSpec.revision;
-  if (sameModel && existingState.migrationStatus === "pending") {
-    const venvPython: PythonCommand = {
-      executable: path.join(
-        asrPaths.venv,
-        process.platform === "win32" ? "Scripts" : "bin",
-        process.platform === "win32" ? "python.exe" : "python",
-      ),
-      prefixArgs: [],
-    };
-    try {
-      logStage("正在验证模型最小推理（CPU INT8）...");
-      await verifyModel(venvPython, asrPaths.model, spawnFn);
-      writeAsrState(asrPaths.stateFile, modelSpec.key);
-      return { success: true, pythonPath: venvPython.executable, asrPaths };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return { success: false, error: message, asrPaths };
-    }
-  }
-
-  // Idempotency: a same-model v2 CPU profile has already passed this probe.
-  if (sameModel) {
-    return { success: true, pythonPath: "already installed", asrPaths };
-  }
+  const hasReadyInstallation = existingState.kind === "ready";
 
   // ponytail: one active model reuses the Phase 1 directory; use per-model
   // directories only if retaining several installed models becomes a real need.
 
-  // Invalidate stale state marker so a failed retry does not leave
-  // behind a valid-looking marker alongside now-present artifacts.
-  if (existingState.kind !== "not_installed") {
-    try {
-      unlinkSyncFn(asrPaths.stateFile);
-    } catch (err: unknown) {
-      const code = (err as NodeJS.ErrnoException)?.code;
-      if (code !== "ENOENT") {
-        return {
-          success: false,
-          error: `Cannot clear stale ASR state: ${(err as Error)?.message ?? String(err)}`,
-          asrPaths,
-        };
-      }
-    }
-  }
-
   try {
+    let python: PythonCommand;
+    let targetVenv: string;
     const pythonOverride = options.pythonOverride ?? process.env.BILIBILI_ASR_PYTHON;
-    logStage("正在查找 Python 3.9+...");
-    const python = await discoverPython(spawnFn, pythonOverride);
+    if (hasReadyInstallation) {
+      if (pythonOverride?.trim()) {
+        logStage("正在查找 Python 3.9+...");
+        python = await discoverPython(spawnFn, pythonOverride);
+      } else {
+        python = pythonCommandForVenv(asrPaths.venv);
+      }
+      venvStaging = prepareRuntimeStaging(asrPaths);
+      targetVenv = venvStaging;
+      logStage("正在创建隔离的 ASR 运行时...");
+    } else {
+      logStage("正在查找 Python 3.9+...");
+      python = await discoverPython(spawnFn, pythonOverride);
+      targetVenv = asrPaths.venv;
+      logStage("正在创建虚拟环境...");
+    }
 
-    logStage("正在创建虚拟环境...");
-    const venvPython = await createVenv(python, asrPaths.venv, spawnFn, mkdirSyncFn);
+    const venvPython = await createVenv(python, targetVenv, spawnFn, mkdirSyncFn);
 
-    logStage("正在安装 faster-whisper...");
+    logStage("正在安装受控 ASR 运行时...");
     await installRuntime(venvPython, spawnFn);
 
-    const modelBudget = modelInstallBudgetBytes(modelSpec);
-    assertInstallFreeSpace(asrPaths.root, modelBudget);
-    modelStaging = prepareModelStaging(asrPaths);
+    let candidateModel = asrPaths.model;
+    let modelBudget: number | undefined;
+    if (!sameModel) {
+      modelBudget = modelInstallBudgetBytes(modelSpec);
+      assertInstallFreeSpace(asrPaths.root, modelBudget);
+      modelStaging = prepareModelStaging(asrPaths, hasReadyInstallation);
 
-    logStage(`正在下载模型（约 ${modelSpec.approximateMB} MB）...`);
-    await downloadModel(
-      venvPython,
-      modelStaging,
-      modelSpec.repository,
-      modelSpec.revision,
-      spawnFn,
-      mkdirSyncFn,
-      modelBudget,
-    );
-
-    logStage("正在验证模型加载（CPU INT8）...");
-    await verifyModel(venvPython, modelStaging, spawnFn);
-    validateModelInstallTree(modelStaging, modelBudget);
-    if (fs.existsSync(asrPaths.model)) {
-      throw new Error("ASR model destination changed during setup");
+      logStage(`正在下载模型（约 ${modelSpec.approximateMB} MB）...`);
+      await downloadModel(
+        venvPython,
+        modelStaging,
+        modelSpec.repository,
+        modelSpec.revision,
+        spawnFn,
+        mkdirSyncFn,
+        modelBudget,
+      );
+      candidateModel = modelStaging;
     }
-    fs.renameSync(modelStaging, asrPaths.model);
-    modelStaging = undefined;
+
+    const readiness = await verifyDeviceReadiness(
+      venvPython,
+      candidateModel,
+      devicePreference,
+      spawnFn,
+      logStage,
+    );
+    if (modelStaging !== undefined && modelBudget !== undefined) {
+      validateModelInstallTree(modelStaging, modelBudget);
+    }
+
+    if (hasReadyInstallation) {
+      const candidateStateBackup = path.join(
+        asrPaths.root,
+        `.state-backup-${randomUUID()}.json`,
+      );
+      fs.renameSync(asrPaths.stateFile, candidateStateBackup);
+      stateBackup = candidateStateBackup;
+
+      const venvStat = fs.lstatSync(asrPaths.venv);
+      if (!venvStat.isDirectory() || venvStat.isSymbolicLink()) {
+        throw new Error("Existing ASR runtime path is unsafe");
+      }
+      const candidateVenvBackup = path.join(asrPaths.root, `.venv-backup-${randomUUID()}`);
+      fs.renameSync(asrPaths.venv, candidateVenvBackup);
+      venvBackup = candidateVenvBackup;
+      fs.renameSync(venvStaging!, asrPaths.venv);
+      venvStaging = undefined;
+    }
+
+    if (modelStaging !== undefined) {
+      if (fs.existsSync(asrPaths.model)) {
+        const modelStat = fs.lstatSync(asrPaths.model);
+        if (!modelStat.isDirectory() || modelStat.isSymbolicLink()) {
+          throw new Error("Existing ASR model path is unsafe");
+        }
+        const candidateModelBackup = path.join(
+          asrPaths.root,
+          `.models-backup-${randomUUID()}`,
+        );
+        fs.renameSync(asrPaths.model, candidateModelBackup);
+        modelBackup = candidateModelBackup;
+      }
+      fs.renameSync(modelStaging, asrPaths.model);
+      modelStaging = undefined;
+    }
 
     writeAsrState(
       asrPaths.stateFile,
       modelSpec.key,
+      readiness,
       fs.writeFileSync,
       fs.renameSync,
-      fs.unlinkSync,
+      unlinkSyncFn,
       mkdirSyncFn,
     );
-    return { success: true, pythonPath: python.executable, asrPaths };
+
+    // Publication is complete. Backup deletion is best-effort and cannot turn
+    // an already-active verified Profile into a reported failure.
+    if (modelBackup !== undefined) {
+      try { fs.rmSync(modelBackup, { recursive: true, force: true }); } catch { /* best-effort */ }
+      modelBackup = undefined;
+    }
+    if (venvBackup !== undefined) {
+      try { fs.rmSync(venvBackup, { recursive: true, force: true }); } catch { /* best-effort */ }
+      venvBackup = undefined;
+    }
+    if (stateBackup !== undefined) {
+      try { unlinkSyncFn(stateBackup); } catch { /* best-effort */ }
+      stateBackup = undefined;
+    }
+    return {
+      success: true,
+      pythonPath: hasReadyInstallation
+        ? pythonCommandForVenv(asrPaths.venv).executable
+        : python.executable,
+      executionProfile: readiness.executionProfile,
+      failureCategory: readiness.failureCategory,
+      asrPaths,
+    };
   } catch (error) {
+    let rollbackFailed = false;
+    if (modelBackup !== undefined) {
+      try {
+        if (fs.existsSync(asrPaths.model)) {
+          fs.rmSync(asrPaths.model, { recursive: true, force: true });
+        }
+        if (fs.existsSync(modelBackup)) {
+          fs.renameSync(modelBackup, asrPaths.model);
+        }
+        modelBackup = undefined;
+      } catch {
+        rollbackFailed = true;
+      }
+    }
+    if (venvBackup !== undefined) {
+      try {
+        if (fs.existsSync(asrPaths.venv)) {
+          fs.rmSync(asrPaths.venv, { recursive: true, force: true });
+        }
+        if (fs.existsSync(venvBackup)) {
+          fs.renameSync(venvBackup, asrPaths.venv);
+        }
+        venvBackup = undefined;
+      } catch {
+        rollbackFailed = true;
+      }
+    }
+    if (stateBackup !== undefined) {
+      if (!rollbackFailed) {
+        try {
+          if (fs.existsSync(asrPaths.stateFile)) {
+            unlinkSyncFn(asrPaths.stateFile);
+          }
+          fs.renameSync(stateBackup, asrPaths.stateFile);
+          stateBackup = undefined;
+        } catch {
+          rollbackFailed = true;
+        }
+      }
+      if (rollbackFailed) {
+        // The previous state must not describe partially restored artifacts.
+        // Leaving its backup inactive makes all future reads fail closed.
+        try {
+          if (fs.existsSync(asrPaths.stateFile)) {
+            unlinkSyncFn(asrPaths.stateFile);
+          }
+        } catch {
+          // The bounded rollback error below remains authoritative.
+        }
+      }
+    }
     if (modelStaging !== undefined) {
       try {
         cleanupModelStaging(asrPaths, modelStaging);
@@ -653,7 +951,24 @@ export async function runAsrInstallation(
         // Keep the original bounded setup error.
       }
     }
+    if (venvStaging !== undefined) {
+      try {
+        cleanupRuntimeStaging(asrPaths, venvStaging);
+      } catch {
+        // Keep the original bounded setup error.
+      }
+    }
     const message = error instanceof Error ? error.message : String(error);
-    return { success: false, error: message, asrPaths };
+    const readinessError = error instanceof AsrReadinessError ? error : undefined;
+    return {
+      success: false,
+      error: rollbackFailed
+        ? "ASR setup failed and the previous installation could not be restored"
+        : message,
+      failureCategory: readinessError?.category,
+      failureDevice: readinessError?.device,
+      gpuFailureCategory: readinessError?.gpuFailureCategory,
+      asrPaths,
+    };
   }
 }

--- a/src/asr/installer.ts
+++ b/src/asr/installer.ts
@@ -291,7 +291,10 @@ export async function createVenv(
 ): Promise<PythonCommand> {
   mkdirSyncFn(path.dirname(venvPath), { recursive: true, mode: 0o700 });
 
-  const result = await spawnFn(python.executable, toPythonArgs(python, "-m", "venv", venvPath));
+  const result = await spawnFn(
+    python.executable,
+    toPythonArgs(python, "-m", "venv", "--copies", venvPath),
+  );
   if (result.code !== 0) {
     throw new Error(`venv creation failed: ${result.stderr.slice(0, 500)}`);
   }

--- a/src/asr/state.ts
+++ b/src/asr/state.ts
@@ -4,6 +4,7 @@ import os from "os";
 import { randomUUID } from "crypto";
 
 export const ASR_PINNED_RUNTIME = "faster-whisper==1.2.1";
+export const ASR_PINNED_CTRANSLATE2 = "ctranslate2==4.8.0";
 export const ASR_STATE_VERSION = 2;
 const ASR_LEGACY_STATE_VERSION = 1;
 
@@ -14,6 +15,9 @@ export const ASR_EXECUTION_PROFILES = [
 
 export type AsrExecutionProfile = (typeof ASR_EXECUTION_PROFILES)[number];
 export const ASR_CPU_EXECUTION_PROFILE = ASR_EXECUTION_PROFILES[0];
+export const ASR_CUDA_EXECUTION_PROFILE = ASR_EXECUTION_PROFILES[1];
+export const ASR_DEVICE_PREFERENCES = ["auto", "cpu", "cuda"] as const;
+export type AsrDevicePreference = (typeof ASR_DEVICE_PREFERENCES)[number];
 export type AsrDeviceReadiness = "not_ready" | "migration_pending" | "ready";
 export type AsrMigrationStatus = "pending" | "completed";
 
@@ -96,6 +100,11 @@ export interface AsrState {
   failureCategory?: AsrFailureCategory;
 }
 
+export interface AsrStateWriteOptions {
+  executionProfile?: AsrExecutionProfile;
+  failureCategory?: AsrFailureCategory;
+}
+
 export function modelKeyForRepo(repository: string, revision: string): AsrModelKey | null {
   const spec = ASR_MODEL_SPECS.find(
     (s) => s.repository === repository && s.revision === revision,
@@ -165,6 +174,13 @@ export function resolveExecutionProfile(
   return ASR_EXECUTION_PROFILES.find(
     (profile) => profile.device === device && profile.computeType === computeType,
   );
+}
+
+export function resolveDevicePreference(value: unknown): AsrDevicePreference | undefined {
+  return typeof value === "string" &&
+    (ASR_DEVICE_PREFERENCES as readonly string[]).includes(value)
+    ? value as AsrDevicePreference
+    : undefined;
 }
 
 function isFailureCategory(value: unknown): value is AsrFailureCategory {
@@ -265,11 +281,10 @@ export function readAsrState(
     executionProfile = resolveExecutionProfile(parsed.device, parsed.compute_type);
     if (
       executionProfile === undefined ||
-      executionProfile.device !== "cpu" ||
       parsed.device_readiness !== "ready" ||
       parsed.migration_status !== "completed" ||
       (Object.prototype.hasOwnProperty.call(parsed, "failure_category") &&
-        !isFailureCategory(parsed.failure_category))
+        (!isFailureCategory(parsed.failure_category) || executionProfile.device === "cuda"))
     ) {
       return { kind: "incomplete" };
     }
@@ -329,6 +344,7 @@ export function readAsrState(
 export function writeAsrState(
   stateFile: string,
   modelKey: AsrModelKey = "small",
+  options: AsrStateWriteOptions = {},
   writeFileSync: typeof fs.writeFileSync = fs.writeFileSync,
   renameSync: typeof fs.renameSync = fs.renameSync,
   unlinkSync: typeof fs.unlinkSync = fs.unlinkSync,
@@ -338,16 +354,33 @@ export function writeAsrState(
   chmodSync: typeof fs.chmodSync = fs.chmodSync,
 ): void {
   const spec = resolveModelSpec(modelKey);
+  const executionProfile = options.executionProfile ?? ASR_CPU_EXECUTION_PROFILE;
+  const resolvedProfile = resolveExecutionProfile(
+    executionProfile.device,
+    executionProfile.computeType,
+  );
+  if (resolvedProfile === undefined) {
+    throw new Error("Invalid ASR execution profile");
+  }
+  if (
+    options.failureCategory !== undefined &&
+    (!isFailureCategory(options.failureCategory) || resolvedProfile.device === "cuda")
+  ) {
+    throw new Error("Invalid ASR failure category for execution profile");
+  }
   const state = {
     kind: "ready",
     version: ASR_STATE_VERSION,
     runtime: ASR_PINNED_RUNTIME,
     model: spec.repository,
     revision: spec.revision,
-    device: "cpu",
-    compute_type: "int8",
+    device: resolvedProfile.device,
+    compute_type: resolvedProfile.computeType,
     device_readiness: "ready",
     migration_status: "completed",
+    ...(options.failureCategory === undefined
+      ? {}
+      : { failure_category: options.failureCategory }),
   };
 
   const dir = path.dirname(stateFile);

--- a/src/asr/transcription.ts
+++ b/src/asr/transcription.ts
@@ -183,6 +183,8 @@ export function buildAsrRuntimeEnv(
     "LANG",
     "LC_ALL",
     "NO_COLOR",
+    "CUDA_PATH",
+    "LD_LIBRARY_PATH",
   ]);
   const env: Record<string, string> = {
     HF_HUB_OFFLINE: "1",
@@ -845,10 +847,10 @@ export async function transcribeVideoPart(
           state.migrationStatus === "pending"
         ? ASR_CPU_EXECUTION_PROFILE
         : undefined;
-    if (executionProfile === undefined || executionProfile.device !== "cpu") {
+    if (executionProfile === undefined) {
       throw new AsrError(
         "ASR_NOT_READY",
-        "Local ASR has no verified CPU execution profile. Run setup, then inspect doctor --json.",
+        "Local ASR has no verified execution profile. Run setup, then inspect doctor --json.",
       );
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,9 +15,11 @@ import {
   ASR_FAILURE_CATEGORIES,
   readAsrState,
   deriveAsrPaths,
+  resolveDevicePreference,
   resolveExecutionProfile,
   type AsrStateKind,
   type AsrDeviceReadiness,
+  type AsrDevicePreference,
   type AsrExecutionProfile,
   type AsrFailureCategory,
   type AsrMigrationStatus,
@@ -26,13 +28,111 @@ import {
   type AsrModelKey,
   type AsrModelSpec,
 } from "./asr/state.js";
-import { runAsrInstallation } from "./asr/installer.js";
+import { runAsrInstallation, type InstallResult } from "./asr/installer.js";
 
 const ASR_MODEL_TIER_DESCRIPTIONS: Record<AsrModelKey, string> = {
   tiny: "速度优先：适合快速提取和长视频初筛，准确率相对较低",
   base: "均衡：兼顾速度、质量和资源占用",
-  small: "质量优先：CPU 耗时和内存占用更高",
+  small: "质量优先：耗时和内存占用更高",
 };
+
+type AsrSetupResult = Pick<
+  InstallResult,
+  | "success"
+  | "error"
+  | "executionProfile"
+  | "failureCategory"
+  | "failureDevice"
+  | "gpuFailureCategory"
+>;
+
+const ASR_GPU_FAILURE_EXPLANATIONS: Record<AsrFailureCategory, string> = {
+  no_nvidia_gpu: "当前环境没有检测到可用的 NVIDIA GPU",
+  cuda_runtime_missing: "CUDA、cuBLAS 或 cuDNN 运行组件无法由当前 ASR 进程加载",
+  runtime_version_mismatch: "NVIDIA 驱动、CUDA 组件或受控 ASR 运行时版本不兼容",
+  model_probe_failed: "GPU 模型加载或最小推理没有成功完成",
+};
+
+const ASR_GPU_FAILURE_ACTIONS: Record<AsrFailureCategory, string> = {
+  no_nvidia_gpu: "确认机器确有 NVIDIA GPU 且 nvidia-smi 可用；否则重新运行 setup 选择 cpu",
+  cuda_runtime_missing: "按官方 GPU 说明安装与受控运行时兼容的 CUDA 12、cuBLAS 和 cuDNN 9，让启动 MCP 的同一环境可以加载它们，然后重启 MCP 客户端并重跑 setup：https://github.com/SYSTRAN/faster-whisper#gpu",
+  runtime_version_mismatch: "升级 NVIDIA 驱动和兼容的 CUDA 12 组件，重启 MCP 客户端后重跑 setup；setup 会重新固定 Python 运行时版本",
+  model_probe_failed: "先重跑 setup；若仍失败，可选择 cpu 继续使用，并携带 doctor --json 的脱敏类别报告问题",
+};
+
+function explainAsrFailure(
+  category: AsrFailureCategory,
+  device: "cpu" | "cuda",
+): string {
+  if (device === "cuda") return ASR_GPU_FAILURE_EXPLANATIONS[category];
+  if (category === "runtime_version_mismatch") {
+    return "受控 ASR Python 运行时版本不匹配";
+  }
+  return "CPU 模型加载或最小推理没有成功完成";
+}
+
+function actionForAsrFailure(
+  category: AsrFailureCategory,
+  device: "cpu" | "cuda",
+): string {
+  if (device === "cuda") return ASR_GPU_FAILURE_ACTIONS[category];
+  return "重新运行 setup；若仍失败，请携带 doctor --json 的脱敏类别报告问题";
+}
+
+function reportAsrSetupResult(
+  result: AsrSetupResult,
+  requestedDevice: AsrDevicePreference,
+): boolean {
+  if (result.success) {
+    const profile = result.executionProfile === undefined
+      ? "设备就绪"
+      : result.executionProfile.device === "cuda"
+        ? "CUDA Float16"
+        : "CPU INT8";
+    console.log(`✅ ASR 模型安装成功并通过 ${profile} 验证。`);
+    if (result.failureCategory !== undefined) {
+      console.log(
+        `   GPU 未启用：${explainAsrFailure(result.failureCategory, "cuda")}（${result.failureCategory}）。`,
+      );
+      console.log("   已验证 CPU INT8，可以继续使用 ASR；也可以修复 GPU 环境后重新运行 setup。");
+      console.log(`   若要启用 GPU：${actionForAsrFailure(result.failureCategory, "cuda")}。`);
+      console.log("   bilibili-mcp 不会自动安装或修改 NVIDIA 驱动、CUDA、cuBLAS、cuDNN、PATH 或 LD_LIBRARY_PATH。");
+    }
+    console.log("   管理路径：~/.bilibili-mcp/asr/");
+    console.log("   运行 bilibili-mcp doctor --json 可查看 ASR 状态。");
+    return true;
+  }
+
+  console.error(`❌ ASR 安装失败：${redactSecrets(result.error) ?? "未知错误"}`);
+  if (result.failureCategory !== undefined) {
+    if (result.gpuFailureCategory !== undefined) {
+      console.log(
+        `   GPU 验证失败：${explainAsrFailure(result.gpuFailureCategory, "cuda")}（${result.gpuFailureCategory}）。`,
+      );
+      console.log(
+        `   CPU 回退验证也失败：${explainAsrFailure(result.failureCategory, "cpu")}（${result.failureCategory}）。`,
+      );
+      console.log(`   GPU 处理方法：${actionForAsrFailure(result.gpuFailureCategory, "cuda")}。`);
+      console.log(`   CPU 处理方法：${actionForAsrFailure(result.failureCategory, "cpu")}。`);
+    } else {
+      const failureDevice = result.failureDevice ?? (requestedDevice === "cpu" ? "cpu" : "cuda");
+      const label = failureDevice === "cuda" ? "GPU" : "CPU";
+      console.log(
+        `   ${label} 验证失败：${explainAsrFailure(result.failureCategory, failureDevice)}（${result.failureCategory}）。`,
+      );
+      console.log(`   处理方法：${actionForAsrFailure(result.failureCategory, failureDevice)}。`);
+    }
+    console.log("   bilibili-mcp 不会自动安装或修改 NVIDIA 驱动、CUDA、cuBLAS、cuDNN、PATH 或 LD_LIBRARY_PATH。");
+    if (requestedDevice === "cuda") {
+      console.log("   你选择了 cuda，因此没有回退到 CPU；已有已验证配置（如有）保持不变。");
+      console.log("   你可以修复 GPU 环境后重新运行 setup 并重新选择 cuda，或重新运行 setup 选择 cpu。");
+    }
+  } else {
+    console.log("   已保留部分下载文件，重新运行 setup 可从断点续传。");
+    console.log("   当前 MCP 服务不受影响，字幕回退为 SUBTITLE_UNAVAILABLE。");
+  }
+  return false;
+}
 
 // Version info
 import fs from "fs";
@@ -79,6 +179,12 @@ export function parseModelChoice(input: string): AsrModelKey | null {
   if (trimmed === "3" || trimmed === "small") return "small";
 
   return null; // invalid, re-prompt
+}
+
+export function parseDeviceChoice(input: string): AsrDevicePreference | null {
+  const normalized = input.trim().toLowerCase();
+  if (normalized === "") return "auto";
+  return resolveDevicePreference(normalized) ?? null;
 }
 
 // Start MCP server
@@ -333,11 +439,13 @@ export interface SetupCredentialsOptions {
   nonInteractive?: boolean;
   /** 允许列表内的 ASR 模型（仅非交互模式可用） */
   asrModel?: AsrModelKey;
+  /** 受控的 ASR 设备偏好（仅与非交互模型选择同用） */
+  asrDevice?: AsrDevicePreference;
 }
 
 export async function setupCredentials(
   configure: () => Promise<boolean | void> = configureCredentials,
-  runAsr: (modelKey: AsrModelKey) => Promise<{ success: boolean; error?: string }> = async () => ({ success: false, error: "installer not injected" }),
+  runAsr: (modelKey: AsrModelKey, devicePreference: AsrDevicePreference) => Promise<AsrSetupResult> = async () => ({ success: false, error: "installer not injected" }),
   askHiddenFn: (question: string) => Promise<string> = askHidden,
   options: SetupCredentialsOptions = {},
 ) {
@@ -347,6 +455,16 @@ export async function setupCredentials(
     console.error(
       "Run: bilibili-mcp setup --non-interactive --asr-model <tiny|base|small>",
     );
+    process.exitCode = 1;
+    return;
+  }
+  if (options.asrDevice !== undefined && !options.nonInteractive) {
+    console.error("Error: --asr-device requires --non-interactive.");
+    process.exitCode = 1;
+    return;
+  }
+  if (options.asrDevice !== undefined && options.asrModel === undefined) {
+    console.error("Error: --asr-device requires --asr-model.");
     process.exitCode = 1;
     return;
   }
@@ -373,17 +491,9 @@ export async function setupCredentials(
       console.log("No --asr-model given; setup complete without ASR installation.");
       return;
     }
-    const result = await runAsr(options.asrModel);
-    if (result.success) {
-      console.log("✅ ASR 模型安装成功并通过 CPU INT8 验证。");
-      console.log(`   管理路径：~/.bilibili-mcp/asr/`);
-      console.log(
-        "   运行 bilibili-mcp doctor --json 可查看 ASR 状态。",
-      );
-    } else {
-      console.error(`❌ ASR 安装失败：${redactSecrets(result.error) ?? "未知错误"}`);
-      console.log("   已保留部分下载文件，重新运行 setup 可从断点续传。");
-      console.log("   当前 MCP 服务不受影响，字幕回退为 SUBTITLE_UNAVAILABLE。");
+    const devicePreference = options.asrDevice ?? "auto";
+    const result = await runAsr(options.asrModel, devicePreference);
+    if (!reportAsrSetupResult(result, devicePreference)) {
       process.exitCode = 1;
     }
     return;
@@ -425,7 +535,7 @@ export async function setupCredentials(
     "ASR 语音识别（可选）：安装本地 faster-whisper 模型，",
   );
   console.log(
-    "用于后续在没有 CC/AI 字幕时提供本地语音识别。当前阶段仅安装模型，不执行转录。",
+    "用于后续在没有 CC/AI 字幕时提供本地语音识别。setup 会用程序生成的短 WAV 验证设备，不访问 Bilibili。",
   );
 
   const answer = await askHiddenFn("是否现在安装？[y/N] ");
@@ -458,19 +568,22 @@ export async function setupCredentials(
   const resolvedKey: AsrModelKey = modelKey;
   const spec = resolveModelSpec(resolvedKey);
   console.log(`已选择：${spec.key}（约 ${spec.approximateMB} MB）`);
+  console.log("");
+  console.log("请选择执行设备（Enter 默认 auto）：");
+  console.log("  auto：优先验证 NVIDIA GPU；失败时解释原因并验证 CPU 回退");
+  console.log("  cpu：仅验证 CPU INT8，不探测 GPU");
+  console.log("  cuda：必须通过 CUDA Float16 验证；失败时不回退 CPU");
+  let devicePreference: AsrDevicePreference | null = null;
+  while (devicePreference === null) {
+    devicePreference = parseDeviceChoice(await askHiddenFn("> "));
+    if (devicePreference === null) {
+      console.log("无效选择，请输入 auto、cpu 或 cuda，或直接按 Enter 选择 auto。");
+    }
+  }
   console.log("正在安装 ASR 模型，可能需要几分钟...");
-  const result = await runAsr(modelKey);
+  const result = await runAsr(modelKey, devicePreference);
 
-  if (result.success) {
-    console.log("✅ ASR 模型安装成功并通过 CPU INT8 验证。");
-    console.log(`   管理路径：~/.bilibili-mcp/asr/`);
-    console.log(
-      "   运行 bilibili-mcp doctor --json 可查看 ASR 状态。",
-    );
-  } else {
-    console.error(`❌ ASR 安装失败：${redactSecrets(result.error) ?? "未知错误"}`);
-    console.log("   已保留部分下载文件，重新运行 setup 可从断点续传。");
-    console.log("   当前 MCP 服务不受影响，字幕回退为 SUBTITLE_UNAVAILABLE。");
+  if (!reportAsrSetupResult(result, devicePreference)) {
     process.exitCode = 1;
   }
 }
@@ -511,7 +624,8 @@ export function createCli() {
     .description("配置 Bilibili 凭证和可选 ASR（交互式需要终端，--non-interactive 供自动化使用）")
     .option("--non-interactive", "非交互模式：使用已有的 env/global config 凭据，绝不提示")
     .option("--asr-model <tiny|base|small>", "非交互模式下的 ASR 模型（需与 --non-interactive 同用）")
-    .action(async (cmdOptions: { nonInteractive?: boolean; asrModel?: string }) => {
+    .option("--asr-device <auto|cpu|cuda>", "非交互模式下的 ASR 设备偏好（默认 auto，需与 --asr-model 同用）")
+    .action(async (cmdOptions: { nonInteractive?: boolean; asrModel?: string; asrDevice?: string }) => {
       const options: SetupCredentialsOptions = {
         nonInteractive: Boolean(cmdOptions.nonInteractive),
       };
@@ -530,10 +644,19 @@ export function createCli() {
         }
         options.asrModel = resolvedKey;
       }
+      if (cmdOptions.asrDevice !== undefined) {
+        const devicePreference = resolveDevicePreference(cmdOptions.asrDevice.trim().toLowerCase());
+        if (devicePreference === undefined) {
+          console.error("Error: --asr-device must be one of: auto, cpu, cuda");
+          process.exitCode = 1;
+          return;
+        }
+        options.asrDevice = devicePreference;
+      }
       await setupCredentials(
         configureCredentials,
-        async (modelKey: AsrModelKey) =>
-          runAsrInstallation({ modelKey, onStage: (s) => console.log(`  ${s}`) }),
+        async (modelKey: AsrModelKey, devicePreference: AsrDevicePreference) =>
+          runAsrInstallation({ modelKey, devicePreference, onStage: (s) => console.log(`  ${s}`) }),
         askHidden,
         options,
       );

--- a/tests/asr-installer.test.ts
+++ b/tests/asr-installer.test.ts
@@ -40,7 +40,7 @@ function materializeMockVenv(args: string[]): void {
     (arg, index) => arg === "venv" && args[index - 1] === "-m",
   );
   if (moduleIndex < 0) return;
-  const venvPath = args[moduleIndex + 1];
+  const venvPath = args[args.length - 1];
   const binDir = path.join(venvPath, process.platform === "win32" ? "Scripts" : "bin");
   fs.mkdirSync(binDir, { recursive: true });
   fs.writeFileSync(
@@ -946,14 +946,14 @@ function spawnOk(stdout = "") {
 }
 
 describe("createVenv", () => {
-  it("creates a venv and returns venv Python command", async () => {
+  it("creates a venv with a copied interpreter and returns its Python command", async () => {
     const spawnFn = spawnOk();
     const mkdirSyncFn = vi.fn();
     const python: PythonCommand = { executable: "python3", prefixArgs: [] };
     const venvPath = path.join(os.tmpdir(), "test-venv");
     const result = await createVenv(python, venvPath, spawnFn, mkdirSyncFn);
 
-    expect(spawnFn).toHaveBeenCalledWith("python3", ["-I", "-m", "venv", venvPath]);
+    expect(spawnFn).toHaveBeenCalledWith("python3", ["-I", "-m", "venv", "--copies", venvPath]);
     expect(result.executable).toContain("python");
     expect(result.prefixArgs).toEqual([]);
   });
@@ -1651,7 +1651,7 @@ describe("runAsrInstallation", () => {
     // venv
     const vv = vi.fn(() => Promise.resolve({ code: 0, stdout: "", stderr: "" }));
     await createVenv({ executable: "python3", prefixArgs: [] }, "/tmp/venv", vv, vi.fn());
-    expect(vv.mock.calls[0][1]).toEqual(["-I", "-m", "venv", "/tmp/venv"]);
+    expect(vv.mock.calls[0][1]).toEqual(["-I", "-m", "venv", "--copies", "/tmp/venv"]);
 
     // pip
     const pip = vi.fn(() => Promise.resolve({ code: 0, stdout: "", stderr: "" }));

--- a/tests/asr-installer.test.ts
+++ b/tests/asr-installer.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../src/asr/installer.js";
 import {
   ASR_MODEL_SPECS,
+  ASR_PINNED_CTRANSLATE2,
   ASR_PINNED_MODEL,
   ASR_PINNED_REVISION,
   ASR_PINNED_RUNTIME,
@@ -30,6 +31,23 @@ import {
   type AsrModelKey,
   type AsrState,
 } from "../src/asr/state.js";
+
+const CPU_PROFILE = { device: "cpu", computeType: "int8" } as const;
+const CUDA_PROFILE = { device: "cuda", computeType: "float16" } as const;
+
+function materializeMockVenv(args: string[]): void {
+  const moduleIndex = args.findIndex(
+    (arg, index) => arg === "venv" && args[index - 1] === "-m",
+  );
+  if (moduleIndex < 0) return;
+  const venvPath = args[moduleIndex + 1];
+  const binDir = path.join(venvPath, process.platform === "win32" ? "Scripts" : "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(binDir, process.platform === "win32" ? "python.exe" : "python"),
+    "fake",
+  );
+}
 
 // ---------- state.ts ----------
 
@@ -243,7 +261,7 @@ describe("writeAsrState", () => {
     const unlink = vi.fn();
     const mkdir = vi.fn();
 
-    expect(() => writeAsrState("/tmp/asr/state.json", "small", write, rename, unlink, mkdir)).toThrow("atomically");
+    expect(() => writeAsrState("/tmp/asr/state.json", "small", {}, write, rename, unlink, mkdir)).toThrow("atomically");
     expect(unlink).toHaveBeenCalledWith(expect.stringMatching(/\.state-[0-9a-f-]{36}\.tmp$/));
   });
 
@@ -253,7 +271,7 @@ describe("writeAsrState", () => {
     const unlink = vi.fn();
     const mkdir = vi.fn();
 
-    expect(() => writeAsrState("/tmp/asr/state.json", "small", write, rename, unlink, mkdir)).toThrow("write ASR state file");
+    expect(() => writeAsrState("/tmp/asr/state.json", "small", {}, write, rename, unlink, mkdir)).toThrow("write ASR state file");
     expect(rename).not.toHaveBeenCalled();
     expect(unlink).toHaveBeenCalledWith(expect.stringMatching(/\.state-[0-9a-f-]{36}\.tmp$/));
   });
@@ -272,6 +290,7 @@ describe("writeAsrState", () => {
     expect(() => writeAsrState(
       stateFile,
       "small",
+      {},
       fs.writeFileSync,
       (() => { throw new Error("interrupted"); }) as typeof fs.renameSync,
       fs.unlinkSync,
@@ -496,7 +515,7 @@ describe("writeAsrState secure temp file", () => {
     const unlink = vi.fn();
     const mkdir = vi.fn();
 
-    writeAsrState("/tmp/asr/state.json", "small", write, rename, unlink, mkdir);
+    writeAsrState("/tmp/asr/state.json", "small", {}, write, rename, unlink, mkdir);
 
     expect(mkdir).toHaveBeenCalledWith(path.dirname("/tmp/asr/state.json"), {
       recursive: true,
@@ -524,7 +543,7 @@ describe("writeAsrState secure temp file", () => {
     const mkdir = vi.fn();
     const randomId = vi.fn(() => "abc-123");
 
-    writeAsrState("/tmp/asr/state.json", "small", write, rename, unlink, mkdir, randomId);
+    writeAsrState("/tmp/asr/state.json", "small", {}, write, rename, unlink, mkdir, randomId);
 
     expect(written[0].path).toBe(path.join("/tmp/asr", ".state-abc-123.tmp"));
     expect(rename).toHaveBeenCalledWith(
@@ -543,8 +562,8 @@ describe("writeAsrState secure temp file", () => {
       .mockReturnValueOnce("first")
       .mockReturnValueOnce("second");
 
-    writeAsrState("/tmp/asr/state.json", "small", write, rename, unlink, mkdir, randomId);
-    writeAsrState("/tmp/asr/state.json", "small", write, rename, unlink, mkdir, randomId);
+    writeAsrState("/tmp/asr/state.json", "small", {}, write, rename, unlink, mkdir, randomId);
+    writeAsrState("/tmp/asr/state.json", "small", {}, write, rename, unlink, mkdir, randomId);
 
     const tmpPaths = write.mock.calls.map(([p]) => p);
     expect(tmpPaths).toEqual([
@@ -579,6 +598,7 @@ describe("writeAsrState secure temp file", () => {
       writeAsrState(
         "/tmp/asr/state.json",
         "small",
+        {},
         write,
         rename,
         unlink,
@@ -611,6 +631,7 @@ describe("writeAsrState secure temp file", () => {
       writeAsrState(
         "/tmp/asr/state.json",
         "small",
+        {},
         write,
         rename,
         unlink,
@@ -642,6 +663,7 @@ describe("writeAsrState secure temp file", () => {
     writeAsrState(
       "/tmp/asr/state.json",
       "small",
+      {},
       write,
       rename,
       unlink,
@@ -669,6 +691,7 @@ describe("writeAsrState secure temp file", () => {
     writeAsrState(
       "/tmp/asr/state.json",
       "small",
+      {},
       write,
       rename,
       unlink,
@@ -707,6 +730,7 @@ describe("writeAsrState secure temp file", () => {
         writeAsrState(
           "/tmp/asr/state.json",
           "small",
+          {},
           write,
           rename,
           unlink,
@@ -744,6 +768,7 @@ describe("writeAsrState secure temp file", () => {
       writeAsrState(
         "/tmp/asr/state.json",
         "small",
+        {},
         write,
         rename,
         unlink,
@@ -948,13 +973,33 @@ describe("installRuntime", () => {
 
     expect(spawnFn).toHaveBeenCalledWith(
       "/tmp/venv/bin/python",
-      ["-I", "-m", "pip", "install", "--quiet", ASR_PINNED_RUNTIME],
+      [
+        "-I",
+        "-m",
+        "pip",
+        "install",
+        "--quiet",
+        ASR_PINNED_RUNTIME,
+        "ctranslate2==4.8.0",
+      ],
     );
   });
 
   it("throws on pip failure", async () => {
-    const spawnFn = vi.fn(() => Promise.resolve({ code: 1, stdout: "", stderr: "pip error" }));
-    await expect(installRuntime({ executable: "python3", prefixArgs: [] }, spawnFn)).rejects.toThrow("pip install");
+    const spawnFn = vi.fn(() => Promise.resolve({
+      code: 1,
+      stdout: "",
+      stderr: "pip error at C:\\private\\venv TOKEN=secret",
+    }));
+    let caught: unknown;
+    try {
+      await installRuntime({ executable: "python3", prefixArgs: [] }, spawnFn);
+    } catch (error) {
+      caught = error;
+    }
+    expect(String(caught)).toContain("pip install");
+    expect(String(caught)).not.toContain("private");
+    expect(String(caught)).not.toContain("TOKEN");
   });
 });
 
@@ -994,6 +1039,80 @@ describe("downloadModel", () => {
 });
 
 describe("verifyModel", () => {
+  it("passes the allowlisted CUDA profile through argv and consumes the generator", async () => {
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      expect(args[2]).toContain("for _ in segments");
+      expect(args.slice(-2)).toEqual(["cuda", "float16"]);
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+
+    await verifyModel(
+      { executable: "python3", prefixArgs: [] },
+      "/tmp/models",
+      CUDA_PROFILE,
+      spawnFn,
+    );
+  });
+
+  it("does not apply CUDA loader diagnostics to CPU probe failures", async () => {
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      const exceptionBlock = args[2].slice(args[2].indexOf("except Exception as error:"));
+      expect(exceptionBlock).toContain("    if device == 'cuda':");
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+
+    await verifyModel(
+      { executable: "python3", prefixArgs: [] },
+      "/tmp/models",
+      CPU_PROFILE,
+      spawnFn,
+    );
+  });
+
+  it.each([
+    ["no_nvidia_gpu", 20],
+    ["cuda_runtime_missing", 21],
+    ["runtime_version_mismatch", 22],
+    ["model_probe_failed", 23],
+  ] as const)("returns only the sanitized %s readiness category", async (category, code) => {
+    const spawnFn = vi.fn(() => Promise.resolve({
+      code,
+      stdout: `FAILED:${category}\n`,
+      stderr: "raw stderr at C:\\private\\cuda.dll TOKEN=secret",
+    }));
+
+    let caught: unknown;
+    try {
+      await verifyModel(
+        { executable: "python3", prefixArgs: [] },
+        "/tmp/models",
+        CUDA_PROFILE,
+        spawnFn,
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toMatchObject({ category });
+    expect(String(caught)).not.toContain("private");
+    expect(String(caught)).not.toContain("TOKEN");
+  });
+
+  it("rejects a readiness category paired with the wrong exit code", async () => {
+    const spawnFn = vi.fn(() => Promise.resolve({
+      code: 23,
+      stdout: "FAILED:cuda_runtime_missing\n",
+      stderr: "raw C:\\private\\cuda.dll TOKEN=secret",
+    }));
+
+    await expect(verifyModel(
+      { executable: "python3", prefixArgs: [] },
+      "/tmp/models",
+      CUDA_PROFILE,
+      spawnFn,
+    )).rejects.toMatchObject({ category: "model_probe_failed" });
+  });
+
   it("runs a minimal inference against a generated WAV and cleans it", async () => {
     let probePath = "";
     const spawnFn = vi.fn((_file: string, args: string[]) => {
@@ -1005,7 +1124,7 @@ describe("verifyModel", () => {
       return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
     });
 
-    await verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", spawnFn);
+    await verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", CPU_PROFILE, spawnFn);
 
     expect(probePath).not.toBe("");
     expect(fs.existsSync(probePath)).toBe(false);
@@ -1020,8 +1139,8 @@ describe("verifyModel", () => {
     });
 
     await expect(
-      verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", spawnFn),
-    ).rejects.toThrow("Model verification failed");
+      verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", CPU_PROFILE, spawnFn),
+    ).rejects.toMatchObject({ category: "model_probe_failed" });
     expect(fs.existsSync(probePath)).toBe(false);
   });
 
@@ -1039,8 +1158,8 @@ describe("verifyModel", () => {
 
     try {
       await expect(
-        verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", spawnFn),
-      ).rejects.toThrow("cleanup denied");
+        verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", CPU_PROFILE, spawnFn),
+      ).rejects.toMatchObject({ category: "model_probe_failed" });
     } finally {
       unlinkSpy.mockRestore();
       if (probePath) realUnlinkSync(probePath);
@@ -1049,7 +1168,7 @@ describe("verifyModel", () => {
 
   it("passes model path via argv", async () => {
     const spawnFn = vi.fn(() => Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" }));
-    await verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", spawnFn);
+    await verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", CPU_PROFILE, spawnFn);
 
     const args = spawnFn.mock.calls[0][1];
     expect(args).toContain("/tmp/models");
@@ -1057,12 +1176,12 @@ describe("verifyModel", () => {
 
   it("throws when stdout is not exactly VERIFIED", async () => {
     const spawnFn = vi.fn(() => Promise.resolve({ code: 0, stdout: "VERIFIED and more\n", stderr: "" }));
-    await expect(verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", spawnFn)).rejects.toThrow("did not confirm load");
+    await expect(verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", CPU_PROFILE, spawnFn)).rejects.toMatchObject({ category: "model_probe_failed" });
   });
 
   it("throws on non-zero exit", async () => {
     const spawnFn = vi.fn(() => Promise.resolve({ code: 1, stdout: "", stderr: "import error" }));
-    await expect(verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", spawnFn)).rejects.toThrow("Model verification failed");
+    await expect(verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", CPU_PROFILE, spawnFn)).rejects.toMatchObject({ category: "model_probe_failed" });
   });
 });
 
@@ -1261,7 +1380,7 @@ describe("runAsrInstallation", () => {
     try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ok */ }
   });
 
-  it("is idempotent when already ready", async () => {
+  it("re-pins the runtime and reruns explicit CPU readiness when already ready", async () => {
     const tmpBase = path.join(os.tmpdir(), "bilibili-mcp-asr-idem-" + Date.now());
     fs.mkdirSync(tmpBase, { recursive: true });
     const stateFile = path.join(tmpBase, "state.json");
@@ -1275,11 +1394,24 @@ describe("runAsrInstallation", () => {
     }
     writeAsrState(stateFile);
 
-    const spawnFn = vi.fn();
-    const result = await runAsrInstallation({ spawnFn, asrBase: tmpBase });
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      return Promise.resolve({
+        code: 0,
+        stdout: args.includes("pip") || args.includes("venv") ? "" : "VERIFIED\n",
+        stderr: "",
+      });
+    });
+    const result = await runAsrInstallation({
+      spawnFn,
+      asrBase: tmpBase,
+      devicePreference: "cpu",
+    });
 
     expect(result.success).toBe(true);
-    expect(spawnFn).not.toHaveBeenCalled();
+    expect(spawnFn).toHaveBeenCalledTimes(3);
+    expect(spawnFn.mock.calls[1][1]).toContain(ASR_PINNED_CTRANSLATE2);
+    expect(spawnFn.mock.calls[2][1].slice(-2)).toEqual(["cpu", "int8"]);
 
     // cleanup
     try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ok */ }
@@ -1356,6 +1488,10 @@ describe("runAsrInstallation", () => {
       PYTHONHOME: "/some/home",
       OTHER_VAR: "x",
       PATH: "/usr/bin",
+      CUDA_PATH: "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.8",
+      LD_LIBRARY_PATH: "/opt/cuda/lib64",
+      LD_PRELOAD: "/tmp/injected.so",
+      CUDA_PATH_EVIL: "C:\\private",
     };
     const result = buildAsrChildEnv(source);
     expect(result.BILIBILI_SESSDATA).toBeUndefined();
@@ -1366,22 +1502,23 @@ describe("runAsrInstallation", () => {
     expect(result.PYTHONHOME).toBeUndefined();
     expect(result.OTHER_VAR).toBeUndefined();
     expect(result.PATH).toBe("/usr/bin");
+    expect(result.CUDA_PATH).toContain("NVIDIA GPU Computing Toolkit");
+    expect(result.LD_LIBRARY_PATH).toBe("/opt/cuda/lib64");
+    expect(result.LD_PRELOAD).toBeUndefined();
+    expect(result.CUDA_PATH_EVIL).toBeUndefined();
     expect(result.PIP_NO_INPUT).toBe("1");
     expect(result.PYTHONNOUSERSITE).toBe("1");
   });
 
-  it("stale-marker unlink with permission error aborts before mutation", async () => {
+  it("does not clear an invalid stale marker before installation succeeds", async () => {
     const tmpBase = path.join(os.tmpdir(), "bilibili-mcp-asr-perm-" + Date.now());
     fs.mkdirSync(tmpBase, { recursive: true });
     const stateFile = path.join(tmpBase, "state.json");
     // Write an incomplete marker
     fs.writeFileSync(stateFile, JSON.stringify({ kind: "ready", version: 999 }), "utf8");
 
-    const unlockFn = vi.fn(() => {
-      const err = new Error("EPERM: permission denied") as NodeJS.ErrnoException;
-      err.code = "EPERM";
-      throw err;
-    });
+    const previous = fs.readFileSync(stateFile, "utf8");
+    const unlockFn = vi.fn();
     const spawnFn = vi.fn();
 
     const result = await runAsrInstallation({
@@ -1391,37 +1528,49 @@ describe("runAsrInstallation", () => {
     });
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain("Cannot clear stale ASR state");
-    // Must not proceed to spawn
-    expect(spawnFn).not.toHaveBeenCalled();
+    expect(result.error).toContain("Python 3.9+ not found");
+    expect(unlockFn).not.toHaveBeenCalled();
+    expect(fs.readFileSync(stateFile, "utf8")).toBe(previous);
 
     try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ok */ }
   });
 
-  it("stale-marker unlink with ENOENT proceeds to install", async () => {
+  it("atomically replaces an invalid stale marker after setup succeeds", async () => {
     const tmpBase = path.join(os.tmpdir(), "bilibili-mcp-asr-enoent-" + Date.now());
     fs.mkdirSync(tmpBase, { recursive: true });
     const stateFile = path.join(tmpBase, "state.json");
     fs.writeFileSync(stateFile, JSON.stringify({ kind: "ready", version: 999 }), "utf8");
 
-    const unlockFn = vi.fn(() => {
-      const err = new Error("ENOENT") as NodeJS.ErrnoException;
-      err.code = "ENOENT";
-      throw err;
-    });
-    // discoverPython will fail with no candidates matching, but that's fine —
-    // what matters is unlink ENOENT is swallowed and execution continues
-    const spawnFn = vi.fn(() => Promise.resolve({ code: 0, stdout: "Python 3.12.0\n", stderr: "" }));
+    const modelsDir = path.join(tmpBase, "models");
+    fs.mkdirSync(modelsDir, { recursive: true });
+    for (const file of ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]) {
+      fs.writeFileSync(path.join(modelsDir, file), "placeholder");
+    }
+    const binDir = path.join(tmpBase, "venv", process.platform === "win32" ? "Scripts" : "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, process.platform === "win32" ? "python.exe" : "python"), "fake");
+    const unlockFn = vi.fn();
+    let step = 0;
+    const outputs = ["Python 3.12.0\n", "", "", "DOWNLOADED\n", "VERIFIED\n"];
+    const spawnFn = vi.fn(() => Promise.resolve({
+      code: 0,
+      stdout: outputs[step++] ?? "",
+      stderr: "",
+    }));
 
     const result = await runAsrInstallation({
       spawnFn,
       asrBase: tmpBase,
       fsUnlinkSync: unlockFn,
+      devicePreference: "cpu",
     });
 
-    // ENOENT swallowed → install attempted (succeeds or fails is fine)
-    expect(unlockFn).toHaveBeenCalled();
-    expect(spawnFn).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(unlockFn).not.toHaveBeenCalled();
+    expect(readAsrState(stateFile)).toMatchObject({
+      kind: "ready",
+      executionProfile: CPU_PROFILE,
+    });
 
     try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ok */ }
   });
@@ -1518,7 +1667,7 @@ describe("runAsrInstallation", () => {
 
     // verify
     const vrfy = vi.fn(() => Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" }));
-    await verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", vrfy);
+    await verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", CPU_PROFILE, vrfy);
     expect(vrfy.mock.calls[0][1][0]).toBe("-I");
     expect(vrfy.mock.calls[0][1][1]).toBe("-c");
   });
@@ -1723,7 +1872,7 @@ describe("readAsrState Execution Profile schema", () => {
     expect(state.failureCategory).toBeUndefined();
   });
 
-  it("recognizes the future CUDA profile but does not mark it ready before GPU support", () => {
+  it("reads a verified v2 CUDA profile", () => {
     expect(resolveExecutionProfile("cuda", "float16")).toEqual({
       device: "cuda",
       computeType: "float16",
@@ -1735,7 +1884,11 @@ describe("readAsrState Execution Profile schema", () => {
       compute_type: "float16",
     });
 
-    expect(state.kind).toBe("incomplete");
+    expect(state.kind).toBe("ready");
+    expect(state.executionProfile).toEqual({ device: "cuda", computeType: "float16" });
+    expect(state.deviceReadiness).toBe("ready");
+    expect(state.migrationStatus).toBe("completed");
+    expect(state.failureCategory).toBeUndefined();
   });
 
   it("accepts a sanitized GPU failure category on the CPU fallback profile", () => {
@@ -1795,6 +1948,42 @@ describe("writeAsrState Phase 2", () => {
     writeAsrState(stateFile, "base");
     const parsed = JSON.parse(fs.readFileSync(stateFile, "utf8"));
     expect(parsed.model).toBe("Systran/faster-whisper-base");
+  });
+
+  it("writes a verified CUDA profile", () => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    writeAsrState(stateFile, "small", {
+      executionProfile: { device: "cuda", computeType: "float16" },
+    });
+
+    expect(JSON.parse(fs.readFileSync(stateFile, "utf8"))).toMatchObject({
+      device: "cuda",
+      compute_type: "float16",
+      device_readiness: "ready",
+      migration_status: "completed",
+    });
+  });
+
+  it("writes only a sanitized GPU failure category on a CPU fallback", () => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    writeAsrState(stateFile, "small", {
+      executionProfile: { device: "cpu", computeType: "int8" },
+      failureCategory: "cuda_runtime_missing",
+    });
+
+    expect(JSON.parse(fs.readFileSync(stateFile, "utf8"))).toMatchObject({
+      device: "cpu",
+      compute_type: "int8",
+      failure_category: "cuda_runtime_missing",
+    });
+  });
+
+  it("rejects a CUDA profile paired with a failure category", () => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    expect(() => writeAsrState(stateFile, "small", {
+      executionProfile: { device: "cuda", computeType: "float16" },
+      failureCategory: "no_nvidia_gpu",
+    })).toThrow("failure category");
   });
 
   it("throws for invalid model key", () => {
@@ -1885,10 +2074,21 @@ describe("runAsrInstallation with modelKey", () => {
     writeAsrState(stateFile, "tiny");
     expect(readAsrState(stateFile).kind).toBe("ready");
 
-    // Now install small — should invalidate tiny state and reinstall
+    // Now install small. The downloaded staging tree is published only after verification.
     let step = 0;
-    const outputs = ["Python 3.12.0\n", "", "", "DOWNLOADED\n", "VERIFIED\n"];
-    const spawnFn = vi.fn(() => Promise.resolve({ code: 0, stdout: outputs[step++] ?? "", stderr: "" }));
+    const outputs = ["", "", "DOWNLOADED\n", "VERIFIED\n"];
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      const stdout = outputs[step++] ?? "";
+      if (stdout.trim() === "DOWNLOADED") {
+        const staging = args.find((arg) => arg.includes(".models-staging-"));
+        if (!staging) throw new Error("missing staging path");
+        for (const file of ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]) {
+          fs.writeFileSync(path.join(staging, file), `new-${file}`);
+        }
+      }
+      return Promise.resolve({ code: 0, stdout, stderr: "" });
+    });
 
     const result = await runAsrInstallation({ spawnFn, fsMkdirSync: fs.mkdirSync, asrBase: tmpBase, modelKey: "small" });
     expect(result.success).toBe(true);
@@ -1904,7 +2104,7 @@ describe("runAsrInstallation with modelKey", () => {
     try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ok */ }
   });
 
-  it("same-model ready state is idempotent (skips reinstall)", async () => {
+  it("same-model ready state reruns the selected readiness probe", async () => {
     const tmpBase = path.join(os.tmpdir(), "bilibili-mcp-asr-p2-same-" + Date.now());
     fs.mkdirSync(tmpBase, { recursive: true });
     const stateFile = path.join(tmpBase, "state.json");
@@ -1918,16 +2118,28 @@ describe("runAsrInstallation with modelKey", () => {
     }
     writeAsrState(stateFile, "small");
 
-    const spawnFn = vi.fn();
-    const result = await runAsrInstallation({ spawnFn, asrBase: tmpBase, modelKey: "small" });
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      return Promise.resolve({
+        code: 0,
+        stdout: args.includes("pip") || args.includes("venv") ? "" : "VERIFIED\n",
+        stderr: "",
+      });
+    });
+    const result = await runAsrInstallation({
+      spawnFn,
+      asrBase: tmpBase,
+      modelKey: "small",
+      devicePreference: "cpu",
+    });
     expect(result.success).toBe(true);
-    expect(result.pythonPath).toBe("already installed");
-    expect(spawnFn).not.toHaveBeenCalled();
+    expect(spawnFn).toHaveBeenCalledTimes(3);
+    expect(spawnFn.mock.calls[2][1].slice(-2)).toEqual(["cpu", "int8"]);
 
     try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ok */ }
   });
 
-  it("promotes a same-model v1 state with one CPU probe and no reinstall", async () => {
+  it("promotes a same-model v1 state with a staged runtime and one CPU probe", async () => {
     const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "bilibili-mcp-asr-v1-promote-"));
     const stateFile = path.join(tmpBase, "state.json");
     const binDir = path.join(tmpBase, "venv", os.platform() === "win32" ? "Scripts" : "bin");
@@ -1944,13 +2156,25 @@ describe("runAsrInstallation with modelKey", () => {
       model: ASR_PINNED_MODEL,
       revision: ASR_PINNED_REVISION,
     }));
-    const spawnFn = vi.fn(() => Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" }));
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      return Promise.resolve({
+        code: 0,
+        stdout: args.includes("pip") || args.includes("venv") ? "" : "VERIFIED\n",
+        stderr: "",
+      });
+    });
 
-    const result = await runAsrInstallation({ spawnFn, asrBase: tmpBase, modelKey: "small" });
+    const result = await runAsrInstallation({
+      spawnFn,
+      asrBase: tmpBase,
+      modelKey: "small",
+      devicePreference: "cpu",
+    });
 
     expect(result.success).toBe(true);
-    expect(spawnFn).toHaveBeenCalledTimes(1);
-    expect(spawnFn.mock.calls[0][1]).toContain(path.join(tmpBase, "models"));
+    expect(spawnFn).toHaveBeenCalledTimes(3);
+    expect(spawnFn.mock.calls[2][1]).toContain(path.join(tmpBase, "models"));
     const state = readAsrState(stateFile);
     expect(state.executionProfile).toEqual({ device: "cpu", computeType: "int8" });
     expect(state.migrationStatus).toBe("completed");
@@ -1975,18 +2199,29 @@ describe("runAsrInstallation with modelKey", () => {
       revision: ASR_PINNED_REVISION,
     });
     fs.writeFileSync(stateFile, previous);
-    const spawnFn = vi.fn(() => Promise.resolve({ code: 1, stdout: "", stderr: "probe failed" }));
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (args.includes("venv") || args.includes("pip")) {
+        return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      }
+      return Promise.resolve({ code: 23, stdout: "FAILED:model_probe_failed\n", stderr: "probe failed" });
+    });
 
-    const result = await runAsrInstallation({ spawnFn, asrBase: tmpBase, modelKey: "small" });
+    const result = await runAsrInstallation({
+      spawnFn,
+      asrBase: tmpBase,
+      modelKey: "small",
+      devicePreference: "cpu",
+    });
 
     expect(result.success).toBe(false);
-    expect(spawnFn).toHaveBeenCalledTimes(1);
+    expect(spawnFn).toHaveBeenCalledTimes(3);
     expect(fs.readFileSync(stateFile, "utf8")).toBe(previous);
     expect(readAsrState(stateFile).migrationStatus).toBe("pending");
     fs.rmSync(tmpBase, { recursive: true, force: true });
   });
 
-  it("already-installed tiny is idempotent with explicit modelKey", async () => {
+  it("already-installed tiny reruns readiness with explicit modelKey", async () => {
     const tmpBase = path.join(os.tmpdir(), "bilibili-mcp-asr-p2-tidem-" + Date.now());
     fs.mkdirSync(tmpBase, { recursive: true });
     const stateFile = path.join(tmpBase, "state.json");
@@ -2000,10 +2235,22 @@ describe("runAsrInstallation with modelKey", () => {
     }
     writeAsrState(stateFile, "tiny");
 
-    const spawnFn = vi.fn();
-    const result = await runAsrInstallation({ spawnFn, asrBase: tmpBase, modelKey: "tiny" });
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      return Promise.resolve({
+        code: 0,
+        stdout: args.includes("pip") || args.includes("venv") ? "" : "VERIFIED\n",
+        stderr: "",
+      });
+    });
+    const result = await runAsrInstallation({
+      spawnFn,
+      asrBase: tmpBase,
+      modelKey: "tiny",
+      devicePreference: "cpu",
+    });
     expect(result.success).toBe(true);
-    expect(spawnFn).not.toHaveBeenCalled();
+    expect(spawnFn).toHaveBeenCalledTimes(3);
 
     try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ok */ }
   });
@@ -2036,7 +2283,7 @@ describe("runAsrInstallation with modelKey", () => {
     try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ok */ }
   });
 
-  it("model-switch failure: ready tiny → switch to small, verify fails → incomplete", async () => {
+  it("model-switch failure preserves the ready tiny state and model", async () => {
     const tmpBase = path.join(os.tmpdir(), "bilibili-mcp-asr-p2-swfail-" + Date.now());
     fs.mkdirSync(tmpBase, { recursive: true });
     const stateFile = path.join(tmpBase, "state.json");
@@ -2052,6 +2299,8 @@ describe("runAsrInstallation with modelKey", () => {
     }
     writeAsrState(stateFile, "tiny");
     expect(readAsrState(stateFile).kind).toBe("ready");
+    const previousState = fs.readFileSync(stateFile, "utf8");
+    const previousModel = fs.readFileSync(path.join(modelsDir, "model.bin"), "utf8");
 
     // Switch to small — pass discovery/venv/pip/download, fail verify
     let step = 0;
@@ -2070,10 +2319,12 @@ describe("runAsrInstallation with modelKey", () => {
 
     const result = await runAsrInstallation({
       spawnFn, fsMkdirSync: fs.mkdirSync, asrBase: tmpBase, modelKey: "small",
+      devicePreference: "cpu",
     });
     expect(result.success).toBe(false);
-    // Old tiny ready marker must be gone → state is incomplete
-    expect(readAsrState(stateFile).kind).toBe("incomplete");
+    expect(fs.readFileSync(stateFile, "utf8")).toBe(previousState);
+    expect(fs.readFileSync(path.join(modelsDir, "model.bin"), "utf8")).toBe(previousModel);
+    expect(readAsrState(stateFile)).toMatchObject({ kind: "ready", modelKey: "tiny" });
 
     try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ok */ }
   });
@@ -2321,5 +2572,544 @@ describe("ASR installer staging containment", () => {
     expect(serialized).not.toContain("synthetic-secret");
     expect(serialized).not.toContain("synthetic-proxy");
     expect(serialized).not.toContain("synthetic-private-path");
+  });
+});
+
+describe("runAsrInstallation device readiness", () => {
+  function readyInstall(
+    modelKey: AsrModelKey = "small",
+    executionProfile = CPU_PROFILE,
+  ): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "bilibili-mcp-asr-device-"));
+    const binDir = path.join(root, "venv", process.platform === "win32" ? "Scripts" : "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, process.platform === "win32" ? "python.exe" : "python"), "fake");
+    const modelDir = path.join(root, "models");
+    fs.mkdirSync(modelDir, { recursive: true });
+    for (const file of ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]) {
+      fs.writeFileSync(path.join(modelDir, file), `old-${modelKey}`);
+    }
+    writeAsrState(path.join(root, "state.json"), modelKey, { executionProfile });
+    return root;
+  }
+
+  it("explicit CPU reruns only CPU readiness and saves cpu/int8", async () => {
+    const root = readyInstall();
+    const profiles: string[] = [];
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (args.includes("venv")) return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      if (args.includes("pip")) return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      profiles.push(args.slice(-2).join("/"));
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+
+    try {
+      const result = await runAsrInstallation({
+        asrBase: root,
+        devicePreference: "cpu",
+        spawnFn,
+      });
+
+      expect(result).toMatchObject({
+        success: true,
+        executionProfile: CPU_PROFILE,
+      });
+      expect(profiles).toEqual(["cpu/int8"]);
+      expect(readAsrState(path.join(root, "state.json")).executionProfile).toEqual(CPU_PROFILE);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses an explicit Python override to rebuild a ready same-model runtime", async () => {
+    const root = readyInstall();
+    const override = "/synthetic/python";
+    const spawnFn = vi.fn((file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (file === override && args.includes("--version")) {
+        return Promise.resolve({ code: 0, stdout: "Python 3.12.0\n", stderr: "" });
+      }
+      if (args.includes("venv") || args.includes("pip")) {
+        return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      }
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+
+    try {
+      const result = await runAsrInstallation({
+        asrBase: root,
+        pythonOverride: override,
+        devicePreference: "cpu",
+        spawnFn,
+      });
+
+      expect(result.success).toBe(true);
+      expect(spawnFn).toHaveBeenCalledWith(override, ["-I", "--version"]);
+      expect(spawnFn.mock.calls.some(([file, args]) =>
+        file === override && args.includes("venv"),
+      )).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses an explicit Python override while staging a ready model switch", async () => {
+    const root = readyInstall("tiny");
+    const override = "/synthetic/python";
+    const spawnFn = vi.fn((file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (file === override && args.includes("--version")) {
+        return Promise.resolve({ code: 0, stdout: "Python 3.12.0\n", stderr: "" });
+      }
+      if (args.includes("venv") || args.includes("pip")) {
+        return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      }
+      if (args.some((arg) => arg.includes("snapshot_download"))) {
+        const staging = args.find((arg) => arg.includes(".models-staging-"));
+        if (!staging) throw new Error("missing staging path");
+        for (const fileName of ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]) {
+          fs.writeFileSync(path.join(staging, fileName), `new-${fileName}`);
+        }
+        return Promise.resolve({ code: 0, stdout: "DOWNLOADED\n", stderr: "" });
+      }
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+
+    try {
+      const result = await runAsrInstallation({
+        asrBase: root,
+        modelKey: "small",
+        pythonOverride: override,
+        devicePreference: "cpu",
+        spawnFn,
+      });
+
+      expect(result.success).toBe(true);
+      expect(spawnFn).toHaveBeenCalledWith(override, ["-I", "--version"]);
+      expect(spawnFn.mock.calls.some(([file, args]) =>
+        file === override && args.includes("venv"),
+      )).toBe(true);
+      expect(readAsrState(path.join(root, "state.json")).modelKey).toBe("small");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("labels an explicit CPU probe failure as CPU readiness", async () => {
+    const root = readyInstall();
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (args.includes("venv") || args.includes("pip")) {
+        return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      }
+      return Promise.resolve({
+        code: 23,
+        stdout: "FAILED:model_probe_failed\n",
+        stderr: "private CPU error",
+      });
+    });
+
+    try {
+      const result = await runAsrInstallation({
+        asrBase: root,
+        devicePreference: "cpu",
+        spawnFn,
+      });
+
+      expect(result).toMatchObject({
+        success: false,
+        failureCategory: "model_probe_failed",
+        failureDevice: "cpu",
+      });
+      expect(result.gpuFailureCategory).toBeUndefined();
+      expect(JSON.stringify(result)).not.toContain("private CPU error");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("auto saves CUDA when the real GPU probe succeeds", async () => {
+    const root = readyInstall();
+    const profiles: string[] = [];
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (args.includes("venv")) return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      if (args.includes("pip")) return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      profiles.push(args.slice(-2).join("/"));
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+
+    try {
+      const result = await runAsrInstallation({ asrBase: root, spawnFn });
+      expect(result).toMatchObject({ success: true, executionProfile: CUDA_PROFILE });
+      expect(profiles).toEqual(["cuda/float16"]);
+      expect(readAsrState(path.join(root, "state.json")).executionProfile).toEqual(CUDA_PROFILE);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports success when post-publication runtime backup cleanup fails", async () => {
+    const root = readyInstall();
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (args.includes("venv") || args.includes("pip")) {
+        return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      }
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+    const originalRmSync = fs.rmSync.bind(fs);
+    const rmSpy = vi.spyOn(fs, "rmSync").mockImplementation((candidate, options) => {
+      if (String(candidate).includes(".venv-backup-")) {
+        throw new Error("cleanup denied");
+      }
+      return originalRmSync(candidate, options);
+    });
+
+    try {
+      const result = await runAsrInstallation({
+        asrBase: root,
+        devicePreference: "cpu",
+        spawnFn,
+      });
+
+      expect(result).toMatchObject({ success: true, executionProfile: CPU_PROFILE });
+      expect(readAsrState(path.join(root, "state.json"))).toMatchObject({
+        kind: "ready",
+        executionProfile: CPU_PROFILE,
+      });
+    } finally {
+      rmSpy.mockRestore();
+      originalRmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("auto records a sanitized category only after CPU fallback also succeeds", async () => {
+    const root = readyInstall();
+    const profiles: string[] = [];
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (args.includes("venv")) return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      if (args.includes("pip")) return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      const profile = args.slice(-2).join("/");
+      profiles.push(profile);
+      return profile === "cuda/float16"
+        ? Promise.resolve({
+            code: 21,
+            stdout: "FAILED:cuda_runtime_missing\n",
+            stderr: "raw C:\\private\\cublas.dll TOKEN=secret",
+          })
+        : Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+
+    try {
+      const result = await runAsrInstallation({ asrBase: root, spawnFn });
+      expect(result).toMatchObject({
+        success: true,
+        executionProfile: CPU_PROFILE,
+        failureCategory: "cuda_runtime_missing",
+      });
+      expect(profiles).toEqual(["cuda/float16", "cpu/int8"]);
+      expect(readAsrState(path.join(root, "state.json"))).toMatchObject({
+        executionProfile: CPU_PROFILE,
+        failureCategory: "cuda_runtime_missing",
+      });
+      expect(JSON.stringify(result)).not.toContain("private");
+      expect(JSON.stringify(result)).not.toContain("TOKEN");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps both sanitized categories when auto GPU and CPU probes fail", async () => {
+    const root = readyInstall();
+    const previous = fs.readFileSync(path.join(root, "state.json"), "utf8");
+    const profiles: string[] = [];
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (args.includes("venv") || args.includes("pip")) {
+        return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      }
+      const profile = args.slice(-2).join("/");
+      profiles.push(profile);
+      return profile === "cuda/float16"
+        ? Promise.resolve({ code: 21, stdout: "FAILED:cuda_runtime_missing\n", stderr: "private GPU" })
+        : Promise.resolve({ code: 23, stdout: "FAILED:model_probe_failed\n", stderr: "private CPU" });
+    });
+
+    try {
+      const result = await runAsrInstallation({ asrBase: root, spawnFn });
+      expect(result).toMatchObject({
+        success: false,
+        failureCategory: "model_probe_failed",
+        failureDevice: "cpu",
+        gpuFailureCategory: "cuda_runtime_missing",
+      });
+      expect(profiles).toEqual(["cuda/float16", "cpu/int8"]);
+      expect(fs.readFileSync(path.join(root, "state.json"), "utf8")).toBe(previous);
+      expect(JSON.stringify(result)).not.toContain("private GPU");
+      expect(JSON.stringify(result)).not.toContain("private CPU");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("explicit CUDA failure preserves the prior verified state without CPU fallback", async () => {
+    const root = readyInstall();
+    const previous = fs.readFileSync(path.join(root, "state.json"), "utf8");
+    const runtimeMarker = path.join(root, "venv", "runtime-marker.txt");
+    fs.writeFileSync(runtimeMarker, "previous-runtime");
+    const profiles: string[] = [];
+    const pipExecutables: string[] = [];
+    const spawnFn = vi.fn((file: string, args: string[]) => {
+      if (args.includes("venv")) return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      if (args.includes("pip")) {
+        pipExecutables.push(file);
+        return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      }
+      profiles.push(args.slice(-2).join("/"));
+      return Promise.resolve({
+        code: 20,
+        stdout: "FAILED:no_nvidia_gpu\n",
+        stderr: "raw private details",
+      });
+    });
+
+    try {
+      const result = await runAsrInstallation({
+        asrBase: root,
+        devicePreference: "cuda",
+        spawnFn,
+      });
+      expect(result).toMatchObject({ success: false, failureCategory: "no_nvidia_gpu" });
+      expect(profiles).toEqual(["cuda/float16"]);
+      expect(pipExecutables).toHaveLength(1);
+      expect(pipExecutables[0]).toContain(".venv-staging-");
+      expect(fs.readFileSync(runtimeMarker, "utf8")).toBe("previous-runtime");
+      expect(fs.readFileSync(path.join(root, "state.json"), "utf8")).toBe(previous);
+      expect(JSON.stringify(result)).not.toContain("private");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an invalid device preference before subprocess or mutation", async () => {
+    const root = readyInstall();
+    const previous = fs.readFileSync(path.join(root, "state.json"), "utf8");
+    const spawnFn = vi.fn();
+
+    try {
+      const result = await runAsrInstallation({
+        asrBase: root,
+        devicePreference: "gpu" as never,
+        spawnFn,
+      });
+      expect(result.success).toBe(false);
+      expect(spawnFn).not.toHaveBeenCalled();
+      expect(fs.readFileSync(path.join(root, "state.json"), "utf8")).toBe(previous);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("model-switch CUDA failure keeps the previous model and profile", async () => {
+    const root = readyInstall("tiny");
+    const stateFile = path.join(root, "state.json");
+    const previousState = fs.readFileSync(stateFile, "utf8");
+    const oldModel = fs.readFileSync(path.join(root, "models", "model.bin"), "utf8");
+    const runtimeMarker = path.join(root, "venv", "runtime-marker.txt");
+    fs.writeFileSync(runtimeMarker, "previous-runtime");
+    const pipExecutables: string[] = [];
+    const spawnFn = vi.fn((file: string, args: string[]) => {
+      if (args.includes("--version")) return Promise.resolve({ code: 0, stdout: "Python 3.12.0\n", stderr: "" });
+      if (args.includes("venv")) return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      if (args.includes("pip")) {
+        pipExecutables.push(file);
+        return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      }
+      if (args.some((arg) => arg.includes("snapshot_download"))) {
+        return Promise.resolve({ code: 0, stdout: "DOWNLOADED\n", stderr: "" });
+      }
+      if (args.slice(-2).join("/") === "cuda/float16") {
+        return Promise.resolve({ code: 21, stdout: "FAILED:cuda_runtime_missing\n", stderr: "private" });
+      }
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    });
+
+    try {
+      const result = await runAsrInstallation({
+        asrBase: root,
+        modelKey: "small",
+        devicePreference: "cuda",
+        spawnFn,
+      });
+      expect(result).toMatchObject({ success: false, failureCategory: "cuda_runtime_missing" });
+      expect(fs.readFileSync(stateFile, "utf8")).toBe(previousState);
+      expect(fs.readFileSync(path.join(root, "models", "model.bin"), "utf8")).toBe(oldModel);
+      expect(fs.readFileSync(runtimeMarker, "utf8")).toBe("previous-runtime");
+      expect(pipExecutables).toHaveLength(1);
+      expect(pipExecutables[0]).toContain(".venv-staging-");
+      expect(readAsrState(stateFile).modelKey).toBe("tiny");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not publish CPU fallback when the GPU probe WAV cannot be removed", async () => {
+    const root = readyInstall();
+    const stateFile = path.join(root, "state.json");
+    const previousState = fs.readFileSync(stateFile, "utf8");
+    const profiles: string[] = [];
+    let orphanedProbe = "";
+    const originalUnlinkSync = fs.unlinkSync.bind(fs);
+    const unlinkSpy = vi.spyOn(fs, "unlinkSync").mockImplementation((candidate) => {
+      const probe = String(candidate);
+      if (
+        orphanedProbe === "" &&
+        path.basename(probe).startsWith(".bilibili-mcp-asr-probe-")
+      ) {
+        orphanedProbe = probe;
+        throw new Error("cleanup denied");
+      }
+      return originalUnlinkSync(candidate);
+    });
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (args.includes("venv") || args.includes("pip")) {
+        return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      }
+      profiles.push(args.slice(-2).join("/"));
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+
+    try {
+      const result = await runAsrInstallation({ asrBase: root, spawnFn });
+
+      expect(result).toMatchObject({
+        success: false,
+        failureCategory: "model_probe_failed",
+        failureDevice: "cuda",
+      });
+      expect(profiles).toEqual(["cuda/float16"]);
+      expect(fs.readFileSync(stateFile, "utf8")).toBe(previousState);
+      expect(orphanedProbe).not.toBe("");
+      expect(fs.existsSync(orphanedProbe)).toBe(true);
+    } finally {
+      unlinkSpy.mockRestore();
+      if (orphanedProbe && fs.existsSync(orphanedProbe)) {
+        originalUnlinkSync(orphanedProbe);
+      }
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when state publication and model rollback both fail", async () => {
+    const root = readyInstall("tiny");
+    const stateFile = path.join(root, "state.json");
+    const modelDir = path.join(root, "models");
+    let statePublicationFailed = false;
+    const originalRenameSync = fs.renameSync.bind(fs);
+    const originalRmSync = fs.rmSync.bind(fs);
+    const renameSpy = vi.spyOn(fs, "renameSync").mockImplementation((source, destination) => {
+      if (
+        path.dirname(String(source)) === root &&
+        path.basename(String(source)).startsWith(".state-") &&
+        path.extname(String(source)) === ".tmp" &&
+        String(destination) === stateFile
+      ) {
+        statePublicationFailed = true;
+        throw new Error("state publication denied");
+      }
+      return originalRenameSync(source, destination);
+    });
+    const rmSpy = vi.spyOn(fs, "rmSync").mockImplementation((candidate, options) => {
+      if (statePublicationFailed && String(candidate) === modelDir) {
+        throw new Error("model rollback denied");
+      }
+      return originalRmSync(candidate, options);
+    });
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (args.includes("venv") || args.includes("pip")) {
+        return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      }
+      if (args.some((arg) => arg.includes("snapshot_download"))) {
+        const staging = args.find((arg) => arg.includes(".models-staging-"));
+        if (!staging) throw new Error("missing staging path");
+        for (const file of ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]) {
+          fs.writeFileSync(path.join(staging, file), `new-small-${file}`);
+        }
+        return Promise.resolve({ code: 0, stdout: "DOWNLOADED\n", stderr: "" });
+      }
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+
+    try {
+      const result = await runAsrInstallation({
+        asrBase: root,
+        modelKey: "small",
+        devicePreference: "cuda",
+        spawnFn,
+      });
+
+      expect(result).toMatchObject({
+        success: false,
+        error: "ASR setup failed and the previous installation could not be restored",
+      });
+      expect(fs.existsSync(stateFile)).toBe(false);
+      expect(readAsrState(stateFile).kind).toBe("incomplete");
+      expect(fs.readFileSync(path.join(modelDir, "model.bin"), "utf8")).toBe(
+        "new-small-model.bin",
+      );
+      expect(
+        fs.readdirSync(root).some((entry) => entry.startsWith(".state-backup-")),
+      ).toBe(true);
+    } finally {
+      renameSpy.mockRestore();
+      rmSpy.mockRestore();
+      originalRmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the old runtime when its backup rename fails", async () => {
+    const root = readyInstall();
+    const stateFile = path.join(root, "state.json");
+    const runtimeMarker = path.join(root, "venv", "runtime-marker.txt");
+    const previousState = fs.readFileSync(stateFile, "utf8");
+    fs.writeFileSync(runtimeMarker, "previous-runtime");
+    const originalRenameSync = fs.renameSync.bind(fs);
+    const renameSpy = vi.spyOn(fs, "renameSync").mockImplementation((source, destination) => {
+      if (
+        String(source) === path.join(root, "venv") &&
+        path.basename(String(destination)).startsWith(".venv-backup-")
+      ) {
+        throw new Error("runtime backup denied");
+      }
+      return originalRenameSync(source, destination);
+    });
+    const spawnFn = vi.fn((_file: string, args: string[]) => {
+      materializeMockVenv(args);
+      if (args.includes("venv") || args.includes("pip")) {
+        return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      }
+      return Promise.resolve({ code: 0, stdout: "VERIFIED\n", stderr: "" });
+    });
+
+    try {
+      const result = await runAsrInstallation({
+        asrBase: root,
+        devicePreference: "cpu",
+        spawnFn,
+      });
+
+      expect(result.success).toBe(false);
+      expect(fs.readFileSync(runtimeMarker, "utf8")).toBe("previous-runtime");
+      expect(fs.readFileSync(stateFile, "utf8")).toBe(previousState);
+      expect(readAsrState(stateFile).kind).toBe("ready");
+    } finally {
+      renameSpy.mockRestore();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/asr-transcription.test.ts
+++ b/tests/asr-transcription.test.ts
@@ -22,6 +22,7 @@ import { FakeIpDnsError } from "../src/security/pinned-https.js";
 import { AsrError } from "../src/utils/errors.js";
 
 const CPU_PROFILE = { device: "cpu", computeType: "int8" } as const;
+const CUDA_PROFILE = { device: "cuda", computeType: "float16" } as const;
 
 const tempDirs: string[] = [];
 const candidate: PlaybackAudioCandidate = {
@@ -240,6 +241,9 @@ describe("ASR child isolation and lifecycle", () => {
     const env = buildAsrRuntimeEnv({
       PATH: "safe-path",
       SYSTEMROOT: "safe-root",
+      CUDA_PATH: "C:\\CUDA\\v12.8",
+      LD_LIBRARY_PATH: "/opt/cuda/lib64",
+      LD_PRELOAD: "/tmp/injected.so",
       BILIBILI_SESSDATA: "secret",
       BILIBILI_BILI_JCT: "secret",
       BILIBILI_DEDEUSERID: "secret",
@@ -249,11 +253,17 @@ describe("ASR child isolation and lifecycle", () => {
       HTTPS_PROXY: "http://secret-proxy",
     });
 
-    expect(env).toMatchObject({ PATH: "safe-path", SYSTEMROOT: "safe-root" });
+    expect(env).toMatchObject({
+      PATH: "safe-path",
+      SYSTEMROOT: "safe-root",
+      CUDA_PATH: "C:\\CUDA\\v12.8",
+      LD_LIBRARY_PATH: "/opt/cuda/lib64",
+    });
     expect(JSON.stringify(env)).not.toContain("secret");
     expect(env).not.toHaveProperty("PYTHONPATH");
     expect(env).not.toHaveProperty("PYTHONHOME");
     expect(env).not.toHaveProperty("HTTPS_PROXY");
+    expect(env).not.toHaveProperty("LD_PRELOAD");
   });
 });
 
@@ -693,8 +703,8 @@ describe("ASR orchestration", () => {
     expect(getPlayback).not.toHaveBeenCalled();
   });
 
-  it("does not execute a CUDA profile before the CUDA readiness ticket", async () => {
-    const getPlayback = vi.fn();
+  it("runs the exact verified CUDA profile from state", async () => {
+    const runRuntime = vi.fn(async () => ({ language: "zh", segments: [] }));
 
     await expect(transcribeVideoPart(
       { bvid: "BV1T6PQzQErF", cid: 12345, durationSeconds: 60 },
@@ -702,14 +712,18 @@ describe("ASR orchestration", () => {
         ...readyDependencies(),
         getState: () => ({
           kind: "ready",
-          executionProfile: { device: "cuda", computeType: "float16" },
+          executionProfile: CUDA_PROFILE,
           deviceReadiness: "ready",
           migrationStatus: "completed",
         }),
-        getPlayback,
+        getPlayback: async () => ({ candidates: [candidate], durationSeconds: 60 }),
+        createTempDir: async () => path.join(os.tmpdir(), `${ASR_TEMP_PREFIX}cuda`),
+        removeTempDir: vi.fn(async () => undefined),
+        downloadAudio: vi.fn(async () => undefined),
+        runRuntime,
       },
-    )).rejects.toMatchObject({ code: "ASR_NOT_READY" });
-    expect(getPlayback).not.toHaveBeenCalled();
+    )).resolves.toMatchObject({ language: "zh" });
+    expect(runRuntime.mock.calls[0][3]).toEqual(CUDA_PROFILE);
   });
 
   it("cleans the request directory after download or runtime failure", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -7,6 +7,7 @@ import {
   buildDoctorStatus,
   createCli,
   doctorCommand,
+  parseDeviceChoice,
   parseModelChoice,
   setupCredentials,
   type DoctorStatus,
@@ -65,6 +66,7 @@ describe("CLI help and commands", () => {
 
     expect(output).toContain("--non-interactive");
     expect(output).toContain("--asr-model");
+    expect(output).toContain("--asr-device");
   });
 
   it("help output does not contain duplicated [command] placeholder in a single line", () => {
@@ -610,13 +612,14 @@ describe("setup credential loadability", () => {
     const runAsr = vi.fn(async (_modelKey: string) => ({ success: true }));
     const askHiddenFn = vi.fn()
       .mockResolvedValueOnce("y")   // Yes to ASR
-      .mockResolvedValueOnce("");   // Enter = small model
+      .mockResolvedValueOnce("")    // Enter = small model
+      .mockResolvedValueOnce("");   // Enter = auto
 
     await setupCredentials(configure, runAsr, askHiddenFn);
 
     expect(configure).not.toHaveBeenCalled();
     expect(runAsr).toHaveBeenCalledOnce();
-    expect(runAsr).toHaveBeenCalledWith("small");
+    expect(runAsr).toHaveBeenCalledWith("small", "auto");
   });
 
   it("failed opted-in ASR installation sets process.exitCode 1", async () => {
@@ -626,7 +629,8 @@ describe("setup credential loadability", () => {
     const runAsr = vi.fn(async (_modelKey: string) => ({ success: false, error: "test failure" }));
     const askHiddenFn = vi.fn()
       .mockResolvedValueOnce("y")   // Yes to ASR
-      .mockResolvedValueOnce("");   // Enter = small model
+      .mockResolvedValueOnce("")    // Enter = small model
+      .mockResolvedValueOnce("");   // Enter = auto
 
     process.exitCode = undefined;
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -642,12 +646,155 @@ describe("setup credential loadability", () => {
     const runAsr = vi.fn(async (_modelKey: string) => ({ success: true }));
     const askHiddenFn = vi.fn()
       .mockResolvedValueOnce("y")   // Yes to ASR
-      .mockResolvedValueOnce("");   // Enter = small model
+      .mockResolvedValueOnce("")    // Enter = small model
+      .mockResolvedValueOnce("");   // Enter = auto
 
     process.exitCode = undefined;
     await setupCredentials(configure, runAsr, askHiddenFn);
 
     expect(process.exitCode).toBeUndefined();
+  });
+
+  it("reports the validated CUDA profile instead of claiming CPU", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    vi.spyOn(credentialManager, "getCredentials").mockReturnValue(null);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const askHiddenFn = vi.fn()
+      .mockResolvedValueOnce("y")
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("auto");
+
+    await setupCredentials(
+      vi.fn(async () => {}),
+      vi.fn(async () => ({
+        success: true,
+        executionProfile: { device: "cuda" as const, computeType: "float16" as const },
+      })),
+      askHiddenFn,
+    );
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("CUDA Float16");
+    expect(output).not.toContain("通过 CPU INT8 验证");
+  });
+
+  it("explains an auto GPU failure and lets the user choose how to proceed", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    vi.spyOn(credentialManager, "getCredentials").mockReturnValue(null);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const askHiddenFn = vi.fn()
+      .mockResolvedValueOnce("y")
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("auto");
+
+    await setupCredentials(
+      vi.fn(async () => {}),
+      vi.fn(async () => ({
+        success: true,
+        executionProfile: { device: "cpu" as const, computeType: "int8" as const },
+        failureCategory: "cuda_runtime_missing" as const,
+      })),
+      askHiddenFn,
+    );
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("cuda_runtime_missing");
+    expect(output).toContain("CUDA、cuBLAS 或 cuDNN");
+    expect(output).toContain("CUDA 12");
+    expect(output).toContain("github.com/SYSTRAN/faster-whisper#gpu");
+    expect(output).toContain("CPU INT8");
+    expect(output).toContain("不会自动安装或修改");
+    expect(output).toContain("重新运行 setup");
+  });
+
+  it("explains explicit CUDA failure without silently falling back", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    vi.spyOn(credentialManager, "getCredentials").mockReturnValue(null);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const askHiddenFn = vi.fn()
+      .mockResolvedValueOnce("y")
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("cuda");
+    process.exitCode = undefined;
+
+    await setupCredentials(
+      vi.fn(async () => {}),
+      vi.fn(async () => ({
+        success: false,
+        error: "ASR device readiness failed (runtime_version_mismatch)",
+        failureCategory: "runtime_version_mismatch" as const,
+      })),
+      askHiddenFn,
+    );
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(process.exitCode).toBe(1);
+    expect(output).toContain("runtime_version_mismatch");
+    expect(output).toContain("升级 NVIDIA 驱动");
+    expect(output).toContain("没有回退到 CPU");
+    expect(output).toContain("选择 cpu");
+    expect(output).toContain("重新选择 cuda");
+  });
+
+  it("labels an explicit CPU readiness failure as CPU instead of GPU", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    vi.spyOn(credentialManager, "getCredentials").mockReturnValue(null);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const askHiddenFn = vi.fn()
+      .mockResolvedValueOnce("y")
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("cpu");
+    process.exitCode = undefined;
+
+    await setupCredentials(
+      vi.fn(async () => {}),
+      vi.fn(async () => ({
+        success: false,
+        error: "ASR device readiness failed (model_probe_failed)",
+        failureCategory: "model_probe_failed" as const,
+        failureDevice: "cpu" as const,
+      })),
+      askHiddenFn,
+    );
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(process.exitCode).toBe(1);
+    expect(output).toContain("CPU 验证失败");
+    expect(output).not.toContain("GPU 验证失败");
+    expect(output).not.toContain("升级 NVIDIA 驱动");
+  });
+
+  it("explains both failures when auto GPU and CPU readiness fail", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    vi.spyOn(credentialManager, "getCredentials").mockReturnValue(null);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const askHiddenFn = vi.fn()
+      .mockResolvedValueOnce("y")
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("auto");
+    process.exitCode = undefined;
+
+    await setupCredentials(
+      vi.fn(async () => {}),
+      vi.fn(async () => ({
+        success: false,
+        error: "ASR device readiness failed (model_probe_failed)",
+        failureCategory: "model_probe_failed" as const,
+        failureDevice: "cpu" as const,
+        gpuFailureCategory: "cuda_runtime_missing" as const,
+      })),
+      askHiddenFn,
+    );
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(process.exitCode).toBe(1);
+    expect(output).toContain("GPU 验证失败");
+    expect(output).toContain("cuda_runtime_missing");
+    expect(output).toContain("CPU 回退验证也失败");
+    expect(output).toContain("model_probe_failed");
   });
 
   it("redacts credential-looking values from ASR error messages", async () => {
@@ -660,7 +807,8 @@ describe("setup credential loadability", () => {
     }));
     const askHiddenFn = vi.fn()
       .mockResolvedValueOnce("y")   // Yes to ASR
-      .mockResolvedValueOnce("");   // Enter = small model
+      .mockResolvedValueOnce("")    // Enter = small model
+      .mockResolvedValueOnce("");   // Enter = auto
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -753,7 +901,37 @@ describe("setup credential loadability", () => {
       expect(configure).not.toHaveBeenCalled();
       expect(askHiddenFn).not.toHaveBeenCalled();
       expect(runAsr).toHaveBeenCalledOnce();
-      expect(runAsr).toHaveBeenCalledWith("tiny");
+      expect(runAsr).toHaveBeenCalledWith("tiny", "auto");
+    });
+
+    it("passes an explicit CUDA preference in non-interactive setup", async () => {
+      vi.spyOn(credentialManager, "getCredentialSource").mockReturnValue("global_config");
+      vi.spyOn(credentialManager, "getCredentials").mockReturnValue({
+        sessdata: "s", bili_jct: "j", dedeuserid: "d", expiresAt: Date.now() + 86400000,
+      });
+      const runAsr = vi.fn(async () => ({ success: true }));
+
+      await setupCredentials(vi.fn(), runAsr, vi.fn(), {
+        nonInteractive: true,
+        asrModel: "small",
+        asrDevice: "cuda",
+      });
+
+      expect(runAsr).toHaveBeenCalledWith("small", "cuda");
+    });
+
+    it("rejects --asr-device without --asr-model", async () => {
+      const runAsr = vi.fn(async () => ({ success: true }));
+      process.exitCode = undefined;
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await setupCredentials(vi.fn(), runAsr, vi.fn(), {
+        nonInteractive: true,
+        asrDevice: "cpu",
+      });
+
+      expect(process.exitCode).toBe(1);
+      expect(runAsr).not.toHaveBeenCalled();
     });
 
     it("rejects non-interactive setup when the credential source is none even with loadable credentials", async () => {
@@ -855,6 +1033,21 @@ describe("parseModelChoice", () => {
   it("whitespace-only input trims to empty and defaults to small", () => {
     expect(parseModelChoice(" ")).toBe("small");
     expect(parseModelChoice("\t")).toBe("small");
+  });
+});
+
+describe("parseDeviceChoice", () => {
+  it.each([
+    ["", "auto"],
+    ["auto", "auto"],
+    [" CPU ", "cpu"],
+    ["CUDA", "cuda"],
+  ])("parses %j as %s", (input, expected) => {
+    expect(parseDeviceChoice(input)).toBe(expected);
+  });
+
+  it.each(["gpu", "1", "float16", "../cuda"])("rejects %j", (input) => {
+    expect(parseDeviceChoice(input)).toBeNull();
   });
 });
 
@@ -992,6 +1185,30 @@ describe("buildDoctorStatus ASR Execution Profile", () => {
     });
   });
 
+  it("reports the verified v2 CUDA profile", () => {
+    const status = buildDoctorStatus(vi.fn(() => ({
+      kind: "ready" as const,
+      version: 2,
+      runtime: ASR_PINNED_RUNTIME,
+      model: ASR_PINNED_MODEL,
+      revision: ASR_PINNED_REVISION,
+      modelKey: "small" as const,
+      executionProfile: { device: "cuda" as const, computeType: "float16" as const },
+      deviceReadiness: "ready" as const,
+      migrationStatus: "completed" as const,
+    })));
+
+    expect(status.asr).toEqual({
+      status: "ready",
+      model: "small",
+      device: "cuda",
+      compute_type: "float16",
+      device_readiness: "ready",
+      migration_status: "completed",
+      failure_category: null,
+    });
+  });
+
   it("reports only an allowlisted sanitized failure category", () => {
     const status = buildDoctorStatus(vi.fn(() => ({
       kind: "ready" as const,
@@ -1104,11 +1321,26 @@ describe("setupCredentials model selection", () => {
     const runAsr = vi.fn(async (_modelKey: string) => ({ success: true }));
     const askHiddenFn = vi.fn()
       .mockResolvedValueOnce("y")   // Yes to ASR
-      .mockResolvedValueOnce("");   // Enter = small
+      .mockResolvedValueOnce("")    // Enter = small
+      .mockResolvedValueOnce("");   // Enter = auto
 
     await setupCredentials(configure, runAsr, askHiddenFn);
 
-    expect(runAsr).toHaveBeenCalledWith("small");
+    expect(runAsr).toHaveBeenCalledWith("small", "auto");
+  });
+
+  it("passes an explicit CPU preference after model selection", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    vi.spyOn(credentialManager, "getCredentials").mockReturnValue(null);
+    const runAsr = vi.fn(async () => ({ success: true }));
+    const askHiddenFn = vi.fn()
+      .mockResolvedValueOnce("y")
+      .mockResolvedValueOnce("base")
+      .mockResolvedValueOnce("cpu");
+
+    await setupCredentials(vi.fn(async () => {}), runAsr, askHiddenFn);
+
+    expect(runAsr).toHaveBeenCalledWith("base", "cpu");
   });
 
   it("numeric 1 selects tiny", async () => {
@@ -1118,11 +1350,12 @@ describe("setupCredentials model selection", () => {
     const runAsr = vi.fn(async (_modelKey: string) => ({ success: true }));
     const askHiddenFn = vi.fn()
       .mockResolvedValueOnce("y")   // Yes to ASR
-      .mockResolvedValueOnce("1");  // tiny
+      .mockResolvedValueOnce("1")   // tiny
+      .mockResolvedValueOnce("");   // auto
 
     await setupCredentials(configure, runAsr, askHiddenFn);
 
-    expect(runAsr).toHaveBeenCalledWith("tiny");
+    expect(runAsr).toHaveBeenCalledWith("tiny", "auto");
   });
 
   it("numeric 2 selects base", async () => {
@@ -1132,11 +1365,12 @@ describe("setupCredentials model selection", () => {
     const runAsr = vi.fn(async (_modelKey: string) => ({ success: true }));
     const askHiddenFn = vi.fn()
       .mockResolvedValueOnce("y")
-      .mockResolvedValueOnce("2");
+      .mockResolvedValueOnce("2")
+      .mockResolvedValueOnce("");
 
     await setupCredentials(configure, runAsr, askHiddenFn);
 
-    expect(runAsr).toHaveBeenCalledWith("base");
+    expect(runAsr).toHaveBeenCalledWith("base", "auto");
   });
 
   it("name 'tiny' selects tiny", async () => {
@@ -1146,11 +1380,12 @@ describe("setupCredentials model selection", () => {
     const runAsr = vi.fn(async (_modelKey: string) => ({ success: true }));
     const askHiddenFn = vi.fn()
       .mockResolvedValueOnce("y")
-      .mockResolvedValueOnce("tiny");
+      .mockResolvedValueOnce("tiny")
+      .mockResolvedValueOnce("");
 
     await setupCredentials(configure, runAsr, askHiddenFn);
 
-    expect(runAsr).toHaveBeenCalledWith("tiny");
+    expect(runAsr).toHaveBeenCalledWith("tiny", "auto");
   });
 
   it("re-prompts on invalid input then accepts valid input", async () => {
@@ -1162,13 +1397,13 @@ describe("setupCredentials model selection", () => {
       .mockResolvedValueOnce("y")       // Yes to ASR
       .mockResolvedValueOnce("invalid") // re-prompt
       .mockResolvedValueOnce("4")       // re-prompt
-      .mockResolvedValueOnce("small");  // valid
+      .mockResolvedValueOnce("small")   // valid model
+      .mockResolvedValueOnce("");        // auto
 
     await setupCredentials(configure, runAsr, askHiddenFn);
 
-    expect(runAsr).toHaveBeenCalledWith("small");
-    // 4 total calls: y, invalid, 4, small
-    expect(askHiddenFn).toHaveBeenCalledTimes(4);
+    expect(runAsr).toHaveBeenCalledWith("small", "auto");
+    expect(askHiddenFn).toHaveBeenCalledTimes(5);
   });
 
   it("re-prompts indefinitely until valid (no infinite loop in tests)", async () => {
@@ -1182,13 +1417,14 @@ describe("setupCredentials model selection", () => {
       if (callCount === 1) return "y";    // Yes
       if (callCount === 2) return "bad";  // re-prompt
       if (callCount === 3) return "xyz";  // re-prompt
-      return "base";                      // valid
+      if (callCount === 4) return "base"; // valid model
+      return "auto";
     });
 
     await setupCredentials(configure, runAsr, askHiddenFn);
 
-    expect(runAsr).toHaveBeenCalledWith("base");
-    expect(callCount).toBe(4);
+    expect(runAsr).toHaveBeenCalledWith("base", "auto");
+    expect(callCount).toBe(5);
   });
 
   it("No answer does not print model selector text", async () => {
@@ -1219,7 +1455,8 @@ describe("setupCredentials model selection", () => {
     const runAsr = vi.fn(async (_modelKey: AsrModelKey) => ({ success: true }));
     const askHiddenFn = vi.fn()
       .mockResolvedValueOnce("y")   // Yes
-      .mockResolvedValueOnce("");   // Enter = small
+      .mockResolvedValueOnce("")    // Enter = small
+      .mockResolvedValueOnce("");   // Enter = auto
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     await setupCredentials(configure, runAsr, askHiddenFn);
@@ -1233,7 +1470,7 @@ describe("setupCredentials model selection", () => {
       "速度优先：适合快速提取和长视频初筛，准确率相对较低",
     );
     expect(allOutput).toContain("均衡：兼顾速度、质量和资源占用");
-    expect(allOutput).toContain("质量优先：CPU 耗时和内存占用更高");
+    expect(allOutput).toContain("质量优先：耗时和内存占用更高");
     expect(allOutput).toContain("推荐");
 
     logSpy.mockRestore();


### PR DESCRIPTION
## Summary

- add controlled auto | cpu | cuda setup preferences and persist only verified cpu/int8 or cuda/float16 profiles
- pin faster-whisper==1.2.1 with ctranslate2==4.8.0, verify the selected local model through generated-WAV inference, and provide sanitized GPU failure guidance
- preserve prior installations on readiness failure and fail closed when activation rollback cannot complete
- wire verified profiles into the actual ASR runner and doctor output without changing the public transcript shape

## Verification

- npx vitest run tests/asr-installer.test.ts tests/asr-transcription.test.ts tests/cli.test.ts — 321 passed
- npm test — 44 files / 1,145 tests passed
- npm run build — passed
- npm pack --dry-run --json --ignore-scripts — 193 files; package boundaries preserved
- npm audit --omit=dev --json — 0 vulnerabilities
- git diff --check and Gitleaks — passed
- isolated Windows CPU and GPU setup-to-transcript smokes — passed

## Boundaries

- first-ASR automatic v1 migration remains #67
- Linux GPU is not claimed as machine-verified
- the project does not install or mutate system CUDA components or loader paths

Closes #66