### PR TITLE
[ASR] 首次请求自动迁移 v1 设备状态

### DIFF
--- a/docs/agent-memory/active-work.md
+++ b/docs/agent-memory/active-work.md
@@ -2,30 +2,26 @@
 
 ## Current Product Ticket
 
-GitHub Issue #66 is the current approved child ticket under #55. Work is
-isolated on `codex/issue-66-cuda-readiness` from base
-`6199142cb35a5d3b12f70ee1c41a65e60d3ca696` and is directly executed by Codex
-without Paseo. The implementation adds `auto | cpu | cuda` setup preferences,
-pins `faster-whisper==1.2.1` with `ctranslate2==4.8.0`, verifies the selected
-Profile through generated-WAV inference, and publishes staged runtime/model
-artifacts before the matching ready state. Auto saves CUDA only after real success and otherwise
-explains a sanitized category before verified CPU fallback; explicit CUDA
-never falls back; a readiness failure before activation preserves the prior
-installation. Captured activation errors roll back, and incomplete rollback
-leaves the ready state inactive so the runner fails closed. Focused tests,
-build, the 44-file / 1,145-test suite, isolated exact-pin CPU setup and
-runner smoke, and the initial independent review pass. A fresh Windows run with externally
-supplied CUDA 12 libraries also completed exact-pair setup as `cuda/float16`
-and produced a non-empty actual runner transcript, satisfying the final #66
-hardware gate without changing persistent host configuration. PR #70 then
-found that standard POSIX venv creation can leave `venv/bin/python` as a
-symlink rejected by the managed-path gate. The same-scope repair creates venvs
-with copied executables; 184 focused tests, the 44-file / 1,145-test suite,
-build, and a real Ubuntu 24.04 non-symlink interpreter smoke pass. The first
-Hosted run also exposed only the expected stale canonical-LF package/memory
-receipt, which was refreshed without changing package boundaries. PR #70 is
-the current integration gate. First-ASR automatic migration remains #67;
-merge, Issue close, release, and publication remain separate authority gates.
+GitHub Issue #67 is the current approved child ticket under #55. Work is
+isolated on `codex/issue-67-v1-migration` from base
+`4ad276cf28f01a519d1b848c1afe36cdcaeeface` and is directly executed by Codex
+without Paseo. The candidate reuses #66 device readiness inside the existing
+single ASR slot: the first explicit ASR request holding a v1 migration-pending
+state probes `auto`, atomically records the verified v2 Profile plus only a
+sanitized GPU failure category when needed, and continues that same request on
+the persisted CUDA or CPU Profile. Completed v2 requests never probe again;
+`setup` remains the explicit retry path. Cancellation now reaches the
+readiness subprocess, terminates its process tree, preserves `AbortError`, and
+cannot publish ready state after abort. Deterministic orchestration/readiness
+tests, build, the 44-file / 1,152-test suite, package dry run, production audit,
+and local diff Gitleaks pass. A disposable exact-pin Windows smoke on an NVIDIA
+host recorded `cuda_runtime_missing` and completed same-migration CPU fallback;
+an explicit CPU-path smoke also completed. The host GPU path was attempted but
+did not pass, so no fresh CUDA-success claim is made; Linux GPU remains
+unverified and is covered only by deterministic cross-platform automation.
+Canonical package/memory receipts and the 102-test core Harness are green.
+Commit, push, PR, merge, Issue close, release, and publication remain separate
+authority gates.
 
 ## Harness v2
 

--- a/docs/agent-memory/codemap.md
+++ b/docs/agent-memory/codemap.md
@@ -54,7 +54,8 @@ This file is a navigation index for `@xzxzzx/bilibili-mcp`. It is not a design s
   deadlines/output caps, user-scoped venv creation, exact faster-whisper and
   CTranslate2 pins, staged/budgeted/no-symlink snapshot download, `auto | cpu |
   cuda` readiness with generated short-WAV inference and full generator
-  consumption, sanitized GPU failure categories, temporary-audio cleanup,
+  consumption, abortable readiness subprocesses, sanitized GPU failure
+  categories, temporary-audio cleanup,
   same-model v1 promotion, staged runtime/model publication with captured-error
   rollback, and fail-closed state invalidation when rollback is incomplete. One
   active model reuses the Phase 1 directory; a failed probe keeps the prior
@@ -64,7 +65,8 @@ This file is a navigation index for `@xzxzzx/bilibili-mcp`. It is not a design s
   unique temporary directories, one-active/no-queue concurrency, bounded
   Windows Job/POSIX `RLIMIT` managed-Python execution, strict NDJSON,
   cancellation/tree kill, validated `cpu/int8` or `cuda/float16` Profile-driven
-  Python argv, legacy v1 CPU fallback, guarded cleanup, and all-candidate Fake-IP failure aggregation
+  Python argv, one-time locked v1 auto migration with atomic Profile/failure
+  persistence and same-request execution, guarded cleanup, and all-candidate Fake-IP failure aggregation
   without preventing later-candidate success. MCP requests never
   install or switch models.
 
@@ -143,12 +145,13 @@ When adding or changing a public MCP tool, inspect both `tool-schemas.ts` and `t
 - `tests/asr-installer.test.ts`: deterministic installer/state tests. Strict
   v1/v2 state validation, atomic writes, managed-path safety, Python discovery,
   venv/pip/download gates, generated-WAV inference/cleanup, same-model v1
-  promotion, and full orchestration success/failure. No tests invoke real
+  promotion, readiness cancellation, and full orchestration success/failure. No tests invoke real
   Python, pip, network, or model download.
 - `tests/asr-installer-process.test.ts`: mocked default subprocess deadlines,
   output ceilings, argv, stdio, and platform process-group settings.
 - `tests/asr-transcription.test.ts`: deterministic v1/v2 ready-state and
-  Profile-driven runner coverage plus download, redirect, size/MIME, Fake-IP
+  first-request v1 migration, Profile-driven runner, atomic failure persistence,
+  abort, and no-repeat coverage plus download, redirect, size/MIME, Fake-IP
   aggregation, child argv/environment, strict output, timeout/kill, cleanup,
   and concurrency tests with no real network, Python, audio, Cookie, or model.
 - `tests/bilibili-playback.test.ts`: deterministic playurl auth/parameter, malformed-versus-empty DASH, duration, CDN allowlist, and candidate-order tests.

--- a/docs/agent-memory/decisions.md
+++ b/docs/agent-memory/decisions.md
@@ -923,3 +923,26 @@
   authority and rollback boundary.
 - Evidence: bilingual client guidance, sanitized CLI/doctor tests, and
   `docs/research/2026-08-24-asr-cuda-readiness.md`.
+
+## 2026-08-24 — First-ASR v1 Device Migration
+
+- Decision: A v1 migration-pending installation is probed only by its first
+  explicit ASR request while that request owns the existing single ASR slot.
+  Persist the verified v2 Profile atomically before playback/runtime work, then
+  execute the same request on that Profile. Later v2 requests never probe;
+  rerunning `setup` is the only retry path.
+- Reason: This reuses the installed model without hidden work in doctor,
+  subtitle reads, or unrelated MCP tools, and prevents concurrent model loads,
+  GPU contention, or state writers.
+- Evidence: Issue #67 orchestration, `ASR_BUSY`, same-request CUDA/CPU,
+  no-repeat, atomic-write, and setup retry regressions.
+
+- Decision: Cancellation reaches the readiness subprocess and preserves
+  `AbortError`; no state is written after abort. Successful auto fallback emits
+  at most one stderr entry containing only the fixed failure category and the
+  persisted Profile.
+- Reason: A cancelled first request must release the single ASR slot promptly,
+  and diagnostic output must not expose Python stderr, driver/library paths, or
+  environment details.
+- Evidence: signal-aware subprocess and migration tests, disposable Windows
+  exact-pin smoke, logger boundary review, and diff secret scan.

--- a/docs/agent-memory/executions/2026-08-24-github-67-codex-direct-report.md
+++ b/docs/agent-memory/executions/2026-08-24-github-67-codex-direct-report.md
@@ -1,0 +1,71 @@
+# Issue #67 Codex Direct Execution Report
+
+## Scope
+
+- Ticket: GitHub Issue #67 under #55; blocked-by #66 was already closed.
+- Branch: `codex/issue-67-v1-migration` from
+  `4ad276cf28f01a519d1b848c1afe36cdcaeeface`.
+- Actor: Codex direct, explicitly without Paseo.
+- Product files: `src/asr/installer.ts`, `src/asr/transcription.ts`,
+  `tests/asr-installer.test.ts`, and `tests/asr-transcription.test.ts`.
+
+## Result
+
+- The first explicit ASR request with v1 migration-pending state owns the
+  existing ASR slot, reuses the installed model, runs auto readiness, atomically
+  writes the v2 Profile/fixed failure category, and continues on that Profile.
+- Completed v2 requests do not probe again. Setup remains the retry path.
+- Abort propagates through the readiness subprocess, terminates its process
+  tree, preserves `AbortError`, and cannot publish a ready state.
+- Public transcript and MCP schemas remain unchanged.
+
+## Commands And Results
+
+- `npm run build`: pass.
+- Focused Vitest: 2 files / 235 tests pass.
+- `npm test`: 44 files / 1,152 tests pass.
+- `npm pack --dry-run --json --ignore-scripts`: pass, 193 files.
+- `npm audit --omit=dev --json`: zero production vulnerabilities.
+- Gitleaks 8.30.1 on the current diff: zero findings.
+- GitHub MCP secret scan: attempted; transport failed, so not claimed.
+- Core Harness before receipt refresh: 102 tests, 15 skips, one expected stale
+  package-receipt failure at `dist/asr/installer.d.ts`.
+- Canonical-LF receipt check after refresh: 1/1 pass.
+- Core Harness after refresh: 102 tests pass, 15 existing environment skips.
+
+## Real Smoke And Boundaries
+
+- The unchanged user v1 runtime had `ctranslate2 4.8.1`, so exact-pin readiness
+  correctly failed without state publication.
+- A disposable copied venv was pinned to `4.8.0` and reused the installed model.
+  On a Windows NVIDIA host, auto classified `cuda_runtime_missing`, verified
+  CPU, atomically saved completed `cpu/int8`, and emitted one sanitized log.
+  An explicit CPU-path migration also completed. The disposable copy was
+  removed and the user v1 state remained unchanged.
+- This is a real GPU-attempt/fallback smoke, not a fresh CUDA-success claim.
+  Linux GPU was unavailable; deterministic automation is the only Linux claim
+  until Hosted CI and/or real Linux GPU evidence exists.
+
+## Review
+
+- Standards review found missing cancellation propagation. The repair threads
+  AbortSignal into the subprocess tree killer and adds production-seam tests.
+- Spec review found no behavior error or scope creep. The same-request CUDA test
+  now uses the real migration function with readiness/write seams and a complete
+  v1 model fixture.
+
+## Harness Artifacts
+
+- Task ticket: GitHub Issue #67.
+- Research note: not required; no external behavior research changed design.
+- QA checklist: Issue acceptance plus this report and verification log.
+- Codemap: updated for one-time migration and abortable readiness.
+- Harness security: unchanged; no raw stderr, paths, environment contents,
+  Cookie, audio, or transcript body stored.
+- Harness eval: not changed; this is a product ticket, not a Harness update.
+
+## Remaining Gates
+
+- Wait for GitHub Hosted product/Node/Harness matrices after a later push.
+- Commit, push, PR, merge, Issue close, release, and publication require
+  separate user authorization.

--- a/docs/agent-memory/lessons-learned.md
+++ b/docs/agent-memory/lessons-learned.md
@@ -598,3 +598,17 @@
   orphaned GPU probe before the cleanup failure became non-fallbackable.
 - Future behavior: every readiness attempt must complete its own cleanup before
   another device probe or ready-state publication is allowed.
+
+## 2026-08-24 — ASR migration cancellation
+
+- Lesson: Checking cancellation only before and after a native readiness probe
+  preserves state correctness but can retain the single ASR slot until the
+  subprocess timeout. The signal must terminate the probe process tree, and
+  probe error mapping must preserve `AbortError` instead of converting it into
+  a device failure.
+- Evidence: Issue #67 Standards review found the production-seam gap after the
+  initial no-persistence abort test passed; signal propagation and focused
+  regressions then passed.
+- Future behavior: any new ASR Python subprocess owned by a request must accept
+  the request signal, terminate its tree on abort, clean temporary artifacts,
+  and keep cancellation distinct from readiness/runtime failures.

--- a/docs/agent-memory/project-facts.md
+++ b/docs/agent-memory/project-facts.md
@@ -817,3 +817,20 @@
 - Impact: Issue #66's Windows GPU gate is satisfied without making the project
   install or persist system CUDA components. Linux GPU remains unverified, and
   first-ASR automatic migration remains #67.
+
+- Fact: The isolated Issue #67 candidate performs v1 device migration only
+  inside the first explicit ASR request and the existing one-active/no-queue
+  slot. It reuses the installed model and #66 readiness probe, atomically writes
+  the verified v2 Profile and optional fixed failure category, then continues
+  that request on the same Profile; completed v2 requests do not probe again.
+- Evidence: `src/asr/installer.ts`, `src/asr/transcription.ts`, 235 focused
+  tests, 44 files / 1,152 full tests, build, disposable Windows exact-pin
+  auto/CPU migration smoke, package dry run, production audit, and two-axis
+  review.
+- Impact: Concurrent first-ASR requests still receive retryable `ASR_BUSY`.
+  Abort terminates readiness and leaves v1 pending; readiness or persistence
+  failure keeps v1 pending with existing ASR failure semantics. The public
+  transcript/schema remains device-free, and `setup` is the only retry route.
+  The Windows NVIDIA host lacked usable CUDA libraries in this smoke, so the
+  observed real path was sanitized GPU failure followed by verified CPU
+  fallback; Linux GPU remains unverified.

--- a/docs/agent-memory/verification-log.md
+++ b/docs/agent-memory/verification-log.md
@@ -2700,3 +2700,33 @@ Six release blockers fixed; one regression proof per root cause (new tests
   passed 184/184, the full suite passed 44 files / 1,145 tests, build passed,
   and a real Ubuntu 24.04 smoke confirmed `venv/bin/python` is a regular,
   non-symlink file.
+
+## 2026-08-24 — Issue #67 First-ASR v1 Migration
+
+- TDD evidence: initial focused tests failed because v1 transcription bypassed
+  migration and forced CPU. The implemented path now covers same-request CUDA
+  and CPU Profiles, fixed-category persistence, no-repeat v2 execution,
+  concurrent `ASR_BUSY`, readiness and state-write failure, and abort-before-
+  persistence. Review then exposed missing subprocess cancellation; the added
+  production seam preserves `AbortError` and terminates readiness on abort.
+- Verification: 2 focused files / 235 tests, TypeScript build, and 44 files /
+  1,152 full tests passed. Package dry run retained 193 files; production audit
+  reported zero vulnerabilities. Gitleaks 8.30.1 found zero findings in the
+  current source/test diff. GitHub MCP secret scanning was attempted but its
+  transport failed, so no remote-scan pass is claimed.
+- Real Windows smoke: the unchanged user v1 state was first shown to remain
+  pending because its historical `ctranslate2 4.8.1` does not satisfy the #66
+  `4.8.0` pin. A disposable copy was moved to the exact pin while reusing the
+  installed model. On an NVIDIA host, auto produced only
+  `cuda_runtime_missing`, atomically saved completed `cpu/int8`, and emitted one
+  sanitized fallback log; an explicit CPU-path migration also saved completed
+  `cpu/int8`. The temporary runtime copy was removed; user state stayed v1.
+- Boundary: deterministic GPU-success behavior passes, but this round did not
+  achieve a fresh real CUDA-success probe and does not claim one. Linux GPU was
+  not available; only deterministic cross-platform tests and Hosted CI may be
+  used for that boundary. The core Harness initially failed only on the stale
+  canonical-LF package receipt; after refreshing the complete 193-file package
+  output, six durable-memory hashes, and outer migration hash, the exact
+  conformance check passed 1/1 and core passed 102 tests with 15 existing
+  environment skips. No commit, push, PR, merge, Issue close, release, or
+  publication occurred.

--- a/harness/fixtures/pilot-artifacts/migration.json
+++ b/harness/fixtures/pilot-artifacts/migration.json
@@ -89,27 +89,27 @@
     }
   ],
   "durable_memory": {
-    "docs/agent-memory/active-work.md": "2182539d827902c05b441c471ea2cce19be3145dd8be6a51eb00103e70a80614",
-    "docs/agent-memory/codemap.md": "860f5d42d790ce042c0104e1bd547100b094c24976da72511b9017dbd828ab2f",
-    "docs/agent-memory/decisions.md": "093d5a0ee8e24f22120637aaedfbdd122d9e955cdd3001657aae5aea233382da",
+    "docs/agent-memory/active-work.md": "9f75b048c5834c11e19076d93feca160cd56f69b0f4377a4b96ac946cecbfa13",
+    "docs/agent-memory/codemap.md": "cc3969e610fb6b34cf86b0de2e238397f878d5fef34c27423cbe03f480693f0b",
+    "docs/agent-memory/decisions.md": "aa945c89b056873b7dae8fe55716c8aff9467d6a11b0ed583eefc4a3c9fb6404",
     "docs/agent-memory/executions/2026-08-14-github-36-codex-direct-report.md": "439b169470c2ab1ec3af3625b8ca3e247d6ccd4f01bc39ff967deff673853570",
     "docs/agent-memory/harness-eval.md": "f531cc2d0e69ccc8d41c882c9aefdae03d5583789bc19c51dd45a4188fe9a370",
     "docs/agent-memory/harness-security.md": "b907339f85c0ba13c2a8642b475aa682ae1b313cb51cebec9977aca798df3430",
-    "docs/agent-memory/lessons-learned.md": "43060f93ca33b6655bac4e2c84a4c8abd4f44271024e758af01aa00cc190f924",
-    "docs/agent-memory/project-facts.md": "a7d1d22e4a203307118e5f6990c5678eb34b5955d3fe1c544a10347619c2fcbe",
-    "docs/agent-memory/verification-log.md": "f1461a81ecbeb794294f30f5836125d9f88120d7ee41874e038dc46f06028fac"
+    "docs/agent-memory/lessons-learned.md": "b83c88018dc0d44acc7fa48c8992f319ab03f71f387e129a834d029cc9f4dd04",
+    "docs/agent-memory/project-facts.md": "ff9d05993e60be3ceb4eed263c627e3c7dd64a7ffe07c52d9644fd31c4f97214",
+    "docs/agent-memory/verification-log.md": "3ca969e2eba658e65123a6c5089c969b1ae88b3a1d6ebed3a2c30f6aae607bb5"
   },
   "package": {
-    "output_digest": "1ecd0c27076f5b43126d2ee4c65a08121e3396a2e9f038b4e896cc2be6e54378",
+    "output_digest": "f8c8f764c9ec9c3f421f014f8e64b6cef615b355e13a509c210e921c621355d8",
     "pack_output": [
       {
         "id": "@xzxzzx/bilibili-mcp@1.13.0",
         "name": "@xzxzzx/bilibili-mcp",
         "version": "1.13.0",
-        "size": 1148617,
-        "unpackedSize": 1982016,
-        "shasum": "0c22aac8fefc1f634e14eb86279054b48c83e447",
-        "integrity": "sha512-UebiLKX90VV6URC4OEXUmU4o1CooBX/vBUkYxD5faerGX+LlNbXivAmzWZKgQnItGzam73IiT3KdcB66kMCjsQ==",
+        "size": 1150291,
+        "unpackedSize": 1990979,
+        "shasum": "9c30bc9b294264e872a03b693744c8fc925e5bb9",
+        "integrity": "sha512-cp3MP+vJHRNKrbU2AKXYLsVzG9yFT/HvFckvA+NLxr3ifHzZHqiKSfKYzgo9p15saPTpS5gCcTWPGfVItHXjLw==",
         "filename": "xzxzzx-bilibili-mcp-1.13.0.tgz",
         "files": [
           {
@@ -154,22 +154,22 @@
           },
           {
             "path": "dist/asr/installer.d.ts",
-            "size": 2912,
+            "size": 3213,
             "mode": 420
           },
           {
             "path": "dist/asr/installer.d.ts.map",
-            "size": 2775,
+            "size": 3047,
             "mode": 420
           },
           {
             "path": "dist/asr/installer.js",
-            "size": 31500,
+            "size": 32735,
             "mode": 420
           },
           {
             "path": "dist/asr/installer.js.map",
-            "size": 26435,
+            "size": 27618,
             "mode": 420
           },
           {
@@ -194,22 +194,22 @@
           },
           {
             "path": "dist/asr/transcription.d.ts",
-            "size": 2769,
+            "size": 3389,
             "mode": 420
           },
           {
             "path": "dist/asr/transcription.d.ts.map",
-            "size": 2569,
+            "size": 3150,
             "mode": 420
           },
           {
             "path": "dist/asr/transcription.js",
-            "size": 26728,
+            "size": 29370,
             "mode": 420
           },
           {
             "path": "dist/asr/transcription.js.map",
-            "size": 21140,
+            "size": 23269,
             "mode": 420
           },
           {

--- a/harness/fixtures/three-adapter-pilot-evidence.json
+++ b/harness/fixtures/three-adapter-pilot-evidence.json
@@ -8,7 +8,7 @@
       "product-verification": "pass"
     },
     "file": "migration.json",
-    "sha256": "27fc071e7e4393496cb53825ecd870cda0e7735879a6f03f5e34570a947f1494"
+    "sha256": "66c96072d23c4e87a3905974a015618d5d49f61b798c399fc26abe638907dd04"
   },
   "pilots": [
     {

--- a/src/asr/installer.ts
+++ b/src/asr/installer.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { createAbortError } from "../security/operation-context.js";
 import {
   ASR_CUDA_EXECUTION_PROFILE,
   ASR_CPU_EXECUTION_PROFILE,
@@ -146,8 +147,13 @@ function terminateProcessTree(child: ReturnType<typeof spawn>): void {
 function execFile(
   file: string,
   args: string[],
+  signal?: AbortSignal,
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError());
+      return;
+    }
     const child = spawn(file, args, {
       env: buildAsrChildEnv(process.env),
       shell: false,
@@ -162,7 +168,17 @@ function execFile(
     let timedOut = false;
     let overflowed = false;
     let settled = false;
-    const timeout = setTimeout(() => {
+    let timeout: NodeJS.Timeout | undefined;
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      terminateProcessTree(child);
+      reject(createAbortError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    const cleanup = () => signal?.removeEventListener("abort", onAbort);
+    timeout = setTimeout(() => {
       timedOut = true;
       terminateProcessTree(child);
     }, inferProcessTimeout(args));
@@ -190,6 +206,7 @@ function execFile(
       clearTimeout(timeout);
       if (settled) return;
       settled = true;
+      cleanup();
       if (timedOut) {
         reject(new Error("ASR installer subprocess exceeded its time limit"));
         return;
@@ -204,6 +221,7 @@ function execFile(
       clearTimeout(timeout);
       if (settled) return;
       settled = true;
+      cleanup();
       reject(err);
     });
   });
@@ -539,7 +557,10 @@ export async function verifyModel(
         profile.computeType,
       ),
     );
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw error;
+    }
     // Map subprocess and local probe failures after cleanup so a cleanup
     // failure can prevent auto fallback from publishing a ready Profile.
   } finally {
@@ -611,6 +632,9 @@ async function verifyDeviceReadiness(
     await verifyModel(venvPython, modelPath, ASR_CUDA_EXECUTION_PROFILE, spawnFn);
     return { executionProfile: ASR_CUDA_EXECUTION_PROFILE };
   } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw error;
+    }
     const readinessError = error instanceof AsrReadinessError
       ? error
       : new AsrReadinessError("model_probe_failed", "cuda");
@@ -622,6 +646,9 @@ async function verifyDeviceReadiness(
     try {
       await verifyModel(venvPython, modelPath, ASR_CPU_EXECUTION_PROFILE, spawnFn);
     } catch (cpuError) {
+      if (cpuError instanceof Error && cpuError.name === "AbortError") {
+        throw cpuError;
+      }
       const cpuReadinessError = cpuError instanceof AsrReadinessError
         ? cpuError
         : new AsrReadinessError("model_probe_failed", "cpu");
@@ -636,6 +663,24 @@ async function verifyDeviceReadiness(
       failureCategory: readinessError.category,
     };
   }
+}
+
+export async function verifyInstalledDeviceReadiness(
+  paths: Pick<AsrPaths, "venv" | "model">,
+  preference: AsrDevicePreference = "auto",
+  signal?: AbortSignal,
+  spawnFn: typeof execFile = execFile,
+): Promise<{
+  executionProfile: AsrExecutionProfile;
+  failureCategory?: AsrFailureCategory;
+}> {
+  return await verifyDeviceReadiness(
+    pythonCommandForVenv(paths.venv),
+    paths.model,
+    preference,
+    (file, args) => spawnFn(file, args, signal),
+    () => undefined,
+  );
 }
 
 function prepareModelStaging(asrPaths: AsrPaths, preserveExistingModel: boolean): string {

--- a/src/asr/transcription.ts
+++ b/src/asr/transcription.ts
@@ -23,14 +23,20 @@ import {
 } from "../security/pinned-https.js";
 import { sanitizeRemoteText } from "../utils/bounded-text.js";
 import { AsrError } from "../utils/errors.js";
-import { buildAsrChildEnv } from "./installer.js";
+import { logger } from "../utils/logger.js";
 import {
-  ASR_CPU_EXECUTION_PROFILE,
+  AsrReadinessError,
+  buildAsrChildEnv,
+  verifyInstalledDeviceReadiness,
+} from "./installer.js";
+import {
   deriveAsrPaths,
   readAsrState,
   resolveExecutionProfile,
+  writeAsrState,
   type AsrPaths,
   type AsrExecutionProfile,
+  type AsrFailureCategory,
   type AsrState,
 } from "./state.js";
 
@@ -155,6 +161,11 @@ export interface AsrTranscriptionDependencies {
     executionProfile: AsrExecutionProfile,
     signal?: AbortSignal,
   ) => Promise<AsrTranscriptionResult>;
+  migrateLegacyState?: (
+    paths: AsrPaths,
+    state: AsrState,
+    signal?: AbortSignal,
+  ) => Promise<AsrExecutionProfile>;
 }
 
 let activeTranscriptions = 0;
@@ -763,6 +774,92 @@ export async function cleanupAsrTempDir(tempDir: string): Promise<void> {
   createdAsrTempDirs.delete(target);
 }
 
+type LegacyMigrationResult = {
+  executionProfile: AsrExecutionProfile;
+  failureCategory?: AsrFailureCategory;
+};
+
+export async function migrateLegacyAsrState(
+  paths: AsrPaths,
+  state: AsrState,
+  dependencies: {
+    verifyReadiness?: (
+      paths: AsrPaths,
+      signal?: AbortSignal,
+    ) => Promise<LegacyMigrationResult>;
+    writeState?: typeof writeAsrState;
+    logResult?: (result: LegacyMigrationResult) => void;
+  } = {},
+  signal?: AbortSignal,
+): Promise<AsrExecutionProfile> {
+  if (
+    state.kind !== "ready" ||
+    state.version !== 1 ||
+    state.modelKey === undefined ||
+    state.executionProfile !== undefined ||
+    state.deviceReadiness !== "migration_pending" ||
+    state.migrationStatus !== "pending"
+  ) {
+    throw new AsrError(
+      "ASR_NOT_READY",
+      "Local ASR is not eligible for automatic device migration. Run setup, then inspect doctor --json.",
+    );
+  }
+
+  const verifyReadiness = dependencies.verifyReadiness ??
+    ((currentPaths: AsrPaths, operationSignal?: AbortSignal) =>
+      verifyInstalledDeviceReadiness(currentPaths, "auto", operationSignal));
+  const writeState = dependencies.writeState ?? writeAsrState;
+  const logResult = dependencies.logResult ?? ((result: LegacyMigrationResult) => {
+    const data = {
+      executionProfile: `${result.executionProfile.device}/${result.executionProfile.computeType}`,
+      ...(result.failureCategory === undefined
+        ? {}
+        : { failureCategory: result.failureCategory }),
+    };
+    if (result.failureCategory === undefined) {
+      logger.info("Legacy ASR state migrated to the verified GPU profile.", data, { type: "asr-migration" });
+    } else {
+      logger.warn("Legacy ASR state migrated to the verified CPU fallback profile.", data, { type: "asr-migration" });
+    }
+  });
+
+  throwIfAborted(signal);
+  let result: LegacyMigrationResult;
+  try {
+    result = await verifyReadiness(paths, signal);
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw error;
+    }
+    if (error instanceof AsrReadinessError) {
+      throw new AsrError(
+        "ASR_TRANSCRIPTION_FAILED",
+        `Local ASR device verification failed (${error.device ?? "unknown"}: ${error.category}). Run setup to retry.`,
+        true,
+      );
+    }
+    throw new AsrError(
+      "ASR_TRANSCRIPTION_FAILED",
+      "Local ASR device verification failed. Run setup to retry.",
+      true,
+    );
+  }
+  throwIfAborted(signal);
+
+  try {
+    writeState(paths.stateFile, state.modelKey, result);
+  } catch {
+    throw new AsrError(
+      "ASR_TRANSCRIPTION_FAILED",
+      "Local ASR readiness was verified but its state could not be saved. Run setup to retry.",
+      true,
+    );
+  }
+  logResult(result);
+  return result.executionProfile;
+}
+
 export async function transcribeVideoPart(
   request: AsrTranscriptionRequest,
   dependencies: AsrTranscriptionDependencies = {},
@@ -822,6 +919,7 @@ export async function transcribeVideoPart(
         { executionProfile, signal: operationSignal },
       )
     );
+  const migrateLegacyState = dependencies.migrateLegacyState ?? migrateLegacyAsrState;
   let tempDir: string | undefined;
 
   try {
@@ -835,18 +933,23 @@ export async function transcribeVideoPart(
         "Local ASR is not ready. Run `npx -y @xzxzzx/bilibili-mcp@latest setup`, then inspect `doctor --json`.",
       );
     }
-    const executionProfile = state.executionProfile !== undefined &&
+    let executionProfile = state.executionProfile !== undefined &&
       state.deviceReadiness === "ready" &&
       state.migrationStatus === "completed"
       ? resolveExecutionProfile(
           state.executionProfile.device,
           state.executionProfile.computeType,
         )
-      : state.executionProfile === undefined &&
-          state.deviceReadiness === "migration_pending" &&
-          state.migrationStatus === "pending"
-        ? ASR_CPU_EXECUTION_PROFILE
-        : undefined;
+      : undefined;
+    if (
+      executionProfile === undefined &&
+      state.executionProfile === undefined &&
+      state.deviceReadiness === "migration_pending" &&
+      state.migrationStatus === "pending"
+    ) {
+      executionProfile = await migrateLegacyState(paths, state, signal);
+      throwIfAborted(signal);
+    }
     if (executionProfile === undefined) {
       throw new AsrError(
         "ASR_NOT_READY",

--- a/tests/asr-installer.test.ts
+++ b/tests/asr-installer.test.ts
@@ -12,6 +12,7 @@ import {
   createVenv,
   installRuntime,
   validateModelInstallTree,
+  verifyInstalledDeviceReadiness,
   type PythonCommand,
 } from "../src/asr/installer.js";
 import {
@@ -1182,6 +1183,31 @@ describe("verifyModel", () => {
   it("throws on non-zero exit", async () => {
     const spawnFn = vi.fn(() => Promise.resolve({ code: 1, stdout: "", stderr: "import error" }));
     await expect(verifyModel({ executable: "python3", prefixArgs: [] }, "/tmp/models", CPU_PROFILE, spawnFn)).rejects.toMatchObject({ category: "model_probe_failed" });
+  });
+
+  it("propagates cancellation through the installed-readiness subprocess seam", async () => {
+    const controller = new AbortController();
+    const spawnFn = vi.fn((
+      _file: string,
+      _args: string[],
+      signal?: AbortSignal,
+    ) => new Promise<never>((_resolve, reject) => {
+      expect(signal).toBe(controller.signal);
+      signal?.addEventListener("abort", () => reject(new DOMException(
+        "The operation was aborted.",
+        "AbortError",
+      )), { once: true });
+    }));
+    const pending = verifyInstalledDeviceReadiness(
+      { venv: "/tmp/venv", model: "/tmp/models" },
+      "auto",
+      controller.signal,
+      spawnFn,
+    );
+
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(spawnFn).toHaveBeenCalledOnce();
   });
 });
 

--- a/tests/asr-transcription.test.ts
+++ b/tests/asr-transcription.test.ts
@@ -13,10 +13,12 @@ import {
   downloadPlaybackAudio,
   MAX_ASR_AUDIO_BYTES,
   MAX_ASR_STDOUT_BYTES,
+  migrateLegacyAsrState,
   parseAsrNdjson,
   runManagedAsrRuntime,
   transcribeVideoPart,
 } from "../src/asr/transcription.js";
+import { AsrReadinessError } from "../src/asr/installer.js";
 import type { PlaybackAudioCandidate } from "../src/bilibili/playback.js";
 import { FakeIpDnsError } from "../src/security/pinned-https.js";
 import { AsrError } from "../src/utils/errors.js";
@@ -638,16 +640,24 @@ describe("ASR orchestration", () => {
     expect(runRuntime.mock.calls[0][3]).toEqual(CPU_PROFILE);
   });
 
-  it("uses the controlled legacy CPU fallback for a v1 migration-pending state", async () => {
+  it("migrates a v1 state and uses the verified CUDA profile in the same request", async () => {
     const runRuntime = vi.fn(async () => ({ language: "zh", segments: [] }));
+    const writeState = vi.fn();
+    const migrateLegacyState = vi.fn((paths, state, signal) =>
+      migrateLegacyAsrState(paths, state, {
+        verifyReadiness: vi.fn(async () => ({ executionProfile: CUDA_PROFILE })),
+        writeState,
+        logResult: vi.fn(),
+      }, signal));
 
-    await transcribeVideoPart(
+    await expect(transcribeVideoPart(
       { bvid: "BV1T6PQzQErF", cid: 12345, durationSeconds: 60 },
       {
         ...readyDependencies(),
         getState: () => ({
           kind: "ready",
           version: 1,
+          modelKey: "small",
           deviceReadiness: "migration_pending",
           migrationStatus: "pending",
         }),
@@ -656,6 +666,38 @@ describe("ASR orchestration", () => {
         removeTempDir: vi.fn(async () => undefined),
         downloadAudio: vi.fn(async () => undefined),
         runRuntime,
+        migrateLegacyState,
+      },
+    )).resolves.toEqual({ language: "zh", segments: [] });
+
+    expect(migrateLegacyState).toHaveBeenCalledOnce();
+    expect(writeState).toHaveBeenCalledWith(path.join("managed-root", "state.json"), "small", {
+      executionProfile: CUDA_PROFILE,
+    });
+    expect(runRuntime.mock.calls[0][3]).toEqual(CUDA_PROFILE);
+  });
+
+  it("uses the persisted CPU fallback profile in the same migration request", async () => {
+    const runRuntime = vi.fn(async () => ({ language: "zh", segments: [] }));
+    const migrateLegacyState = vi.fn(async () => CPU_PROFILE);
+
+    await transcribeVideoPart(
+      { bvid: "BV1T6PQzQErF", cid: 12345, durationSeconds: 60 },
+      {
+        ...readyDependencies(),
+        getState: () => ({
+          kind: "ready",
+          version: 1,
+          modelKey: "small",
+          deviceReadiness: "migration_pending",
+          migrationStatus: "pending",
+        }),
+        getPlayback: async () => ({ candidates: [candidate], durationSeconds: 60 }),
+        createTempDir: async () => path.join(os.tmpdir(), `${ASR_TEMP_PREFIX}fallback`),
+        removeTempDir: vi.fn(async () => undefined),
+        downloadAudio: vi.fn(async () => undefined),
+        runRuntime,
+        migrateLegacyState,
       },
     );
 
@@ -705,6 +747,7 @@ describe("ASR orchestration", () => {
 
   it("runs the exact verified CUDA profile from state", async () => {
     const runRuntime = vi.fn(async () => ({ language: "zh", segments: [] }));
+    const migrateLegacyState = vi.fn();
 
     await expect(transcribeVideoPart(
       { bvid: "BV1T6PQzQErF", cid: 12345, durationSeconds: 60 },
@@ -721,9 +764,47 @@ describe("ASR orchestration", () => {
         removeTempDir: vi.fn(async () => undefined),
         downloadAudio: vi.fn(async () => undefined),
         runRuntime,
+        migrateLegacyState,
       },
     )).resolves.toMatchObject({ language: "zh" });
     expect(runRuntime.mock.calls[0][3]).toEqual(CUDA_PROFILE);
+    expect(migrateLegacyState).not.toHaveBeenCalled();
+  });
+
+  it("keeps the single ASR slot while legacy migration is running", async () => {
+    let releaseMigration!: (profile: typeof CPU_PROFILE) => void;
+    const migration = new Promise<typeof CPU_PROFILE>((resolve) => {
+      releaseMigration = resolve;
+    });
+    const migrateLegacyState = vi.fn(() => migration);
+    const getPlayback = vi.fn(async () => ({ candidates: [], durationSeconds: 60 }));
+    const dependencies = {
+      ...readyDependencies(),
+      getState: () => ({
+        kind: "ready" as const,
+        version: 1,
+        modelKey: "small" as const,
+        deviceReadiness: "migration_pending" as const,
+        migrationStatus: "pending" as const,
+      }),
+      migrateLegacyState,
+      getPlayback,
+    };
+    const first = transcribeVideoPart(
+      { bvid: "BV1T6PQzQErF", cid: 1, durationSeconds: 60 },
+      dependencies,
+    );
+    await Promise.resolve();
+
+    await expect(transcribeVideoPart(
+      { bvid: "BV1T6PQzQErF", cid: 2, durationSeconds: 60 },
+      dependencies,
+    )).rejects.toMatchObject({ code: "ASR_BUSY", retryable: true });
+    expect(migrateLegacyState).toHaveBeenCalledOnce();
+    expect(getPlayback).not.toHaveBeenCalled();
+
+    releaseMigration(CPU_PROFILE);
+    await expect(first).resolves.toBeNull();
   });
 
   it("cleans the request directory after download or runtime failure", async () => {
@@ -885,5 +966,97 @@ describe("ASR orchestration", () => {
     await expect(cleanupAsrTempDir(path.join(os.tmpdir(), `${ASR_TEMP_PREFIX}models`))).rejects.toMatchObject({
       code: "ASR_TRANSCRIPTION_FAILED",
     });
+  });
+});
+
+describe("legacy ASR device migration", () => {
+  const paths = readyDependencies().getPaths();
+  const state = {
+    kind: "ready" as const,
+    version: 1,
+    modelKey: "small" as const,
+    deviceReadiness: "migration_pending" as const,
+    migrationStatus: "pending" as const,
+  };
+
+  it("records only the sanitized GPU failure category with the CPU fallback", async () => {
+    const verifyReadiness = vi.fn(async () => ({
+      executionProfile: CPU_PROFILE,
+      failureCategory: "cuda_runtime_missing" as const,
+    }));
+    const writeState = vi.fn();
+    const logResult = vi.fn();
+
+    await expect(migrateLegacyAsrState(paths, state, {
+      verifyReadiness,
+      writeState,
+      logResult,
+    })).resolves.toEqual(CPU_PROFILE);
+
+    expect(writeState).toHaveBeenCalledWith(paths.stateFile, "small", {
+      executionProfile: CPU_PROFILE,
+      failureCategory: "cuda_runtime_missing",
+    });
+    expect(logResult).toHaveBeenCalledOnce();
+    expect(JSON.stringify(logResult.mock.calls)).not.toContain("stderr");
+  });
+
+  it("keeps v1 pending when CPU fallback readiness fails", async () => {
+    const writeState = vi.fn();
+    const logResult = vi.fn();
+
+    await expect(migrateLegacyAsrState(paths, state, {
+      verifyReadiness: vi.fn(async () => {
+        throw new AsrReadinessError(
+          "model_probe_failed",
+          "cpu",
+          "cuda_runtime_missing",
+        );
+      }),
+      writeState,
+      logResult,
+    })).rejects.toMatchObject({ code: "ASR_TRANSCRIPTION_FAILED" });
+
+    expect(writeState).not.toHaveBeenCalled();
+    expect(logResult).not.toHaveBeenCalled();
+  });
+
+  it("keeps v1 pending when the verified profile cannot be persisted", async () => {
+    const logResult = vi.fn();
+
+    await expect(migrateLegacyAsrState(paths, state, {
+      verifyReadiness: vi.fn(async () => ({ executionProfile: CUDA_PROFILE })),
+      writeState: vi.fn(() => {
+        throw new Error("disk write failed");
+      }),
+      logResult,
+    })).rejects.toMatchObject({ code: "ASR_TRANSCRIPTION_FAILED", retryable: true });
+
+    expect(logResult).not.toHaveBeenCalled();
+  });
+
+  it("does not persist readiness when the request is interrupted before the write", async () => {
+    const controller = new AbortController();
+    const writeState = vi.fn();
+    const verifyReadiness = vi.fn((
+      _paths: unknown,
+      signal?: AbortSignal,
+    ) => new Promise<never>((_resolve, reject) => {
+      expect(signal).toBe(controller.signal);
+      signal?.addEventListener("abort", () => reject(new DOMException(
+        "The operation was aborted.",
+        "AbortError",
+      )), { once: true });
+    }));
+    const pending = migrateLegacyAsrState(paths, state, {
+      verifyReadiness,
+      writeState,
+      logResult: vi.fn(),
+    }, controller.signal);
+
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(verifyReadiness).toHaveBeenCalledOnce();
+    expect(writeState).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- migrate complete v1 ASR state on the first ASR request
- prefer verified CUDA/float16 and fall back to CPU/int8 with a sanitized failure category
- preserve pending v1 state when readiness, persistence, or cancellation fails
- keep completed v2 state probe-free and preserve the existing single-ASR concurrency boundary

## Verification

- `npm run build`
- `npm test` (44 files, 1152 tests)
- `npm pack --dry-run --json --ignore-scripts` (193 files)
- `npm audit --omit=dev --json` (0 production vulnerabilities)
- exact Harness real-pilot conformance (1/1)
- Gitleaks staged diff (0 findings)

Closes #67